### PR TITLE
fix: Use fetch_events_aggregated for following feed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "nostrblue"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostrblue"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["Patrick Ulrich"]
 description = "A decentralized social network client built on the Nostr protocol using Rust and Dioxus"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostrbluerust",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "description": "Nostr.blue Rust client",
   "scripts": {
     "tailwind:watch": "tailwindcss -i ./assets/tailwind.css -o ./public/tailwind.css --watch",

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -1137,8 +1137,8 @@ async fn load_following_feed(until: Option<u64>) -> Result<(Vec<Event>, usize), 
 
     log::info!("Fetching events from {} followed accounts", filter.authors.as_ref().map(|a| a.len()).unwrap_or(0));
 
-    // Fetch events using Outbox model (database first, then author-specific relays)
-    match nostr_client::fetch_events_aggregated_outbox(filter, Duration::from_secs(10)).await {
+    // Fetch events using aggregated pattern (database-first)
+    match nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10)).await {
         Ok(events) => {
             let raw_count = events.len();
             log::info!("Loaded {} events from following feed", raw_count);
@@ -1230,8 +1230,8 @@ async fn load_following_with_replies(until: Option<u64>) -> Result<Vec<Event>, S
 
     log::info!("Fetching all events (including replies) from {} followed accounts", filter.authors.as_ref().map(|a| a.len()).unwrap_or(0));
 
-    // Fetch events using Outbox model
-    match nostr_client::fetch_events_aggregated_outbox(filter, Duration::from_secs(10)).await {
+    // Fetch events using aggregated pattern (database-first)
+    match nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10)).await {
         Ok(events) => {
             log::info!("Loaded {} events (including replies) from following feed", events.len());
 
@@ -1273,8 +1273,8 @@ async fn load_global_feed(until: Option<u64>) -> Result<Vec<Event>, String> {
 
     log::info!("Fetching events with filter: {:?}", filter);
 
-    // Fetch events using Outbox model
-    match nostr_client::fetch_events_aggregated_outbox(filter, Duration::from_secs(10)).await {
+    // Fetch events using aggregated pattern (database-first)
+    match nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10)).await {
         Ok(events) => {
             log::info!("Loaded {} events", events.len());
 


### PR DESCRIPTION
Changed the following feed to use the same fetch_events_aggregated call as the explore page, instead of fetch_events_aggregated_outbox. This fixes issues with the following feed not loading properly.

Changes:
- Updated load_following_feed to use fetch_events_aggregated
- Updated load_following_with_replies to use fetch_events_aggregated
- Updated load_global_feed to use fetch_events_aggregated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Version Update**
  * Released version 0.5.3

* **Feed Display Improvements**
  * Following feed now displays top-level posts, sorted by newest first
  * Automatic fallback to global feed when no top-level posts available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->