### PR TITLE
fix: Add scroll-to-top for Home button and UTF-8 safe truncation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "nostrblue"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostrblue"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 authors = ["Patrick Ulrich"]
 description = "A decentralized social network client built on the Nostr protocol using Rust and Dioxus"

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -146,10 +146,15 @@ fn Layout() -> Element {
     let mut sidebar_open = use_signal(|| false);
     let mut more_menu_open = use_signal(|| false);
     let current_route = use_route::<Route>();
+    let navigator = navigator();
 
     // Check if we're on the DMs or Videos pages (hide right sidebar)
     let is_dms_page = matches!(current_route, Route::DMs {});
     let is_videos_page = matches!(current_route, Route::Videos {} | Route::VideoDetail { .. });
+
+    // Check if we're on home page for home button styling
+    let is_home_page = matches!(current_route, Route::Home {});
+    let home_font_weight = if is_home_page { "font-bold" } else { "" };
 
     rsx! {
         div {
@@ -172,9 +177,19 @@ fn Layout() -> Element {
                         class: "h-full flex flex-col p-4 overflow-y-auto",
 
                         // Logo
-                        Link {
-                            to: Route::Home {},
-                            class: "flex items-center gap-2 hover:opacity-80 transition mb-6",
+                        div {
+                            class: "flex items-center gap-2 hover:opacity-80 transition mb-6 cursor-pointer",
+                            onclick: move |_| {
+                                if is_home_page {
+                                    // Already on home page, scroll to top
+                                    if let Some(window) = web_sys::window() {
+                                        let _ = window.scroll_to_with_x_and_y(0.0, 0.0);
+                                    }
+                                } else {
+                                    // Navigate to home
+                                    navigator.push(Route::Home {});
+                                }
+                            },
                             div {
                                 class: "w-12 h-12 bg-blue-500 hover:bg-blue-600 rounded-full flex items-center justify-center text-white font-bold text-xl transition",
                                 "N"
@@ -185,10 +200,24 @@ fn Layout() -> Element {
                         nav {
                             class: "flex flex-col gap-1",
 
-                            NavLink {
-                                to: Route::Home {},
-                                icon: rsx! { crate::components::icons::HomeIcon { class: "w-7 h-7" } },
-                                label: "Home"
+                            // Home button with scroll-to-top functionality
+                            div {
+                                class: "flex items-center justify-start gap-4 px-4 py-2 rounded-full hover:bg-accent transition text-xl w-full cursor-pointer {home_font_weight}",
+                                onclick: move |_| {
+                                    if is_home_page {
+                                        // Already on home page, scroll to top
+                                        if let Some(window) = web_sys::window() {
+                                            let _ = window.scroll_to_with_x_and_y(0.0, 0.0);
+                                        }
+                                    } else {
+                                        // Navigate to home
+                                        navigator.push(Route::Home {});
+                                    }
+                                },
+                                crate::components::icons::HomeIcon { class: "w-7 h-7" }
+                                span {
+                                    "Home"
+                                }
                             }
 
                             NavLink {
@@ -340,10 +369,20 @@ fn Layout() -> Element {
                                 }
 
                                 // Same navigation as desktop
-                                Link {
-                                    to: Route::Home {},
-                                    onclick: move |_| sidebar_open.set(false),
-                                    class: "flex items-center gap-2 hover:opacity-80 transition mb-8",
+                                div {
+                                    class: "flex items-center gap-2 hover:opacity-80 transition mb-8 cursor-pointer",
+                                    onclick: move |_| {
+                                        sidebar_open.set(false);
+                                        if is_home_page {
+                                            // Already on home page, scroll to top
+                                            if let Some(window) = web_sys::window() {
+                                                let _ = window.scroll_to_with_x_and_y(0.0, 0.0);
+                                            }
+                                        } else {
+                                            // Navigate to home
+                                            navigator.push(Route::Home {});
+                                        }
+                                    },
                                     div {
                                         class: "w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center text-white font-bold text-xl",
                                         "N"
@@ -356,12 +395,24 @@ fn Layout() -> Element {
 
                                 nav {
                                     class: "flex flex-col gap-2",
+                                    // Home button with scroll-to-top functionality
                                     div {
-                                        onclick: move |_| sidebar_open.set(false),
-                                        NavLink {
-                                            to: Route::Home {},
-                                            icon: rsx! { crate::components::icons::HomeIcon { class: "w-7 h-7" } },
-                                            label: "Home"
+                                        class: "flex items-center justify-start gap-4 px-4 py-2 rounded-full hover:bg-accent transition text-xl w-full cursor-pointer {home_font_weight}",
+                                        onclick: move |_| {
+                                            sidebar_open.set(false);
+                                            if is_home_page {
+                                                // Already on home page, scroll to top
+                                                if let Some(window) = web_sys::window() {
+                                                    let _ = window.scroll_to_with_x_and_y(0.0, 0.0);
+                                                }
+                                            } else {
+                                                // Navigate to home
+                                                navigator.push(Route::Home {});
+                                            }
+                                        },
+                                        crate::components::icons::HomeIcon { class: "w-7 h-7" }
+                                        span {
+                                            "Home"
                                         }
                                     }
 

--- a/src/services/trending.rs
+++ b/src/services/trending.rs
@@ -169,6 +169,14 @@ pub fn truncate_content(content: &str, max_length: usize) -> String {
     if content.len() <= max_length {
         content.to_string()
     } else {
-        format!("{}...", content[..max_length].trim())
+        // Find the last valid UTF-8 character boundary before max_length
+        let truncate_at = content
+            .char_indices()
+            .take_while(|(idx, _)| *idx < max_length)
+            .last()
+            .map(|(idx, ch)| idx + ch.len_utf8())
+            .unwrap_or(0);
+
+        format!("{}...", content[..truncate_at].trim())
     }
 }


### PR DESCRIPTION
- Home button now scrolls to top when already on home page
- Fixed UTF-8 string slicing panic in trending.rs truncate_content
- Version bumped to 0.4.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Home navigation link now intelligently scrolls to the top when already viewing the Home page, replacing standard navigation behavior for improved user experience.

* **Bug Fixes**
  * Fixed text truncation that could incorrectly split UTF-8 characters, ensuring all displayed content renders properly.

* **Chores**
  * Version updated to 0.4.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->