### PR TITLE
feat: Release version 0.3.5 with zap highlighting for all content types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "nostrblue"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostrblue"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Patrick Ulrich"]
 description = "A decentralized social network client built on the Nostr protocol using Rust and Dioxus"


### PR DESCRIPTION
This release adds visual feedback when users have zapped content across all card types (notes, photos, and videos), providing a consistent interaction pattern with reactions and reposts.

Changes:
- Add zap highlighting to note cards (src/components/note_card.rs)
  * New is_zapped state variable to track if current user has zapped
  * Check P tag in zap receipts (kind 9735) for sender's pubkey
  * Yellow highlight and filled icon when user has zapped
  * Dynamic CSS classes matching reactions/reposts pattern

- Add zap highlighting to photo cards (src/components/photo_card.rs)
  * Same zap tracking implementation as note cards
  * Consistent yellow styling when zapped
  * Maintains Instagram-style photo feed aesthetics

- Add zap highlighting to video cards (src/components/video_card.rs)
  * Same zap tracking implementation as other cards
  * Unified user interaction feedback across all content types

- Update version to 0.3.5 in Cargo.toml

All interaction buttons now follow consistent pattern:
- Reactions: Red highlight when liked
- Reposts: Green highlight when reposted
- Zaps: Yellow highlight when zapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicators on note, photo, and video cards to display when you've already zapped an item.
  * Zap buttons now show active styling with updated icon states after zapping.

* **Chores**
  * Bumped package version to 0.3.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->