### PR TITLE
fix: improve zap sender detection with fallback to description tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "nostrblue"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostrblue"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 authors = ["Patrick Ulrich"]
 description = "A decentralized social network client built on the Nostr protocol using Rust and Dioxus"

--- a/src/components/photo_card.rs
+++ b/src/components/photo_card.rs
@@ -214,16 +214,37 @@ pub fn PhotoCard(event: Event) -> Element {
                 let mut user_has_zapped = false;
 
                 let total_sats: u64 = zaps.iter().filter_map(|zap_event| {
-                    // Check if this zap is from the current user (P tag contains sender pubkey)
+                    // Check if this zap is from the current user
+                    // Per NIP-57: The uppercase P tag contains the pubkey of the zap sender
                     if let Some(ref user_pk) = current_user_pubkey {
-                        if let Some(zap_sender) = zap_event.tags.iter().find_map(|tag| {
+                        // Method 1: Try to get sender from uppercase "P" tag (most common)
+                        let mut zap_sender_pubkey = zap_event.tags.iter().find_map(|tag| {
                             let tag_vec = tag.clone().to_vec();
-                            if tag_vec.first()?.as_str() == "P" {
-                                tag_vec.get(1).map(|s| s.as_str().to_string())
+                            if tag_vec.len() >= 2 && tag_vec.first()?.as_str() == "P" {
+                                Some(tag_vec.get(1)?.as_str().to_string())
                             } else {
                                 None
                             }
-                        }) {
+                        });
+
+                        // Method 2: Fallback - parse description tag (contains zap request JSON)
+                        if zap_sender_pubkey.is_none() {
+                            zap_sender_pubkey = zap_event.tags.iter().find_map(|tag| {
+                                let tag_vec = tag.clone().to_vec();
+                                if tag_vec.first()?.as_str() == "description" {
+                                    let zap_request_json = tag_vec.get(1)?.as_str();
+                                    if let Ok(zap_request) = serde_json::from_str::<serde_json::Value>(zap_request_json) {
+                                        // The pubkey field in the zap request is the sender
+                                        return zap_request.get("pubkey")
+                                            .and_then(|p| p.as_str())
+                                            .map(|s| s.to_string());
+                                    }
+                                }
+                                None
+                            });
+                        }
+
+                        if let Some(zap_sender) = zap_sender_pubkey {
                             if zap_sender == *user_pk {
                                 user_has_zapped = true;
                             }

--- a/src/components/video_card.rs
+++ b/src/components/video_card.rs
@@ -203,16 +203,37 @@ pub fn VideoCard(event: Event) -> Element {
                 let mut user_has_zapped = false;
 
                 let total_sats: u64 = zaps.iter().filter_map(|zap_event| {
-                    // Check if this zap is from the current user (P tag contains sender pubkey)
+                    // Check if this zap is from the current user
+                    // Per NIP-57: The uppercase P tag contains the pubkey of the zap sender
                     if let Some(ref user_pk) = current_user_pubkey {
-                        if let Some(zap_sender) = zap_event.tags.iter().find_map(|tag| {
+                        // Method 1: Try to get sender from uppercase "P" tag (most common)
+                        let mut zap_sender_pubkey = zap_event.tags.iter().find_map(|tag| {
                             let tag_vec = tag.clone().to_vec();
-                            if tag_vec.first()?.as_str() == "P" {
-                                tag_vec.get(1).map(|s| s.as_str().to_string())
+                            if tag_vec.len() >= 2 && tag_vec.first()?.as_str() == "P" {
+                                Some(tag_vec.get(1)?.as_str().to_string())
                             } else {
                                 None
                             }
-                        }) {
+                        });
+
+                        // Method 2: Fallback - parse description tag (contains zap request JSON)
+                        if zap_sender_pubkey.is_none() {
+                            zap_sender_pubkey = zap_event.tags.iter().find_map(|tag| {
+                                let tag_vec = tag.clone().to_vec();
+                                if tag_vec.first()?.as_str() == "description" {
+                                    let zap_request_json = tag_vec.get(1)?.as_str();
+                                    if let Ok(zap_request) = serde_json::from_str::<serde_json::Value>(zap_request_json) {
+                                        // The pubkey field in the zap request is the sender
+                                        return zap_request.get("pubkey")
+                                            .and_then(|p| p.as_str())
+                                            .map(|s| s.to_string());
+                                    }
+                                }
+                                None
+                            });
+                        }
+
+                        if let Some(zap_sender) = zap_sender_pubkey {
                             if zap_sender == *user_pk {
                                 user_has_zapped = true;
                             }


### PR DESCRIPTION
Fixes an issue where zap reactions were not highlighting yellow when the signed-in user was the sender. The zap amount was displaying correctly, but the sender detection was failing in some cases.

Changes:
- Added robust two-method zap sender detection in all card components
- Primary method: Check uppercase "P" tag for sender's pubkey (NIP-57 standard)
- Fallback method: Parse "description" tag JSON to extract sender from zap request
- Applied fix consistently to note_card.rs, photo_card.rs, and video_card.rs
- Bumped version to 0.5.5

Per NIP-57 specification, zap receipts (kind 9735) contain the sender's pubkey in the uppercase "P" tag, but some implementations may not include this tag. The fallback ensures compatibility with all zap implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zap detection to handle additional scenarios with a fallback mechanism, ensuring zaps are properly recognized and counted in more cases.

* **Chores**
  * Bumped version to 0.5.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->