### PR TITLE
feat: Release v0.5.9 - Profile enhancements and video routing fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "nostrblue"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostrblue"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 authors = ["Patrick Ulrich"]
 description = "A decentralized social network client built on the Nostr protocol using Rust and Dioxus"


### PR DESCRIPTION
## Profile Page Enhancements
- Update Articles tab to display article cards in grid layout (matching /articles page)
- Add new Verts tab under Media for vertical/short videos (Kind 22)
- Implement VertsVideoCard component with thumbnail/video preview fallback
- Split Videos tab to show only landscape videos (Kind 21)
- Fix video element rendering bug (quoted "loop" attribute)

## Video Detail Route Fix
- Fix /videos/{noteid} to display the specific video instead of most recent feed
- Ensure requested video is always shown first in ShortsPlayer
- Add deduplication logic to prevent duplicate videos in feed
- Background feed loading for continued scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Verts" media tab in user profiles to browse and view vertical video content.
  * Introduced Recent Verts section in the Following feed for discovering new vertical videos.
  * Enhanced vertical video playback with improved initial event handling.
  * Improved support for displaying vertical video metadata and card layouts.

* **Chores**
  * Version bump to 0.5.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->