### PR TITLE
fix: show profile page placeholders immediately while metadata loads

### DIFF
--- a/src/routes/profile.rs
+++ b/src/routes/profile.rs
@@ -501,6 +501,24 @@ pub fn Profile(pubkey: String) -> Element {
                                     "{post_count.read()} posts"
                                 }
                             }
+                        } else {
+                            // Placeholder header while metadata loads
+                            h2 {
+                                class: "text-xl font-bold",
+                                {
+                                    if let Ok(pk) = PublicKey::from_bech32(&pubkey_for_display)
+                                        .or_else(|_| PublicKey::from_hex(&pubkey_for_display)) {
+                                        let npub = pk.to_bech32().unwrap_or_else(|_| pubkey_for_display.clone());
+                                        if npub.len() > 16 {
+                                            format!("{}...{}", &npub[..12], &npub[npub.len()-4..])
+                                        } else {
+                                            npub
+                                        }
+                                    } else {
+                                        pubkey_for_display.clone()
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -544,6 +562,12 @@ pub fn Profile(pubkey: String) -> Element {
                                 class: "w-32 h-32 rounded-full border-4 border-background bg-blue-600 flex items-center justify-center text-white text-4xl font-bold",
                                 "{get_avatar_initial(metadata)}"
                             }
+                        }
+                    } else {
+                        // Placeholder avatar while metadata loads
+                        div {
+                            class: "w-32 h-32 rounded-full border-4 border-background bg-gray-600 flex items-center justify-center text-white text-4xl font-bold",
+                            "?"
                         }
                     }
                 }
@@ -685,6 +709,69 @@ pub fn Profile(pubkey: String) -> Element {
                     }
 
                     // Following/Followers counts
+                    div {
+                        class: "flex gap-4 mt-3",
+                        div {
+                            class: "hover:underline cursor-pointer",
+                            span {
+                                class: "font-bold",
+                                "{following_count.read()}"
+                            }
+                            span {
+                                class: "text-muted-foreground ml-1",
+                                "Following"
+                            }
+                        }
+                        div {
+                            class: "hover:underline cursor-pointer",
+                            span {
+                                class: "font-bold",
+                                "{followers_count.read()}"
+                            }
+                            span {
+                                class: "text-muted-foreground ml-1",
+                                "Followers"
+                            }
+                        }
+                    }
+                } else {
+                    // Placeholder profile info while metadata loads
+                    h1 {
+                        class: "text-2xl font-bold",
+                        {
+                            // Show truncated npub as placeholder
+                            if let Ok(pk) = PublicKey::from_bech32(&pubkey_for_display)
+                                .or_else(|_| PublicKey::from_hex(&pubkey_for_display)) {
+                                let npub = pk.to_bech32().unwrap_or_else(|_| pubkey_for_display.clone());
+                                if npub.len() > 16 {
+                                    format!("{}...{}", &npub[..12], &npub[npub.len()-4..])
+                                } else {
+                                    npub
+                                }
+                            } else {
+                                pubkey_for_display.clone()
+                            }
+                        }
+                    }
+                    p {
+                        class: "text-muted-foreground",
+                        {
+                            // Show npub as username placeholder
+                            if let Ok(pk) = PublicKey::from_bech32(&pubkey_for_display)
+                                .or_else(|_| PublicKey::from_hex(&pubkey_for_display)) {
+                                let npub = pk.to_bech32().unwrap_or_else(|_| pubkey_for_display.clone());
+                                if npub.len() > 18 {
+                                    format!("@{}...{}", &npub[..12], &npub[npub.len()-6..])
+                                } else {
+                                    format!("@{}", npub)
+                                }
+                            } else {
+                                format!("@{}", pubkey_for_display)
+                            }
+                        }
+                    }
+
+                    // Following/Followers counts (still show even without metadata)
                     div {
                         class: "flex gap-4 mt-3",
                         div {


### PR DESCRIPTION
Profile pages now render immediately with placeholder content instead of showing a blank page while metadata loads. This improves perceived performance and user experience.

Changes:
- Show placeholder avatar ("?") when metadata is loading
- Show truncated npub as display name placeholder
- Show npub as username placeholder
- Show following/followers counts even without metadata
- All profile frame elements now render immediately

The metadata will progressively replace placeholders as it loads from the database cache or relays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added placeholder UI elements that display while profile metadata is loading
  * Profile header, avatar, and information blocks now show placeholders during data loading
  * Following and Followers counts are now visible as placeholders to maintain consistent layout during the loading state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->