### PR TITLE
fix: make embeds interactable in feeds

### DIFF
--- a/src/components/rich_content.rs
+++ b/src/components/rich_content.rs
@@ -1570,6 +1570,7 @@ fn YouTubeRenderer(video_id: String) -> Element {
     rsx! {
         div {
             class: "my-2 rounded-lg overflow-hidden bg-black aspect-video max-w-full",
+            onclick: move |e: MouseEvent| e.stop_propagation(),
             if *is_visible.read() {
                 iframe {
                     src: "{embed_url}",
@@ -1635,6 +1636,7 @@ fn SpotifyRenderer(content_type: String, content_id: String) -> Element {
     rsx! {
         div {
             class: "my-2 rounded-lg overflow-hidden",
+            onclick: move |e: MouseEvent| e.stop_propagation(),
             if *is_visible.read() {
                 iframe {
                     src: "{embed_url}",
@@ -1692,6 +1694,7 @@ fn SoundCloudRenderer(url: String) -> Element {
     rsx! {
         div {
             class: "my-2 rounded-lg overflow-hidden",
+            onclick: move |e: MouseEvent| e.stop_propagation(),
             if *is_visible.read() {
                 iframe {
                     src: "{embed_url}",
@@ -1755,6 +1758,7 @@ fn AppleMusicRenderer(embed_url: String, is_song: bool) -> Element {
     rsx! {
         div {
             class: "my-2 rounded-lg overflow-hidden",
+            onclick: move |e: MouseEvent| e.stop_propagation(),
             if *is_visible.read() {
                 iframe {
                     src: "{final_embed_url}",
@@ -1814,6 +1818,7 @@ fn MixCloudRenderer(username: String, mix_name: String) -> Element {
     rsx! {
         div {
             class: "my-2 rounded-lg overflow-hidden",
+            onclick: move |e: MouseEvent| e.stop_propagation(),
             if *is_visible.read() {
                 iframe {
                     src: "{embed_url}",
@@ -1888,6 +1893,7 @@ fn RumbleRenderer(embed_url: String) -> Element {
     rsx! {
         div {
             class: "my-2 rounded-lg overflow-hidden bg-black aspect-video max-w-full",
+            onclick: move |e: MouseEvent| e.stop_propagation(),
             if *is_visible.read() {
                 iframe {
                     src: "{final_embed_url}",
@@ -1945,6 +1951,7 @@ fn TidalRenderer(embed_url: String) -> Element {
     rsx! {
         div {
             class: "my-2 rounded-lg overflow-hidden",
+            onclick: move |e: MouseEvent| e.stop_propagation(),
             if *is_visible.read() {
                 iframe {
                     src: "{final_embed_url}",


### PR DESCRIPTION
Add stop_propagation() to embed renderer containers (YouTube, Spotify, SoundCloud, AppleMusic, MixCloud, Rumble, Tidal) to prevent clicks from bubbling up to the parent NoteCard and triggering navigation to note detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved click event handling for embedded media players and content (YouTube, Spotify, SoundCloud, Apple Music, and others) to prevent unintended parent-level interactions when clicking on embedded elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->