### PR TITLE
fix: resolve P2PK send failure and send modal freeze

### DIFF
--- a/src/components/cashu_send_modal.rs
+++ b/src/components/cashu_send_modal.rs
@@ -79,7 +79,9 @@ pub fn CashuSendModal(
         }
 
         // Increment request ID and capture current value to prevent race conditions
-        let current_id = fee_request_id.read().wrapping_add(1);
+        // Use peek() instead of read() to avoid subscribing to fee_request_id,
+        // which would cause an infinite loop when we immediately set() it
+        let current_id = fee_request_id.peek().wrapping_add(1);
         fee_request_id.set(current_id);
         is_estimating_fee.set(true);
 


### PR DESCRIPTION
Two fixes:

1. Fix send modal freeze when typing amount (cashu_send_modal.rs)
   - Changed fee_request_id.read() to fee_request_id.peek() to avoid subscribing to the signal inside use_effect, which caused an infinite loop when immediately writing to the same signal

2. Fix P2PK token send failing with "insufficient funds" (send.rs)
   - CDK's prepare_send() has a bug where it uses Some(vec![]) to filter proofs for P2PK sends, which only returns bearer proofs
   - Added execute_p2pk_send_via_swap() that uses wallet.swap() directly, bypassing CDK's buggy proof selection (same approach as Minibits)
   - Updated send_tokens_p2pk() to use the new swap-based function

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an infinite loop issue in fee estimation that could cause the send dialog to become unresponsive.
  * Improved reliability of token sends with enhanced error detection and automatic recovery when insufficient funds or spent proofs are detected.
  * Added better observability through detailed logging of send operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->