### PR TITLE
feat: Release version 0.3.8 with NIP-17 timestamp fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "nostrblue"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostrblue"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 authors = ["Patrick Ulrich"]
 description = "A decentralized social network client built on the Nostr protocol using Rust and Dioxus"


### PR DESCRIPTION
Fix DM timestamp display for NIP-17 encrypted messages by using actual message timestamps instead of randomized gift wrap timestamps.

Changes:
- Add ConversationMessage enum to properly handle both NIP-04 and NIP-17
- Store unwrapped rumor data with actual timestamps for NIP-17 messages
- Update sorting logic to use real message timestamps (rumor.created_at)
- Optimize decryption by returning cached rumor content for NIP-17
- Remove redundant gift wrap unwrapping during display

This ensures messages display in correct chronological order with accurate send times while maintaining NIP-17 privacy features on the relay side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.3.8

* **Refactor**
  * Enhanced internal message handling infrastructure for direct messaging to support multiple message formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->