### PR TITLE
fix: address clippy warnings across codebase

### DIFF
--- a/src/components/add_to_list_modal.rs
+++ b/src/components/add_to_list_modal.rs
@@ -16,7 +16,7 @@ pub struct AddToListModalProps {
 pub fn AddToListModal(props: AddToListModalProps) -> Element {
     let (lists_signal, lists_loading, lists_error, mut refresh_trigger) = use_lists::use_user_lists();
     let mut selected_list_id = use_signal(|| None::<String>);
-    let mut new_list_name = use_signal(|| String::new());
+    let mut new_list_name = use_signal(String::new);
     let mut create_new = use_signal(|| false);
     let mut loading = use_signal(|| false);
     let mut error_msg = use_signal(|| None::<String>);
@@ -34,11 +34,11 @@ pub fn AddToListModal(props: AddToListModalProps) -> Element {
 
     // Clone needed fields before creating the move closure
     let event_id = props.event_id.clone();
-    let on_close = props.on_close.clone();
+    let on_close = props.on_close;
 
     let handle_add_to_list = move |_| {
         let event_id = event_id.clone();
-        let on_close = on_close.clone();
+        let on_close = on_close;
 
         loading.set(true);
         error_msg.set(None);

--- a/src/components/article_card.rs
+++ b/src/components/article_card.rs
@@ -300,7 +300,7 @@ fn format_timestamp(timestamp: u64) -> String {
     use chrono::{DateTime, Utc, Local};
 
     let dt = DateTime::from_timestamp(timestamp as i64, 0)
-        .unwrap_or_else(|| Utc::now());
+        .unwrap_or_else(Utc::now);
     let local_dt = dt.with_timezone(&Local);
     let now = Local::now();
     let duration = now.signed_duration_since(local_dt);

--- a/src/components/board_slideover.rs
+++ b/src/components/board_slideover.rs
@@ -40,7 +40,7 @@ pub fn BoardSlideover(
     let board_a_tag = board.a_tag.clone();
 
     // State for pins (fetched separately)
-    let mut pins = use_signal(|| Vec::<Pin>::new());
+    let mut pins = use_signal(Vec::<Pin>::new);
     let mut pins_loading = use_signal(|| true);
 
     // State for author profile
@@ -135,12 +135,12 @@ pub fn BoardSlideover(
 
     // Handle board delete
     let nav = navigator();
-    let on_close_for_delete = on_close.clone();
+    let on_close_for_delete = on_close;
     let handle_delete = move |_| {
         deleting.set(true);
         let board_clone = board_for_delete.clone();
-        let nav = nav.clone();
-        let on_close = on_close_for_delete.clone();
+        let nav = nav;
+        let on_close = on_close_for_delete;
 
         spawn(async move {
             match delete_pinboard(&board_clone).await {

--- a/src/components/book_picker_modal.rs
+++ b/src/components/book_picker_modal.rs
@@ -39,7 +39,7 @@ pub struct BookPickerModalProps {
 pub fn BookPickerModal(mut props: BookPickerModalProps) -> Element {
     let mut active_tab = use_signal(|| BookPickerTab::Browse);
     let mut search_query = use_signal(String::new);
-    let mut search_results = use_signal(|| Vec::<PublicationIndex>::new());
+    let mut search_results = use_signal(Vec::<PublicationIndex>::new);
     let mut is_searching = use_signal(|| false);
     // Debounce counter to cancel stale search requests
     let mut debounce_counter = use_signal(|| 0u32);
@@ -414,7 +414,7 @@ pub fn BookPickerModal(mut props: BookPickerModalProps) -> Element {
                                                         // Extract d-tag from address
                                                         let section_name = section_ref.address
                                                             .split(':')
-                                                            .last()
+                                                            .next_back()
                                                             .unwrap_or(&section_ref.address);
                                                         let chapter_num = (idx + 1).to_string();
                                                         rsx! {

--- a/src/components/calendar_mini.rs
+++ b/src/components/calendar_mini.rs
@@ -32,7 +32,7 @@ pub fn MiniCalendar(props: MiniCalendarProps) -> Element {
     let selected_date_for_effect = props.selected_date.clone();
     let selected_date_for_highlight = props.selected_date.clone();
     let event_dates = props.event_dates.clone();
-    let on_date_select_handler = props.on_date_select.clone();
+    let on_date_select_handler = props.on_date_select;
 
     // Parse the selected date to get year/month for display
     let mut display_date = use_signal(|| props.selected_date.clone());
@@ -71,7 +71,7 @@ pub fn MiniCalendar(props: MiniCalendarProps) -> Element {
 
     // Navigation handlers
     let go_prev_month = {
-        let on_month_change = props.on_month_change.clone();
+        let on_month_change = props.on_month_change;
         move |_| {
             let (y, m) = *month_info.read();
             let (new_year, new_month) = if m == 1 { (y - 1, 12) } else { (y, m - 1) };
@@ -84,7 +84,7 @@ pub fn MiniCalendar(props: MiniCalendarProps) -> Element {
     };
 
     let go_next_month = {
-        let on_month_change = props.on_month_change.clone();
+        let on_month_change = props.on_month_change;
         move |_| {
             let (y, m) = *month_info.read();
             let (new_year, new_month) = if m == 12 { (y + 1, 1) } else { (y, m + 1) };
@@ -97,7 +97,7 @@ pub fn MiniCalendar(props: MiniCalendarProps) -> Element {
     };
 
     let go_today = {
-        let on_date_select = props.on_date_select.clone();
+        let on_date_select = props.on_date_select;
         move |_| {
             let today = get_today();
             display_date.set(today.clone());
@@ -193,7 +193,7 @@ pub fn MiniCalendar(props: MiniCalendarProps) -> Element {
                                        else { "hover:bg-accent" },
                                 onclick: {
                                     let date = date.clone();
-                                    let handler = on_date_select_handler.clone();
+                                    let handler = on_date_select_handler;
                                     move |_| {
                                         if let Some(h) = &handler {
                                             h.call(date.clone());

--- a/src/components/calendar_view.rs
+++ b/src/components/calendar_view.rs
@@ -76,23 +76,23 @@ pub fn CalendarView(props: CalendarViewProps) -> Element {
             DayView {
                 events: props.events.clone(),
                 date: props.selected_date.clone(),
-                on_event_click: props.on_event_click.clone()
+                on_event_click: props.on_event_click
             }
         },
         CalendarViewMode::Week => rsx! {
             WeekView {
                 events: props.events.clone(),
                 selected_date: props.selected_date.clone(),
-                on_date_select: props.on_date_select.clone(),
-                on_event_click: props.on_event_click.clone()
+                on_date_select: props.on_date_select,
+                on_event_click: props.on_event_click
             }
         },
         CalendarViewMode::Month => rsx! {
             MonthView {
                 events: props.events.clone(),
                 selected_date: props.selected_date.clone(),
-                on_date_select: props.on_date_select.clone(),
-                on_event_click: props.on_event_click.clone()
+                on_date_select: props.on_date_select,
+                on_event_click: props.on_event_click
             }
         },
     }
@@ -137,7 +137,7 @@ fn DayView(props: DayViewProps) -> Element {
             }
 
             // All-day events
-            {render_all_day_events(&day_events, props.on_event_click.clone())}
+            {render_all_day_events(&day_events, props.on_event_click)}
 
             // Time grid
             div {
@@ -258,7 +258,7 @@ fn WeekView(props: WeekViewProps) -> Element {
                                                 style: "{style}",
                                                 onclick: {
                                                     let event = event.clone();
-                                                    let handler = props.on_event_click.clone();
+                                                    let handler = props.on_event_click;
                                                     move |_| {
                                                         if let Some(h) = &handler {
                                                             h.call(event.clone());
@@ -388,7 +388,7 @@ fn MonthView(props: MonthViewProps) -> Element {
                                 class: if is_other_month { "bg-muted/30" } else { "" },
                                 onclick: {
                                     let date = date.clone();
-                                    let handler = props.on_date_select.clone();
+                                    let handler = props.on_date_select;
                                     move |_| {
                                         if let Some(h) = &handler {
                                             h.call(date.clone());
@@ -415,7 +415,7 @@ fn MonthView(props: MonthViewProps) -> Element {
                                                 style: "{style}",
                                                 onclick: {
                                                     let event = event.clone();
-                                                    let handler = props.on_event_click.clone();
+                                                    let handler = props.on_event_click;
                                                     move |e| {
                                                         e.stop_propagation();
                                                         if let Some(h) = &handler {
@@ -736,7 +736,7 @@ fn render_all_day_events(events: &[UnifiedEvent], on_click: Option<EventHandler<
                                 style: "{style}",
                                 onclick: {
                                     let event = (*event).clone();
-                                    let handler = on_click.clone();
+                                    let handler = on_click;
                                     move |_| {
                                         if let Some(h) = &handler {
                                             h.call(event.clone());

--- a/src/components/cashu_add_mint_modal.rs
+++ b/src/components/cashu_add_mint_modal.rs
@@ -7,7 +7,7 @@ pub fn CashuAddMintModal(
     on_close: EventHandler<()>,
     on_mint_added: EventHandler<String>,
 ) -> Element {
-    let mut mint_url = use_signal(|| String::new());
+    let mut mint_url = use_signal(String::new);
     let mut is_checking = use_signal(|| false);
     let mut is_adding = use_signal(|| false);
     let mut mint_info = use_signal(|| Option::<MintInfoDisplay>::None);

--- a/src/components/cashu_create_request_modal.rs
+++ b/src/components/cashu_create_request_modal.rs
@@ -6,8 +6,8 @@ use crate::stores::cashu::PaymentRequestProgress;
 pub fn CashuCreateRequestModal(
     on_close: EventHandler<()>,
 ) -> Element {
-    let mut amount_input = use_signal(|| String::new());
-    let mut description_input = use_signal(|| String::new());
+    let mut amount_input = use_signal(String::new);
+    let mut description_input = use_signal(String::new);
     let mut use_nostr_transport = use_signal(|| true);
     let mut request_string = use_signal(|| Option::<String>::None);
     let mut current_request_id = use_signal(|| Option::<String>::None);

--- a/src/components/cashu_mint_discovery_modal.rs
+++ b/src/components/cashu_mint_discovery_modal.rs
@@ -9,7 +9,7 @@ pub fn CashuMintDiscoveryModal(
     on_mint_selected: EventHandler<String>,
 ) -> Element {
     let mut is_loading = use_signal(|| true);
-    let mut discovered_mints = use_signal(|| Vec::<DiscoveredMint>::new());
+    let mut discovered_mints = use_signal(Vec::<DiscoveredMint>::new);
     let mut error_message = use_signal(|| Option::<String>::None);
     let mut selected_mint = use_signal(|| Option::<String>::None);
     let mut is_adding = use_signal(|| false);
@@ -50,7 +50,7 @@ pub fn CashuMintDiscoveryModal(
     };
 
     // Get existing mints to filter out already added ones (memoized to avoid cloning on every render)
-    let existing_mints = use_memo(move || cashu::get_mints());
+    let existing_mints = use_memo(cashu::get_mints);
 
     // Precompute display names for discovered mints to avoid URL parsing on every render
     let mints_with_display = use_memo(move || {

--- a/src/components/cashu_optimize_modal.rs
+++ b/src/components/cashu_optimize_modal.rs
@@ -8,7 +8,7 @@ pub fn CashuOptimizeModal(
     on_close: EventHandler<()>,
 ) -> Element {
     let mut is_optimizing = use_signal(|| false);
-    let mut results = use_signal(|| Vec::<(String, ConsolidationResult)>::new());
+    let mut results = use_signal(Vec::<(String, ConsolidationResult)>::new);
     let mut error_message = use_signal(|| Option::<String>::None);
     let mut is_complete = use_signal(|| false);
 

--- a/src/components/cashu_pay_request_modal.rs
+++ b/src/components/cashu_pay_request_modal.rs
@@ -31,8 +31,8 @@ impl PartialEq for PayState {
 pub fn CashuPayRequestModal(
     on_close: EventHandler<()>,
 ) -> Element {
-    let mut request_input = use_signal(|| String::new());
-    let mut custom_amount = use_signal(|| String::new());
+    let mut request_input = use_signal(String::new);
+    let mut custom_amount = use_signal(String::new);
     let mut pay_state = use_signal(|| PayState::Input);
 
     // Use memo for reactive balance updates while modal is open

--- a/src/components/cashu_receive_lightning_modal.rs
+++ b/src/components/cashu_receive_lightning_modal.rs
@@ -8,7 +8,7 @@ use qrcode::{QrCode, render::svg};
 pub fn CashuReceiveLightningModal(
     on_close: EventHandler<()>,
 ) -> Element {
-    let mut amount = use_signal(|| String::new());
+    let mut amount = use_signal(String::new);
     let mints = cashu::get_mints();
     let mut selected_mint = use_signal(|| mints.first().cloned().unwrap_or_default());
     let mut is_generating = use_signal(|| false);
@@ -48,8 +48,8 @@ pub fn CashuReceiveLightningModal(
                 mint_status.set(Some("Connecting...".to_string()));
 
                 // Clone reactive handles into the async task to observe cancellation
-                let is_polling_clone = is_polling.clone();
-                let quote_info_clone = quote_info.clone();
+                let is_polling_clone = is_polling;
+                let quote_info_clone = quote_info;
 
                 spawn(async move {
                     // Try WebSocket subscription first (NUT-17)

--- a/src/components/cashu_receive_modal.rs
+++ b/src/components/cashu_receive_modal.rs
@@ -6,7 +6,7 @@ use crate::stores::cashu::ReceiveTokensOptions;
 pub fn CashuReceiveModal(
     on_close: EventHandler<()>,
 ) -> Element {
-    let mut token_string = use_signal(|| String::new());
+    let mut token_string = use_signal(String::new);
     let mut is_receiving = use_signal(|| false);
     let mut error_message = use_signal(|| Option::<String>::None);
     let mut success_message = use_signal(|| Option::<String>::None);

--- a/src/components/cashu_send_lightning_modal.rs
+++ b/src/components/cashu_send_lightning_modal.rs
@@ -24,7 +24,7 @@ enum PaymentMode {
 pub fn CashuSendLightningModal(
     on_close: EventHandler<()>,
 ) -> Element {
-    let mut invoice = use_signal(|| String::new());
+    let mut invoice = use_signal(String::new);
     let mints = get_mints();
     let mut selected_mint = use_signal(|| mints.first().cloned().unwrap_or_default());
     let mut is_creating_quote = use_signal(|| false);
@@ -44,9 +44,9 @@ pub fn CashuSendLightningModal(
     // MPP state
     let mut payment_mode = use_signal(|| PaymentMode::Single);
     let mut mpp_quote = use_signal(|| Option::<MppQuoteInfo>::None);
-    let mut mpp_allocations = use_signal(|| Vec::<(String, u64)>::new());
-    let mut mint_balances = use_signal(|| Vec::<(String, u64)>::new());
-    let mut mpp_mint_balances = use_signal(|| Vec::<(String, u64)>::new()); // Only MPP-supporting mints
+    let mut mpp_allocations = use_signal(Vec::<(String, u64)>::new);
+    let mut mint_balances = use_signal(Vec::<(String, u64)>::new);
+    let mut mpp_mint_balances = use_signal(Vec::<(String, u64)>::new); // Only MPP-supporting mints
 
     // Read melt progress for UI updates
     let melt_progress = MELT_PROGRESS.read();

--- a/src/components/cashu_send_modal.rs
+++ b/src/components/cashu_send_modal.rs
@@ -10,7 +10,7 @@ use crate::utils::{shorten_url, format::truncate_pubkey};
 pub fn CashuSendModal(
     on_close: EventHandler<()>,
 ) -> Element {
-    let mut amount = use_signal(|| String::new());
+    let mut amount = use_signal(String::new);
     let mints = cashu::get_mints();
     let mut selected_mint = use_signal(|| mints.first().cloned().unwrap_or_default());
     let mut is_sending = use_signal(|| false);
@@ -18,7 +18,7 @@ pub fn CashuSendModal(
     let mut token_result = use_signal(|| Option::<String>::None);
     // P2PK (send to npub) support
     let mut p2pk_enabled = use_signal(|| false);
-    let mut recipient_pubkey = use_signal(|| String::new());
+    let mut recipient_pubkey = use_signal(String::new);
     // Fee estimation
     let mut estimated_fee = use_signal(|| Option::<u64>::None);
     let mut is_estimating_fee = use_signal(|| false);

--- a/src/components/cashu_token_card.rs
+++ b/src/components/cashu_token_card.rs
@@ -148,12 +148,12 @@ pub fn CashuTokenCard(token: String) -> Element {
     // Handle copy button
     let handle_copy = {
         let token = token.clone();
-        let toast_api = toast.clone();
+        let toast_api = toast;
         move |e: MouseEvent| {
             e.stop_propagation();
 
             let token = token.clone();
-            let toast_api = toast_api.clone();
+            let toast_api = toast_api;
             spawn_forever(async move {
                 match copy_to_clipboard(&token).await {
                     Ok(_) => {

--- a/src/components/cashu_transfer_modal.rs
+++ b/src/components/cashu_transfer_modal.rs
@@ -11,14 +11,14 @@ fn select_valid_mint(
     // If current is valid and not excluded, keep it
     if !current.is_empty()
         && mints.contains(&current.to_string())
-        && exclude.map_or(true, |ex| ex != current)
+        && (exclude != Some(current))
     {
         return Some(current.to_string());
     }
 
     // Otherwise, find first valid alternative
     mints.iter()
-        .find(|m| exclude.map_or(true, |ex| *m != ex))
+        .find(|m| exclude.is_none_or(|ex| *m != ex))
         .cloned()
 }
 
@@ -26,11 +26,11 @@ fn select_valid_mint(
 pub fn CashuTransferModal(
     on_close: EventHandler<()>,
 ) -> Element {
-    let mut amount = use_signal(|| String::new());
+    let mut amount = use_signal(String::new);
     // Use memo for reactive mint list that updates when WALLET_STATE changes
-    let mints = use_memo(move || cashu::get_mints());
-    let mut source_mint = use_signal(|| String::new());
-    let mut target_mint = use_signal(|| String::new());
+    let mints = use_memo(cashu::get_mints);
+    let mut source_mint = use_signal(String::new);
+    let mut target_mint = use_signal(String::new);
     let mut is_transferring = use_signal(|| false);
     let mut error_message = use_signal(|| Option::<String>::None);
     let mut fee_estimate = use_signal(|| Option::<u64>::None);

--- a/src/components/citation_editor_modal.rs
+++ b/src/components/citation_editor_modal.rs
@@ -197,8 +197,8 @@ pub fn CitationEditorModal(mut props: CitationEditorModalProps) -> Element {
         let llm_val = llm.read().clone();
         let summary_val = conversation_summary.read().clone();
         let prompt_url_val = prompt_url.read().clone();
-        let on_save = props.on_save.clone();
-        let mut show = props.show.clone();
+        let on_save = props.on_save;
+        let mut show = props.show;
 
         spawn(async move {
             let result = match current_tab {

--- a/src/components/citation_picker_modal.rs
+++ b/src/components/citation_picker_modal.rs
@@ -43,7 +43,7 @@ pub struct CitationPickerModalProps {
 pub fn CitationPickerModal(mut props: CitationPickerModalProps) -> Element {
     let mut active_tab = use_signal(|| PickerTab::MyCitations);
     let mut search_query = use_signal(String::new);
-    let mut search_results = use_signal(|| Vec::<CachedCitation>::new());
+    let mut search_results = use_signal(Vec::<CachedCitation>::new);
     let mut is_searching = use_signal(|| false);
 
     // Selected citation

--- a/src/components/code_issue_card.rs
+++ b/src/components/code_issue_card.rs
@@ -28,7 +28,7 @@ pub fn CodeIssueCard(
 
                 // Status badge
                 CodeStatusBadge {
-                    status: issue.status.clone(),
+                    status: issue.status,
                     size: BadgeSize::Small,
                 }
 

--- a/src/components/code_pull_card.rs
+++ b/src/components/code_pull_card.rs
@@ -26,7 +26,7 @@ pub fn CodePullCard(
 
                 // Status badge
                 CodeStatusBadge {
-                    status: pr.status.clone(),
+                    status: pr.status,
                     size: BadgeSize::Small,
                 }
 

--- a/src/components/comment_composer.rs
+++ b/src/components/comment_composer.rs
@@ -23,9 +23,9 @@ pub fn CommentComposer(
     on_close: EventHandler<()>,
     on_success: EventHandler<()>,
 ) -> Element {
-    let mut content = use_signal(|| String::new());
+    let mut content = use_signal(String::new);
     let mut show_media_uploader = use_signal(|| false);
-    let mut uploaded_media = use_signal(|| Vec::<String>::new());
+    let mut uploaded_media = use_signal(Vec::<String>::new);
     let toast = consume_toast();
 
     // Calculate total length including media URLs
@@ -151,7 +151,7 @@ pub fn CommentComposer(
     };
 
     let handle_publish = {
-        let toast_api = toast.clone();
+        let toast_api = toast;
         move |_| {
             let mut content_value = content.read().clone();
 
@@ -161,7 +161,7 @@ pub fn CommentComposer(
                     content_value.push_str("\n\n");
                 }
                 for url in uploaded_media.read().iter() {
-                    content_value.push_str(&url);
+                    content_value.push_str(url);
                     content_value.push('\n');
                 }
             }
@@ -226,7 +226,7 @@ pub fn CommentComposer(
         // Clone for async block
         let local_id_clone = local_id.clone();
         let content_for_publish = content_value.clone();
-        let toast_for_async = toast_api.clone();
+        let toast_for_async = toast_api;
 
         // Use spawn_forever so the task survives component unmount
         spawn_forever(async move {

--- a/src/components/community_post_card.rs
+++ b/src/components/community_post_card.rs
@@ -500,7 +500,7 @@ pub fn CommunityPostCard(
             // Reply composer modal
             if *show_reply_composer.read() {
                 {
-                    let on_reply_success_clone = on_reply_success.clone();
+                    let on_reply_success_clone = on_reply_success;
                     rsx! {
                         CommunityPostComposer {
                             community: community.clone(),

--- a/src/components/community_post_composer.rs
+++ b/src/components/community_post_composer.rs
@@ -25,8 +25,8 @@ pub fn CommunityPostComposer(
     // Clone values for closures
     let community_for_post = community.clone();
     let reply_to_for_post = reply_to.clone();
-    let on_success_for_post = on_success.clone();
-    let on_close_for_post = on_close.clone();
+    let on_success_for_post = on_success;
+    let on_close_for_post = on_close;
 
     let handle_submit = move |_| {
         let content_text = content.read().trim().to_string();
@@ -37,8 +37,8 @@ pub fn CommunityPostComposer(
 
         let community = community_for_post.clone();
         let reply_to = reply_to_for_post.clone();
-        let on_success = on_success_for_post.clone();
-        let on_close = on_close_for_post.clone();
+        let on_success = on_success_for_post;
+        let on_close = on_close_for_post;
 
         posting.set(true);
         error.set(None);
@@ -67,7 +67,7 @@ pub fn CommunityPostComposer(
         });
     };
 
-    let on_close_backdrop = on_close.clone();
+    let on_close_backdrop = on_close;
 
     // Helper to check for unsaved content and confirm close
     let confirm_close = move |handler: EventHandler<()>| {
@@ -84,13 +84,13 @@ pub fn CommunityPostComposer(
         }
     };
 
-    let on_close_for_backdrop = on_close_backdrop.clone();
-    let on_close_for_button = on_close.clone();
+    let on_close_for_backdrop = on_close_backdrop;
+    let on_close_for_button = on_close;
 
     rsx! {
         div {
             class: "fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4",
-            onclick: move |_| confirm_close(on_close_for_backdrop.clone()),
+            onclick: move |_| confirm_close(on_close_for_backdrop),
 
             div {
                 class: "bg-background rounded-lg p-6 max-w-lg w-full shadow-xl max-h-[90vh] overflow-y-auto",
@@ -109,7 +109,7 @@ pub fn CommunityPostComposer(
                     }
                     button {
                         class: "p-2 hover:bg-accent rounded-full transition",
-                        onclick: move |_| confirm_close(on_close_for_button.clone()),
+                        onclick: move |_| confirm_close(on_close_for_button),
                         svg {
                             class: "w-5 h-5",
                             xmlns: "http://www.w3.org/2000/svg",
@@ -294,7 +294,7 @@ pub fn CommunityPostComposerInline(
     let has_signer = *HAS_SIGNER.read();
 
     let community_for_post = community.clone();
-    let on_success_for_post = on_success.clone();
+    let on_success_for_post = on_success;
 
     let handle_submit = move |_| {
         let content_text = content.read().trim().to_string();
@@ -303,7 +303,7 @@ pub fn CommunityPostComposerInline(
         }
 
         let community = community_for_post.clone();
-        let on_success = on_success_for_post.clone();
+        let on_success = on_success_for_post;
 
         posting.set(true);
         error.set(None);

--- a/src/components/content_menu.rs
+++ b/src/components/content_menu.rs
@@ -41,7 +41,7 @@ impl ContentMenuType {
     }
 
     /// Convert to PinContentType for pin board integration
-    pub fn to_pin_content_type(&self) -> PinContentType {
+    pub fn to_pin_content_type(self) -> PinContentType {
         match self {
             ContentMenuType::Wiki => PinContentType::Article,
             ContentMenuType::Recipe => PinContentType::Recipe,
@@ -248,7 +248,7 @@ pub fn ContentMenu(props: ContentMenuProps) -> Element {
                             is_open.set(false);
 
                             let naddr_to_copy = naddr_copy.clone();
-                            let toast_api = toast.clone();
+                            let toast_api = toast;
 
                             // Create nostr: URI
                             let nostr_uri = format!("nostr:{}", naddr_to_copy);

--- a/src/components/dvm_selector_modal.rs
+++ b/src/components/dvm_selector_modal.rs
@@ -15,7 +15,7 @@ pub fn DvmSelectorModal(
 ) -> Element {
     let providers = DVM_PROVIDERS.read().clone();
     let loading = *DVM_PROVIDERS_LOADING.read();
-    let selected = SELECTED_DVM_PROVIDER.read().clone();
+    let selected = *SELECTED_DVM_PROVIDER.read();
 
     rsx! {
         // Modal overlay

--- a/src/components/emoji_picker.rs
+++ b/src/components/emoji_picker.rs
@@ -200,7 +200,7 @@ enum EmojiCategory {
 pub fn EmojiPicker(props: EmojiPickerProps) -> Element {
     let mut show_picker = use_signal(|| false);
     let mut selected_category = use_signal(|| EmojiCategory::Recent);
-    let mut search_query = use_signal(|| String::new());
+    let mut search_query = use_signal(String::new);
     #[allow(unused_mut)]
     let mut position_below = use_signal(|| false); // Whether to show popup below button
     let button_id = use_signal(|| format!("emoji-picker-{}", uuid::Uuid::new_v4()));

--- a/src/components/event_card.rs
+++ b/src/components/event_card.rs
@@ -464,7 +464,7 @@ fn format_event_time_short(event: &UnifiedEvent) -> String {
 
     // Use relative time for recent/upcoming events
     let now_secs = (js_sys::Date::now() / 1000.0) as u64;
-    let diff = if ts > now_secs { ts - now_secs } else { now_secs - ts };
+    let diff = ts.abs_diff(now_secs);
 
     // Within a week, use relative time
     if diff < 7 * 86400 {

--- a/src/components/gif_picker.rs
+++ b/src/components/gif_picker.rs
@@ -17,7 +17,7 @@ pub fn GifPicker(props: GifPickerProps) -> Element {
     let mut position_right = use_signal(|| true); // Whether to show popup to the right of button
     let button_id = use_signal(|| format!("gif-picker-{}", uuid::Uuid::new_v4()));
     let mut initialized = use_signal(|| false);
-    let mut search_query = use_signal(|| String::new());
+    let mut search_query = use_signal(String::new);
     #[allow(unused_mut)]
     let mut picker_top = use_signal(|| 0.0);
     #[allow(unused_mut)]
@@ -33,7 +33,7 @@ pub fn GifPicker(props: GifPickerProps) -> Element {
     // Debounced search effect
     use_effect(move || {
         let query = search_query.read().clone();
-        if initialized.read().clone() {
+        if *initialized.read() {
             spawn(async move {
                 // Wait 300ms for debouncing
                 #[cfg(target_family = "wasm")]

--- a/src/components/gif_upload_modal.rs
+++ b/src/components/gif_upload_modal.rs
@@ -31,7 +31,7 @@ pub fn GifUploadModal(props: GifUploadModalProps) -> Element {
     // State
     // Store: (filename, data, mime, preview_url) - preview_url is an Object URL for efficient preview
     let mut selected_file = use_signal(|| None::<(String, Vec<u8>, String, Option<String>)>);
-    let mut caption = use_signal(|| String::new());
+    let mut caption = use_signal(String::new);
     let mut upload_server = use_signal(|| UploadServer::NostrBuild);
     let mut uploading = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
@@ -68,7 +68,7 @@ pub fn GifUploadModal(props: GifUploadModalProps) -> Element {
 
     // File selection handler
     let handle_file_select = {
-        let input_id = input_id.clone();
+        let input_id = input_id;
         move |_evt: Event<FormData>| {
             let input_id = input_id.read().clone();
             spawn(async move {
@@ -112,12 +112,12 @@ pub fn GifUploadModal(props: GifUploadModalProps) -> Element {
 
     // Upload handler
     let handle_upload = {
-        let on_upload = props.on_upload.clone();
+        let on_upload = props.on_upload;
         move |_| {
             let file_data = selected_file.read().clone();
             let caption_text = caption.read().clone();
             let server = upload_server.read().clone();
-            let on_upload = on_upload.clone();
+            let on_upload = on_upload;
 
             if file_data.is_none() {
                 error.set(Some("Please select a file first".to_string()));
@@ -170,7 +170,7 @@ pub fn GifUploadModal(props: GifUploadModalProps) -> Element {
                         log::info!("File uploaded successfully: {}", url);
 
                         // Now publish the NIP-94 event
-                        let dims = dimensions.map(|(w, h)| (w, h));
+                        let dims = dimensions;
 
                         match gif_store::publish_gif_event(
                             url.clone(),
@@ -249,7 +249,7 @@ pub fn GifUploadModal(props: GifUploadModalProps) -> Element {
 
     // Clear file selection
     let handle_clear = {
-        let input_id = input_id.clone();
+        let input_id = input_id;
         move |_| {
             // Revoke object URL to free memory
             if let Some((_, _, _, Some(url))) = selected_file.read().as_ref() {

--- a/src/components/live_chat.rs
+++ b/src/components/live_chat.rs
@@ -56,9 +56,9 @@ pub fn LiveChat(
     stream_author_pubkey: String,
     stream_d_tag: String,
 ) -> Element {
-    let mut messages = use_signal(|| Vec::<Event>::new());
+    let mut messages = use_signal(Vec::<Event>::new);
     let mut loading = use_signal(|| false);
-    let mut message_input = use_signal(|| String::new());
+    let mut message_input = use_signal(String::new);
     let mut sending = use_signal(|| false);
     // Make has_signer reactive - read from the store when needed instead of capturing once
     let has_signer = use_memo(move || *HAS_SIGNER.read());

--- a/src/components/live_stream_share_modal.rs
+++ b/src/components/live_stream_share_modal.rs
@@ -29,8 +29,8 @@ pub fn LiveStreamShareModal(
 ) -> Element {
     let mut share_mode = use_signal(|| ShareMode::Main);
     let mut copied = use_signal(|| false);
-    let mut nostr_text = use_signal(|| String::new());
-    let mut dm_recipient = use_signal(|| String::new());
+    let mut nostr_text = use_signal(String::new);
+    let mut dm_recipient = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut dm_error = use_signal(|| Option::<String>::None);
     let mut nostr_error = use_signal(|| Option::<String>::None);

--- a/src/components/media_uploader.rs
+++ b/src/components/media_uploader.rs
@@ -58,7 +58,7 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
     let handle_upload = move |_| {
         if let Some((_filename, data, mime_type)) = selected_file.read().clone() {
             let quality_val = *quality.read();
-            let on_upload = props.on_upload.clone();
+            let on_upload = props.on_upload;
             let input_id_for_clear = input_id_for_upload.clone();
 
             uploading.set(true);

--- a/src/components/mention_autocomplete.rs
+++ b/src/components/mention_autocomplete.rs
@@ -40,10 +40,10 @@ pub struct MentionAutocompleteProps {
 #[component]
 pub fn MentionAutocomplete(props: MentionAutocompleteProps) -> Element {
     let mut show_autocomplete = use_signal(|| false);
-    let search_results = use_signal(|| Vec::<ProfileSearchResult>::new());
+    let search_results = use_signal(Vec::<ProfileSearchResult>::new);
     let mut selected_index = use_signal(|| 0usize);
     let is_searching = use_signal(|| false);
-    let mention_query = use_signal(|| String::new());
+    let mention_query = use_signal(String::new);
     let mention_start_pos = use_signal(|| 0usize);
     let mut internal_cursor_pos = use_signal(|| 0usize);
 
@@ -58,7 +58,7 @@ pub fn MentionAutocomplete(props: MentionAutocompleteProps) -> Element {
     let relay_search_task = use_signal(|| None::<Task>);
 
     // Contact list cache
-    let mut contact_pubkeys = use_signal(|| Vec::<PublicKey>::new());
+    let mut contact_pubkeys = use_signal(Vec::<PublicKey>::new);
 
     // Fetch contacts on mount
     use_effect(move || {
@@ -70,7 +70,7 @@ pub fn MentionAutocomplete(props: MentionAutocompleteProps) -> Element {
 
     let handle_input = move |evt: DioxusEvent<FormData>| {
         let new_value = evt.value().clone();
-        let cursor_pos = get_cursor_position(&**textarea_id.read());
+        let cursor_pos = get_cursor_position(&textarea_id.read());
         internal_cursor_pos.set(cursor_pos);
         if let Some(mut signal) = props.cursor_position {
             let cursor_utf8 = utf16_to_utf8_index(&new_value, cursor_pos);
@@ -85,7 +85,7 @@ pub fn MentionAutocomplete(props: MentionAutocompleteProps) -> Element {
 
         // Update dropdown position if showing
         if *show_autocomplete.read() {
-            update_dropdown_position(&**textarea_id.read(), &mut dropdown_top, &mut dropdown_left, &mut show_below);
+            update_dropdown_position(&textarea_id.read(), &mut dropdown_top, &mut dropdown_left, &mut show_below);
         }
     };
 
@@ -121,7 +121,7 @@ pub fn MentionAutocomplete(props: MentionAutocompleteProps) -> Element {
                         insert_mention(
                             profile.clone(),
                             props.content,
-                            props.on_input.clone(),
+                            props.on_input,
                             *mention_start_pos.read(),
                             mention_query.read().len(),
                             (**textarea_id.read()).clone(),
@@ -146,7 +146,7 @@ pub fn MentionAutocomplete(props: MentionAutocompleteProps) -> Element {
 
     // Shared helper to update cursor position from DOM
     let mut sync_cursor_position = move || {
-        let cursor_pos = get_cursor_position(&**textarea_id.read());
+        let cursor_pos = get_cursor_position(&textarea_id.read());
         internal_cursor_pos.set(cursor_pos);
         if let Some(mut signal) = props.cursor_position {
             let text = props.content.read();
@@ -192,7 +192,7 @@ pub fn MentionAutocomplete(props: MentionAutocompleteProps) -> Element {
                     *dropdown_left.read(),
                     *show_below.read(),
                     props.content,
-                    props.on_input.clone(),
+                    props.on_input,
                     *mention_start_pos.read(),
                     mention_query.read().len(),
                     (**textarea_id.read()).clone(),
@@ -537,7 +537,7 @@ fn render_dropdown(
                                             insert_mention(
                                                 profile_clone.clone(),
                                                 content,
-                                                on_input.clone(),
+                                                on_input,
                                                 mention_start_pos,
                                                 query_len,
                                                 (*textarea_id_clone).clone(),

--- a/src/components/music_zap_dialog.rs
+++ b/src/components/music_zap_dialog.rs
@@ -61,14 +61,14 @@ pub fn MusicZapDialog() -> Element {
     let is_nostr_track = matches!(track.source, TrackSource::Nostr { .. });
 
     let mut amount = use_signal(|| 100u64);
-    let mut comment = use_signal(|| String::new());
+    let mut comment = use_signal(String::new);
     let mut invoice = use_signal(|| None::<String>);
     let mut is_generating = use_signal(|| false);
     let mut error_msg = use_signal(|| None::<String>);
     let mut qr_code_url = use_signal(|| None::<String>);
     let mut artist_profile = use_signal(|| None::<profiles::Profile>);
 
-    let preset_amounts = vec![21, 100, 500, 1000, 2100];
+    let preset_amounts = [21, 100, 500, 1000, 2100];
 
     // Fetch artist profile for nostr tracks
     let track_source_for_effect = track.source.clone();

--- a/src/components/note_composer.rs
+++ b/src/components/note_composer.rs
@@ -7,7 +7,7 @@ const MAX_LENGTH: usize = 5000;
 
 #[component]
 pub fn NoteComposer() -> Element {
-    let mut content = use_signal(|| String::new());
+    let mut content = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut is_focused = use_signal(|| false);
     let mut show_image_uploader = use_signal(|| false);

--- a/src/components/note_menu.rs
+++ b/src/components/note_menu.rs
@@ -269,7 +269,7 @@ pub fn NoteMenu(props: NoteMenuProps) -> Element {
                             is_open.set(false);
 
                             let event_id = event_id_copy.clone();
-                            let toast_api = toast.clone();
+                            let toast_api = toast;
 
                             // Convert event ID to nostr:note1... format (NIP-21 URI)
                             if let Ok(event_id_parsed) = EventId::from_hex(&event_id) {

--- a/src/components/nwc_setup_modal.rs
+++ b/src/components/nwc_setup_modal.rs
@@ -8,7 +8,7 @@ pub fn NwcSetupModal(
     /// Handler to close the modal
     on_close: EventHandler<()>,
 ) -> Element {
-    let mut nwc_uri = use_signal(|| String::new());
+    let mut nwc_uri = use_signal(String::new);
     let mut is_connecting = use_signal(|| false);
     let mut connection_error = use_signal(|| Option::<String>::None);
     let mut connection_success = use_signal(|| false);

--- a/src/components/photo_card.rs
+++ b/src/components/photo_card.rs
@@ -129,7 +129,7 @@ pub fn PhotoCard(event: Event) -> Element {
     let mut author_metadata = use_signal(|| None::<nostr_sdk::Metadata>);
 
     // State for comment composer
-    let mut comment_text = use_signal(|| String::new());
+    let mut comment_text = use_signal(String::new);
     let mut is_posting_comment = use_signal(|| false);
 
     // State for zap modal
@@ -677,7 +677,7 @@ pub fn PhotoCard(event: Event) -> Element {
                     {
                         let count = *reply_count.read();
                         if count == 1 {
-                            format!("View 1 comment")
+                            "View 1 comment".to_string()
                         } else {
                             format!("View all {} comments", count)
                         }

--- a/src/components/pin_board_card.rs
+++ b/src/components/pin_board_card.rs
@@ -568,8 +568,8 @@ pub fn PinBoardMosaicGrid(
                 PinBoardCardMosaic {
                     key: "{board.a_tag}",
                     board: board.clone(),
-                    on_click: on_board_click.clone(),
-                    on_zap_request: on_zap_request.clone(),
+                    on_click: on_board_click,
+                    on_zap_request: on_zap_request,
                     // Assign size variant based on index for variety
                     // Boards with images will use natural aspect ratio anyway
                     size_variant: if board.image.is_some() {

--- a/src/components/pin_board_item_card.rs
+++ b/src/components/pin_board_item_card.rs
@@ -360,7 +360,7 @@ pub fn PinGrid(
                     key: "{pin.event_id}",
                     pin: pin.clone(),
                     show_remove: show_remove,
-                    on_remove: on_remove.clone(),
+                    on_remove: on_remove,
                 }
             }
 

--- a/src/components/pin_board_item_selector.rs
+++ b/src/components/pin_board_item_selector.rs
@@ -30,12 +30,12 @@ pub struct PinToBoardModalProps {
 /// Modal for selecting which board to pin content to
 #[component]
 pub fn PinToBoardModal(props: PinToBoardModalProps) -> Element {
-    let mut boards = use_signal(|| Vec::<Pinboard>::new());
+    let mut boards = use_signal(Vec::<Pinboard>::new);
     let mut loading = use_signal(|| true);
     let mut error_msg = use_signal(|| None::<String>);
     let mut saving = use_signal(|| false);
     let mut success = use_signal(|| false);
-    let mut selected_board_addrs = use_signal(|| Vec::<String>::new());
+    let mut selected_board_addrs = use_signal(Vec::<String>::new);
     let mut pin_note = use_signal(String::new);
 
     // Fetch user's boards on mount
@@ -58,8 +58,8 @@ pub fn PinToBoardModal(props: PinToBoardModalProps) -> Element {
     let content_type = props.content_type.clone();
     let reference = props.reference.clone();
     let title = props.title.clone();
-    let on_close = props.on_close.clone();
-    let on_success = props.on_success.clone();
+    let on_close = props.on_close;
+    let on_success = props.on_success;
 
     let handle_add = move |_| {
         let selected = selected_board_addrs.read().clone();
@@ -68,8 +68,8 @@ pub fn PinToBoardModal(props: PinToBoardModalProps) -> Element {
         let reference = reference.clone();
         let title = title.clone();
         let note = pin_note.read().clone();
-        let _on_close = on_close.clone();
-        let on_success = on_success.clone();
+        let _on_close = on_close;
+        let on_success = on_success;
 
         saving.set(true);
         error_msg.set(None);

--- a/src/components/podcast_chapters.rs
+++ b/src/components/podcast_chapters.rs
@@ -47,7 +47,7 @@ pub fn PodcastChapters(props: PodcastChaptersProps) -> Element {
                 ChapterList {
                     chapters: chapter_list,
                     current_time: props.current_time,
-                    on_seek: props.on_seek.clone(),
+                    on_seek: props.on_seek,
                     compact: props.compact
                 }
             }
@@ -108,7 +108,7 @@ pub fn ChapterList(props: ChapterListProps) -> Element {
                     key: "{idx}",
                     chapter: (*chapter).clone(),
                     is_current: Some(idx) == current_chapter_idx,
-                    on_click: props.on_seek.clone(),
+                    on_click: props.on_seek,
                     compact: props.compact
                 }
             }
@@ -147,7 +147,7 @@ fn ChapterItem(props: ChapterItemProps) -> Element {
 
     let handle_click = {
         let start_time = chapter.start_time;
-        let on_click = props.on_click.clone();
+        let on_click = props.on_click;
         move |_| {
             if let Some(handler) = &on_click {
                 handler.call(start_time);

--- a/src/components/podcast_episode_card.rs
+++ b/src/components/podcast_episode_card.rs
@@ -265,7 +265,7 @@ pub fn PodcastEpisodeCard(props: PodcastEpisodeCardProps) -> Element {
 
     // Format duration
     let duration_str = episode.duration
-        .map(|d| format_duration(d))
+        .map(format_duration)
         .unwrap_or_else(|| "--:--".to_string());
 
     // Image URL with fallback

--- a/src/components/podcast_soundbites.rs
+++ b/src/components/podcast_soundbites.rs
@@ -67,7 +67,7 @@ pub fn PodcastSoundbites(props: PodcastSoundbitesProps) -> Element {
                         soundbite: soundbite.clone(),
                         index: idx,
                         episode_title: props.episode_title.clone(),
-                        on_play: props.on_play.clone(),
+                        on_play: props.on_play,
                         compact: props.compact
                     }
                 }
@@ -106,7 +106,7 @@ fn SoundbiteCard(props: SoundbiteCardProps) -> Element {
 
     let handle_play = {
         let sb = soundbite.clone();
-        let on_play = props.on_play.clone();
+        let on_play = props.on_play;
         move |_| {
             if let Some(handler) = &on_play {
                 handler.call(sb.clone());
@@ -450,7 +450,7 @@ pub fn FeaturedSoundbite(props: FeaturedSoundbiteProps) -> Element {
 
     let handle_play = {
         let sb = soundbite.clone();
-        let on_play = props.on_play.clone();
+        let on_play = props.on_play;
         move |_| {
             if let Some(handler) = &on_play {
                 handler.call(sb.clone());

--- a/src/components/podcast_transcript.rs
+++ b/src/components/podcast_transcript.rs
@@ -105,7 +105,7 @@ pub fn PodcastTranscript(props: PodcastTranscriptProps) -> Element {
                 TranscriptContent {
                     transcript: transcript.clone(),
                     current_time: props.current_time,
-                    on_seek: props.on_seek.clone(),
+                    on_seek: props.on_seek,
                     compact: props.compact
                 }
             }
@@ -156,7 +156,7 @@ fn TranscriptContent(props: TranscriptContentProps) -> Element {
                 TranscriptView {
                     cues: cues,
                     current_time: props.current_time,
-                    on_seek: props.on_seek.clone(),
+                    on_seek: props.on_seek,
                     compact: props.compact
                 }
             }
@@ -220,7 +220,7 @@ fn TranscriptView(props: TranscriptViewProps) -> Element {
                     key: "{idx}",
                     cue: cue.clone(),
                     is_current: Some(idx) == current_idx,
-                    on_click: props.on_seek.clone(),
+                    on_click: props.on_seek,
                     compact: props.compact
                 }
             }
@@ -267,7 +267,7 @@ fn TranscriptCueItem(props: TranscriptCueItemProps) -> Element {
 
     let handle_click = {
         let start_time = cue.start_time;
-        let on_click = props.on_click.clone();
+        let on_click = props.on_click;
         move |_| {
             if let Some(handler) = &on_click {
                 handler.call(start_time);

--- a/src/components/podcast_v4v.rs
+++ b/src/components/podcast_v4v.rs
@@ -272,14 +272,14 @@ pub fn V4VBoostButton(props: V4VBoostButtonProps) -> Element {
                             {
                                 let amt = *amount;
                                 let vb = value_block.clone();
-                                let on_boost = props.on_boost.clone();
+                                let on_boost = props.on_boost;
                                 rsx! {
                                     button {
                                         key: "{amt}",
                                         class: "px-3 py-2 rounded-lg bg-muted hover:bg-muted/80 text-sm font-medium transition",
                                         onclick: move |_| {
                                             let vb = vb.clone();
-                                            let on_boost = on_boost.clone();
+                                            let on_boost = on_boost;
                                             show_menu.set(false);
                                             is_sending.set(true);
                                             spawn(async move {
@@ -339,17 +339,17 @@ struct CustomBoostInputProps {
 
 #[component]
 fn CustomBoostInput(props: CustomBoostInputProps) -> Element {
-    let mut amount = use_signal(|| String::new());
+    let mut amount = use_signal(String::new);
     let mut is_sending = use_signal(|| false);
 
     let handle_send = {
         let vb = props.value_block.clone();
-        let on_send = props.on_send.clone();
+        let on_send = props.on_send;
         move |_| {
             if let Ok(amt) = amount.read().parse::<u64>() {
                 if amt > 0 {
                     let vb = vb.clone();
-                    let on_send = on_send.clone();
+                    let on_send = on_send;
                     is_sending.set(true);
                     spawn(async move {
                         if let Ok(_) = send_v4v_payment(&vb, amt).await {

--- a/src/components/poll_card.rs
+++ b/src/components/poll_card.rs
@@ -25,10 +25,10 @@ pub fn PollCard(event: NostrEvent) -> Element {
     // State
     let mut author_metadata = use_signal(|| None::<nostr_sdk::Metadata>);
     let mut poll_data = use_signal(|| None::<Poll>);
-    let mut votes = use_signal(|| Vec::<NostrEvent>::new());
+    let mut votes = use_signal(Vec::<NostrEvent>::new);
     let mut loading_votes = use_signal(|| true);
     let mut user_vote = use_signal(|| None::<NostrEvent>);
-    let mut selected_options = use_signal(|| Vec::<String>::new());
+    let mut selected_options = use_signal(Vec::<String>::new);
     let mut show_results = use_signal(|| false);
     let mut is_voting = use_signal(|| false);
 
@@ -175,7 +175,7 @@ pub fn PollCard(event: NostrEvent) -> Element {
     // Get display data
     let poll = poll_data.read().clone();
     let poll_title = poll.as_ref().map(|p| p.title.clone()).unwrap_or_default();
-    let poll_type = poll.as_ref().map(|p| p.r#type.clone()).unwrap_or(PollType::SingleChoice);
+    let poll_type = poll.as_ref().map(|p| p.r#type).unwrap_or(PollType::SingleChoice);
     let poll_options = poll.as_ref().map(|p| p.options.clone()).unwrap_or_default();
     let poll_ends_at = poll.as_ref().and_then(|p| p.ends_at);
 

--- a/src/components/poll_creator_modal.rs
+++ b/src/components/poll_creator_modal.rs
@@ -10,7 +10,7 @@ pub fn PollCreatorModal(
     on_poll_created: EventHandler<String>,
 ) -> Element {
     // Form state
-    let mut poll_question = use_signal(|| String::new());
+    let mut poll_question = use_signal(String::new);
     let mut poll_type = use_signal(|| PollType::SingleChoice);
     let mut options = use_signal(|| vec![
         PollOptionData {
@@ -23,8 +23,8 @@ pub fn PollCreatorModal(
         },
     ]);
     let mut end_time_preset = use_signal(|| String::from("1day"));
-    let mut custom_end_time = use_signal(|| String::new());
-    let mut hashtags_input = use_signal(|| String::new());
+    let mut custom_end_time = use_signal(String::new);
+    let mut hashtags_input = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut error_message = use_signal(|| Option::<String>::None);
     let mut show_advanced = use_signal(|| false);

--- a/src/components/poll_timer.rs
+++ b/src/components/poll_timer.rs
@@ -102,20 +102,20 @@ fn format_ended_date(ends_at: Timestamp) -> String {
     let diff = now.as_secs() as i64 - ends_at.as_secs() as i64;
 
     if diff < 60 {
-        return "just now".to_string();
+        "just now".to_string()
     } else if diff < 3600 {
         let minutes = diff / 60;
-        return format!("{} minute{} ago", minutes, if minutes == 1 { "" } else { "s" });
+        format!("{} minute{} ago", minutes, if minutes == 1 { "" } else { "s" })
     } else if diff < 86400 {
         let hours = diff / 3600;
-        return format!("{} hour{} ago", hours, if hours == 1 { "" } else { "s" });
+        format!("{} hour{} ago", hours, if hours == 1 { "" } else { "s" })
     } else if diff < 604800 {
         let days = diff / 86400;
-        return format!("{} day{} ago", days, if days == 1 { "" } else { "s" });
+        format!("{} day{} ago", days, if days == 1 { "" } else { "s" })
     } else {
         // Format as date for older polls
         let date = chrono::DateTime::from_timestamp(ends_at.as_secs() as i64, 0)
             .unwrap_or_default();
-        return date.format("%b %d, %Y").to_string();
+        date.format("%b %d, %Y").to_string()
     }
 }

--- a/src/components/profile_badges.rs
+++ b/src/components/profile_badges.rs
@@ -13,7 +13,7 @@ use crate::utils::nip58::{self, BadgeDefinition};
 /// Shows accepted badges for a user profile
 #[component]
 pub fn ProfileBadgesSection(pubkey: String) -> Element {
-    let mut badges = use_signal(|| Vec::<BadgeDefinition>::new());
+    let mut badges = use_signal(Vec::<BadgeDefinition>::new);
     let mut loading = use_signal(|| true);
     let mut selected_badge = use_signal(|| None::<BadgeDefinition>);
     let mut show_modal = use_signal(|| false);

--- a/src/components/profile_editor_modal.rs
+++ b/src/components/profile_editor_modal.rs
@@ -12,14 +12,14 @@ pub struct ProfileEditorModalProps {
 #[component]
 pub fn ProfileEditorModal(mut props: ProfileEditorModalProps) -> Element {
     // Form fields
-    let mut name = use_signal(|| String::new());
-    let mut display_name = use_signal(|| String::new());
-    let mut about = use_signal(|| String::new());
-    let mut picture = use_signal(|| String::new());
-    let mut banner = use_signal(|| String::new());
-    let mut website = use_signal(|| String::new());
-    let mut nip05 = use_signal(|| String::new());
-    let mut lud16 = use_signal(|| String::new());
+    let mut name = use_signal(String::new);
+    let mut display_name = use_signal(String::new);
+    let mut about = use_signal(String::new);
+    let mut picture = use_signal(String::new);
+    let mut banner = use_signal(String::new);
+    let mut website = use_signal(String::new);
+    let mut nip05 = use_signal(String::new);
+    let mut lud16 = use_signal(String::new);
 
     // NIP-24 fields
     let mut is_bot = use_signal(|| false);

--- a/src/components/publication_toc.rs
+++ b/src/components/publication_toc.rs
@@ -47,7 +47,7 @@ pub fn PublicationToc(
                             nodes: root_children,
                             tree: tree.clone(),
                             selected: selected.clone(),
-                            on_select: on_select.clone(),
+                            on_select: on_select,
                             depth: 0,
                         }
                     }
@@ -78,7 +78,7 @@ fn TocNodeList(
                         node: node.clone(),
                         tree: tree.clone(),
                         selected: selected.clone(),
-                        on_select: on_select.clone(),
+                        on_select: on_select,
                         depth: depth,
                     }
                 }
@@ -158,7 +158,7 @@ fn TocNode(
                     nodes: node.children.clone(),
                     tree: tree.clone(),
                     selected: selected.clone(),
-                    on_select: on_select.clone(),
+                    on_select: on_select,
                     depth: depth + 1,
                 }
             }

--- a/src/components/reaction_button.rs
+++ b/src/components/reaction_button.rs
@@ -32,7 +32,7 @@ pub fn ReactionButton(props: ReactionButtonProps) -> Element {
     let mut custom_emoji_failed = use_signal(|| false);
 
     // Reset custom emoji failed state when reaction changes
-    let user_reaction_for_effect = props.reaction.user_reaction.clone();
+    let user_reaction_for_effect = props.reaction.user_reaction;
     use_effect(use_reactive(&*user_reaction_for_effect.read(), move |_| {
         custom_emoji_failed.set(false);
     }));

--- a/src/components/reaction_defaults_modal.rs
+++ b/src/components/reaction_defaults_modal.rs
@@ -27,7 +27,7 @@ pub struct ReactionDefaultsModalProps {
 pub fn ReactionDefaultsModal(props: ReactionDefaultsModalProps) -> Element {
     // Local state (copy of global for editing)
     let mut local_reactions = use_signal(|| PREFERRED_REACTIONS.read().clone());
-    let mut new_emoji_input = use_signal(|| String::new());
+    let mut new_emoji_input = use_signal(String::new);
     let mut saving = use_signal(|| false);
     let mut error_msg = use_signal(|| None::<String>);
 

--- a/src/components/reaction_picker.rs
+++ b/src/components/reaction_picker.rs
@@ -83,7 +83,7 @@ pub fn InlineReactionPicker(props: InlineReactionPickerProps) -> Element {
             }
 
             // Settings button (if callback provided)
-            if let Some(on_settings) = props.on_settings.clone() {
+            if let Some(on_settings) = props.on_settings {
                 div {
                     class: "ml-1 pl-1 border-l border-gray-200 dark:border-gray-600",
                     button {

--- a/src/components/recipe_tag_selector.rs
+++ b/src/components/recipe_tag_selector.rs
@@ -16,7 +16,7 @@ pub fn RecipeTagSelector(
     #[props(default = 5)]
     max_tags: usize,
 ) -> Element {
-    let mut search_query = use_signal(|| String::new());
+    let mut search_query = use_signal(String::new);
     let mut show_suggestions = use_signal(|| false);
     let mut show_browse = use_signal(|| false);
 

--- a/src/components/reply_composer.rs
+++ b/src/components/reply_composer.rs
@@ -21,10 +21,10 @@ pub fn ReplyComposer(
     on_close: EventHandler<()>,
     on_success: EventHandler<()>,
 ) -> Element {
-    let mut content = use_signal(|| String::new());
+    let mut content = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut show_media_uploader = use_signal(|| false);
-    let mut uploaded_media = use_signal(|| Vec::<String>::new());
+    let mut uploaded_media = use_signal(Vec::<String>::new);
     let mut show_poll_modal = use_signal(|| false);
     let toast = consume_toast();
 
@@ -166,7 +166,7 @@ pub fn ReplyComposer(
     };
 
     let handle_publish = {
-        let toast_api = toast.clone();
+        let toast_api = toast;
         move |_| {
             let mut content_value = content.read().clone();
 
@@ -176,7 +176,7 @@ pub fn ReplyComposer(
                     content_value.push_str("\n\n");
                 }
                 for url in uploaded_media.read().iter() {
-                    content_value.push_str(&url);
+                    content_value.push_str(url);
                     content_value.push('\n');
                 }
             }
@@ -349,7 +349,7 @@ pub fn ReplyComposer(
                 }
                 Err(e) => {
                     log::error!("Failed to publish reply: {}", e);
-                    update_pending_status(&local_id_clone, CommentStatus::Failed(format!("{}", e)));
+                    update_pending_status(&local_id_clone, CommentStatus::Failed(e.to_string()));
                 }
             }
         });

--- a/src/components/report_modal.rs
+++ b/src/components/report_modal.rs
@@ -11,7 +11,7 @@ pub struct ReportModalProps {
 #[component]
 pub fn ReportModal(props: ReportModalProps) -> Element {
     let mut selected_type = use_signal(|| "spam".to_string());
-    let mut details = use_signal(|| String::new());
+    let mut details = use_signal(String::new);
     let mut loading = use_signal(|| false);
     let mut error_msg = use_signal(|| None::<String>);
     let mut success = use_signal(|| false);
@@ -19,7 +19,7 @@ pub fn ReportModal(props: ReportModalProps) -> Element {
     // Extract props fields before closures to avoid moving entire props struct
     let event_id = props.event_id.clone();
     let author_pubkey = props.author_pubkey.clone();
-    let on_close = props.on_close.clone();
+    let on_close = props.on_close;
 
     // Report types from NIP-56
     let report_types = vec![
@@ -35,7 +35,7 @@ pub fn ReportModal(props: ReportModalProps) -> Element {
     let handle_report = move |_| {
         let event_id = event_id.clone();
         let author_pubkey = author_pubkey.clone();
-        let on_close = on_close.clone();
+        let on_close = on_close;
         let report_type = selected_type.read().clone();
         let report_details = details.read().clone();
 

--- a/src/components/rich_content.rs
+++ b/src/components/rich_content.rs
@@ -1495,7 +1495,7 @@ fn WavlakeArtistRenderer(artist_id: String) -> Element {
                 class: "my-2 border border-border rounded-lg overflow-hidden hover:bg-accent/10 transition bg-card cursor-pointer",
                 onclick: {
                     let artist_id_nav = artist.id.clone();
-                    let navigator = nav.clone();
+                    let navigator = nav;
                     move |e: MouseEvent| {
                         e.stop_propagation();
                         // Navigate to artist page

--- a/src/components/search_input.rs
+++ b/src/components/search_input.rs
@@ -8,13 +8,13 @@ use crate::routes::Route;
 
 #[component]
 pub fn SearchInput() -> Element {
-    let mut query = use_signal(|| String::new());
+    let mut query = use_signal(String::new);
     let mut show_dropdown = use_signal(|| false);
-    let mut search_results = use_signal(|| Vec::<ProfileSearchResult>::new());
+    let mut search_results = use_signal(Vec::<ProfileSearchResult>::new);
     let mut selected_index = use_signal(|| 0usize);
     let mut is_searching = use_signal(|| false);
     let mut relay_search_task = use_signal(|| None::<Task>);
-    let mut contact_pubkeys = use_signal(|| Vec::<PublicKey>::new());
+    let mut contact_pubkeys = use_signal(Vec::<PublicKey>::new);
     let navigator = navigator();
 
     // Fetch contacts on mount

--- a/src/components/share_modal.rs
+++ b/src/components/share_modal.rs
@@ -25,8 +25,8 @@ pub fn ShareModal(
 ) -> Element {
     let mut share_mode = use_signal(|| ShareMode::Main);
     let mut copied = use_signal(|| false);
-    let mut nostr_text = use_signal(|| String::new());
-    let mut dm_recipient = use_signal(|| String::new());
+    let mut nostr_text = use_signal(String::new);
+    let mut dm_recipient = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut dm_error = use_signal(|| Option::<String>::None);
     let mut nostr_error = use_signal(|| Option::<String>::None);
@@ -86,12 +86,12 @@ pub fn ShareModal(
     };
 
     // Generate NIP-19 identifier with relay hints from author's write relays
-    let content_nip19 = use_signal(|| String::new());
+    let content_nip19 = use_signal(String::new);
 
     // Generate nevent/naddr (with gossip, relay hints are not needed)
     {
         let event_clone = event.clone();
-        let mut content_nip19_clone = content_nip19.clone();
+        let mut content_nip19_clone = content_nip19;
         use_effect(move || {
             let event_for_async = event_clone.clone();
             spawn(async move {

--- a/src/components/threaded_comment.rs
+++ b/src/components/threaded_comment.rs
@@ -253,10 +253,8 @@ pub fn ThreadedComment(node: ThreadNode, depth: usize) -> Element {
             let _ = audio.play().map_err(|e| {
                 log::debug!("Play failed: {:?}", e);
             });
-        } else {
-            if let Err(e) = audio.pause() {
-                log::debug!("Pause failed: {:?}", e);
-            }
+        } else if let Err(e) = audio.pause() {
+            log::debug!("Pause failed: {:?}", e);
         }
     });
 
@@ -328,7 +326,7 @@ pub fn ThreadedComment(node: ThreadNode, depth: usize) -> Element {
                 },
                 onclick: {
                     let event_id_click = event_id_nav.clone();
-                    let navigator = nav.clone();
+                    let navigator = nav;
                     let is_pending_node = is_pending;
                     let status = pending_status.clone();
                     move |_| {
@@ -676,10 +674,8 @@ pub fn ThreadedComment(node: ThreadNode, depth: usize) -> Element {
                                             if let Err(e) = bookmarks::unbookmark_event(event_id_clone).await {
                                                 log::error!("Failed to unbookmark: {}", e);
                                             }
-                                        } else {
-                                            if let Err(e) = bookmarks::bookmark_event(event_id_clone).await {
-                                                log::error!("Failed to bookmark: {}", e);
-                                            }
+                                        } else if let Err(e) = bookmarks::bookmark_event(event_id_clone).await {
+                                            log::error!("Failed to bookmark: {}", e);
                                         }
                                         is_bookmarking.set(false);
                                     });

--- a/src/components/token_list.rs
+++ b/src/components/token_list.rs
@@ -440,7 +440,7 @@ fn MintRow(mint_url: String, tokens_for_mint: Rc<Vec<TokenData>>, is_expanded: b
 #[component]
 pub fn TokenList() -> Element {
     let tokens = cashu::WALLET_TOKENS.read();
-    let mut expanded_mints = use_signal(|| std::collections::HashSet::<String>::new());
+    let mut expanded_mints = use_signal(std::collections::HashSet::<String>::new);
 
     // Check if there are any tokens OR any mints (mints without tokens should still be shown)
     let has_tokens = !tokens.data().read().is_empty();
@@ -478,7 +478,7 @@ pub fn TokenList() -> Element {
         for token in tokens_data.iter() {
             let normalized_url = normalize_mint_url(&token.mint);
             tokens_by_mint.entry(normalized_url)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(token.clone());
         }
 
@@ -487,7 +487,7 @@ pub fn TokenList() -> Element {
         let wallet_mints = cashu::get_mints();
         for mint_url in wallet_mints {
             let normalized_url = normalize_mint_url(&mint_url);
-            tokens_by_mint.entry(normalized_url).or_insert_with(Vec::new);
+            tokens_by_mint.entry(normalized_url).or_default();
         }
 
         // Sort mints by total balance (descending) and wrap in Rc

--- a/src/components/transaction_history.rs
+++ b/src/components/transaction_history.rs
@@ -130,7 +130,7 @@ fn format_timestamp(timestamp: u64) -> String {
 
     let datetime = Utc.timestamp_opt(timestamp as i64, 0)
         .single()
-        .unwrap_or_else(|| Utc::now());
+        .unwrap_or_else(Utc::now);
 
     let local_datetime: DateTime<Local> = datetime.into();
     let now = Local::now();
@@ -138,17 +138,17 @@ fn format_timestamp(timestamp: u64) -> String {
     let duration = now.signed_duration_since(local_datetime);
 
     if duration.num_seconds() < 60 {
-        return "Just now".to_string();
+        "Just now".to_string()
     } else if duration.num_minutes() < 60 {
         let mins = duration.num_minutes();
-        return format!("{}m ago", mins);
+        format!("{}m ago", mins)
     } else if duration.num_hours() < 24 {
         let hours = duration.num_hours();
-        return format!("{}h ago", hours);
+        format!("{}h ago", hours)
     } else if duration.num_days() < 7 {
         let days = duration.num_days();
-        return format!("{}d ago", days);
+        format!("{}d ago", days)
     } else {
-        return local_datetime.format("%b %d, %Y").to_string();
+        local_datetime.format("%b %d, %Y").to_string()
     }
 }

--- a/src/components/trending_notes.rs
+++ b/src/components/trending_notes.rs
@@ -6,7 +6,7 @@ use crate::utils::truncate_pubkey;
 
 #[component]
 pub fn TrendingNotes() -> Element {
-    let mut trending_notes = use_signal(|| Vec::<TrendingNote>::new());
+    let mut trending_notes = use_signal(Vec::<TrendingNote>::new);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| false);
 

--- a/src/components/virtual_list.rs
+++ b/src/components/virtual_list.rs
@@ -1,18 +1,18 @@
-/// Virtual scrolling component with dynamic height support (Phase 3.1)
-///
-/// Renders only visible items in large lists to maintain smooth performance.
-/// Handles 10,000+ items efficiently by rendering only what's in the viewport.
-///
-/// # Features
-/// - Dynamic height tracking for variable-sized items
-/// - Configurable overscan for smooth scrolling
-/// - Automatic height measurement via DOM
-/// - Memory-efficient: O(viewport_size) DOM nodes vs O(total_items)
-///
-/// # Performance Impact
-/// - Before: Rendering 1000 notes = 1000 DOM nodes (slow, memory intensive)
-/// - After: Rendering 1000 notes = ~20 DOM nodes (fast, constant memory)
-/// - Maintains 60fps even with 10,000+ items
+//! Virtual scrolling component with dynamic height support (Phase 3.1)
+//!
+//! Renders only visible items in large lists to maintain smooth performance.
+//! Handles 10,000+ items efficiently by rendering only what's in the viewport.
+//!
+//! # Features
+//! - Dynamic height tracking for variable-sized items
+//! - Configurable overscan for smooth scrolling
+//! - Automatic height measurement via DOM
+//! - Memory-efficient: O(viewport_size) DOM nodes vs O(total_items)
+//!
+//! # Performance Impact
+//! - Before: Rendering 1000 notes = 1000 DOM nodes (slow, memory intensive)
+//! - After: Rendering 1000 notes = ~20 DOM nodes (fast, constant memory)
+//! - Maintains 60fps even with 10,000+ items
 
 use dioxus::prelude::*;
 use std::collections::HashMap;
@@ -342,7 +342,7 @@ pub fn VirtualList<T: PartialEq + 'static>(props: VirtualListProps<T>) -> Elemen
 
                     LAST_SCROLL_UPDATE.store(now, Ordering::Relaxed);
 
-                    let mut state = virtual_state.clone();
+                    let mut state = virtual_state;
                     // Note: Element storage not available on non-WASM
                     state.write().scroll_top = 0.0; // Fallback for non-WASM
                     log::trace!("Updated scroll_top (non-WASM fallback)");
@@ -364,7 +364,7 @@ pub fn VirtualList<T: PartialEq + 'static>(props: VirtualListProps<T>) -> Elemen
                         let item_index = *index;
                         let item_rc = item.clone();
                         #[allow(unused_variables)]
-                        let state = virtual_state.clone();
+                        let state = virtual_state;
                         rsx! {
                             div {
                                 key: "{index}",

--- a/src/components/voice_message_card.rs
+++ b/src/components/voice_message_card.rs
@@ -262,10 +262,8 @@ pub fn VoiceMessageCard(event: NostrEvent) -> Element {
             let _ = audio.play().map_err(|e| {
                 log::debug!("Play failed: {:?}", e);
             });
-        } else {
-            if let Err(e) = audio.pause() {
-                log::debug!("Pause failed: {:?}", e);
-            }
+        } else if let Err(e) = audio.pause() {
+            log::debug!("Pause failed: {:?}", e);
         }
     });
 

--- a/src/components/voice_recorder.rs
+++ b/src/components/voice_recorder.rs
@@ -81,9 +81,9 @@ pub fn VoiceRecorder(
                                 // Monitor duration and auto-stop at 60 seconds
                                 // Clone signals and recorder_id for the monitoring loop
                                 let monitor_recorder_id = recorder_id.clone();
-                                let mut monitor_current_time = current_time.clone();
-                                let monitor_state = state.clone();
-                                let monitor_is_mounted = is_mounted.clone();
+                                let mut monitor_current_time = current_time;
+                                let monitor_state = state;
+                                let monitor_is_mounted = is_mounted;
 
                                 spawn(async move {
                                     let started_at = js_sys::Date::now() / 1000.0;
@@ -104,7 +104,7 @@ pub fn VoiceRecorder(
                                             monitor_current_time.set(elapsed);
 
                                             // Log every second
-                                            if (elapsed * 10.0) as u32 % 10 == 0 {
+                                            if ((elapsed * 10.0) as u32).is_multiple_of(10) {
                                                 log::debug!("Recording time: {:.1}s", elapsed);
                                             }
 
@@ -380,10 +380,9 @@ pub fn VoiceRecorder(
 
                                         // Extract waveform
                                         let waveform = if let Ok(wf_val) = Reflect::get(&result, &JsValue::from_str("waveform")) {
-                                            let arr = js_sys::Array::from(&wf_val).to_vec().into_iter()
+                                            js_sys::Array::from(&wf_val).to_vec().into_iter()
                                                 .map(|v| v.as_f64().unwrap_or(0.0) as u8)
-                                                .collect::<Vec<_>>();
-                                            arr
+                                                .collect::<Vec<_>>()
                                         } else {
                                             log::warn!("Failed to extract waveform, using placeholder");
                                             vec![0u8; 100]
@@ -517,7 +516,7 @@ pub fn VoiceRecorder(
                         }
                     },
                     RecorderState::Stopped { .. } => {
-                        let audio_src = blob_url.as_ref().map(|s| s.as_str()).unwrap_or("");
+                        let audio_src = blob_url.as_deref().unwrap_or("");
                         rsx! {
                             // Always render audio element, even if blob URL is not ready yet
                             audio {

--- a/src/components/webbookmark_card.rs
+++ b/src/components/webbookmark_card.rs
@@ -49,7 +49,7 @@ pub fn WebBookmarkCard(event: NostrEvent, on_edit: Option<EventHandler<NostrEven
     // Handle delete
     let handle_delete = {
         let event_clone = event.clone();
-        let mut deleting = deleting.clone();
+        let mut deleting = deleting;
         move |_| {
             let event_for_delete = event_clone.clone();
             deleting.set(true);
@@ -71,7 +71,7 @@ pub fn WebBookmarkCard(event: NostrEvent, on_edit: Option<EventHandler<NostrEven
     // Handle toggle favorite
     let handle_toggle_favorite = {
         let event_clone = event.clone();
-        let mut toggling_favorite = toggling_favorite.clone();
+        let mut toggling_favorite = toggling_favorite;
         move |_| {
             let event_for_toggle = event_clone.clone();
             let current_fav = is_fav;
@@ -95,7 +95,7 @@ pub fn WebBookmarkCard(event: NostrEvent, on_edit: Option<EventHandler<NostrEven
     // Handle edit
     let handle_edit = {
         let event_clone = event.clone();
-        let mut show_actions_edit = show_actions.clone();
+        let mut show_actions_edit = show_actions;
         move |_| {
             if let Some(ref handler) = on_edit {
                 handler.call(event_clone.clone());
@@ -343,7 +343,7 @@ pub fn WebBookmarkCardSkeleton() -> Element {
 /// Format timestamp to relative time
 fn format_timestamp(timestamp: u64) -> String {
     let dt = DateTime::from_timestamp(timestamp as i64, 0)
-        .unwrap_or_else(|| Utc::now());
+        .unwrap_or_else(Utc::now);
     let local_dt = dt.with_timezone(&Local);
     let now = Local::now();
     let duration = now.signed_duration_since(local_dt);

--- a/src/components/webbookmark_modal.rs
+++ b/src/components/webbookmark_modal.rs
@@ -21,15 +21,15 @@ pub fn WebBookmarkModal(
     on_close: EventHandler<()>,
 ) -> Element {
     // Form state
-    let mut url_input = use_signal(|| String::new());
-    let mut title_input = use_signal(|| String::new());
-    let mut description_input = use_signal(|| String::new());
-    let mut image_input = use_signal(|| String::new());
-    let mut tags_input = use_signal(|| String::new());
-    let mut published_at_input = use_signal(|| String::new());
+    let mut url_input = use_signal(String::new);
+    let mut title_input = use_signal(String::new);
+    let mut description_input = use_signal(String::new);
+    let mut image_input = use_signal(String::new);
+    let mut tags_input = use_signal(String::new);
+    let mut published_at_input = use_signal(String::new);
 
     // Track reserved tags (favorite, archived) to preserve them on save
-    let mut reserved_tags = use_signal(|| Vec::<String>::new());
+    let mut reserved_tags = use_signal(Vec::<String>::new);
 
     // UI state
     let mut is_fetching_metadata = use_signal(|| false);

--- a/src/components/wiki_backlinks.rs
+++ b/src/components/wiki_backlinks.rs
@@ -144,7 +144,7 @@ pub fn WikiBacklinksCompact(
     class: String,
 ) -> Element {
     let mut loading = use_signal(|| true);
-    let mut pages = use_signal(|| Vec::<CachedWikiPage>::new());
+    let mut pages = use_signal(Vec::<CachedWikiPage>::new);
     let mut total = use_signal(|| 0usize);
 
     use_effect(move || {

--- a/src/components/zap_modal.rs
+++ b/src/components/zap_modal.rs
@@ -65,8 +65,8 @@ pub struct ZapModalProps {
 #[component]
 pub fn ZapModal(props: ZapModalProps) -> Element {
     let mut zap_amount = use_signal(|| 21u64);
-    let mut custom_amount = use_signal(|| String::new());
-    let mut zap_message = use_signal(|| String::new());
+    let mut custom_amount = use_signal(String::new);
+    let mut zap_message = use_signal(String::new);
     let mut loading = use_signal(|| false);
     let mut error_msg = use_signal(|| None::<String>);
     let mut invoice = use_signal(|| None::<String>);
@@ -84,7 +84,7 @@ pub fn ZapModal(props: ZapModalProps) -> Element {
         let amount = *zap_amount.read();
         let message = zap_message.read().clone();
         let event_id_str = props.event_id.clone();
-        let toast_api = toast.clone();
+        let toast_api = toast;
 
         loading.set(true);
         error_msg.set(None);
@@ -131,8 +131,7 @@ pub fn ZapModal(props: ZapModalProps) -> Element {
                 client
                     .relays()
                     .await
-                    .into_iter()
-                    .map(|(url, _)| url)
+                    .into_keys()
                     .take(5)
                     .collect::<Vec<RelayUrl>>()
             } else {

--- a/src/context/app_context.rs
+++ b/src/context/app_context.rs
@@ -1,10 +1,10 @@
-/// Application Context
-///
-/// Provides centralized access to stores and services, reducing prop drilling
-/// and making component dependencies explicit.
-///
-/// Based on Phase 3.2 of performance.md - adopting Notedeck's context pattern
-/// to eliminate prop drilling and create cleaner component interfaces.
+//! Application Context
+//!
+//! Provides centralized access to stores and services, reducing prop drilling
+//! and making component dependencies explicit.
+//!
+//! Based on Phase 3.2 of performance.md - adopting Notedeck's context pattern
+//! to eliminate prop drilling and create cleaner component interfaces.
 
 use dioxus::signals::ReadableExt;
 use nostr_sdk::Client;

--- a/src/hooks/use_lists.rs
+++ b/src/hooks/use_lists.rs
@@ -60,7 +60,7 @@ impl UserList {
 /// Hook to fetch all user lists (NIP-51)
 /// Returns (lists, loading, error, refresh)
 pub fn use_user_lists() -> (Signal<Vec<UserList>>, Signal<bool>, Signal<Option<String>>, Signal<u32>) {
-    let mut lists = use_signal(|| Vec::<UserList>::new());
+    let mut lists = use_signal(Vec::<UserList>::new);
     let mut loading = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
     let refresh_trigger = use_signal(|| 0u32);

--- a/src/routes/article_detail.rs
+++ b/src/routes/article_detail.rs
@@ -18,7 +18,7 @@ pub fn ArticleDetail(naddr: String) -> Element {
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
     let mut author_metadata = use_signal(|| None::<nostr_sdk::Metadata>);
-    let mut comments = use_signal(|| Vec::<NostrEvent>::new());
+    let mut comments = use_signal(Vec::<NostrEvent>::new);
     let mut loading_comments = use_signal(|| false);
     let mut show_comment_composer = use_signal(|| false);
     let mut show_share_modal = use_signal(|| false);
@@ -596,7 +596,7 @@ fn format_timestamp(timestamp: u64) -> String {
     use chrono::{DateTime, Utc};
 
     let dt = DateTime::from_timestamp(timestamp as i64, 0)
-        .unwrap_or_else(|| Utc::now());
+        .unwrap_or_else(Utc::now);
 
     dt.format("%B %d, %Y").to_string()
 }

--- a/src/routes/article_new.rs
+++ b/src/routes/article_new.rs
@@ -5,12 +5,12 @@ use crate::components::MarkdownEditor;
 #[component]
 pub fn ArticleNew() -> Element {
     let navigator = navigator();
-    let mut title = use_signal(|| String::new());
-    let mut summary = use_signal(|| String::new());
-    let content = use_signal(|| String::new());
-    let mut identifier = use_signal(|| String::new());
-    let mut cover_image = use_signal(|| String::new());
-    let mut hashtags = use_signal(|| String::new());
+    let mut title = use_signal(String::new);
+    let mut summary = use_signal(String::new);
+    let content = use_signal(String::new);
+    let mut identifier = use_signal(String::new);
+    let mut cover_image = use_signal(String::new);
+    let mut hashtags = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut error_message = use_signal(|| Option::<String>::None);
 
@@ -22,7 +22,7 @@ pub fn ArticleNew() -> Element {
     let content_chars = content.read().chars().count();
     let can_publish = title_chars > 0
         && content_chars > 0
-        && identifier.read().len() > 0
+        && !identifier.read().is_empty()
         && !*is_publishing.read();
 
     // Handle close

--- a/src/routes/articles.rs
+++ b/src/routes/articles.rs
@@ -25,7 +25,7 @@ impl FeedType {
 #[component]
 pub fn Articles() -> Element {
     // State for feed events
-    let mut articles = use_signal(|| Vec::<Event>::new());
+    let mut articles = use_signal(Vec::<Event>::new);
     let mut loading = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
     let mut refresh_trigger = use_signal(|| 0);

--- a/src/routes/badge_new.rs
+++ b/src/routes/badge_new.rs
@@ -16,11 +16,11 @@ pub fn BadgeNew() -> Element {
     let navigator = use_navigator();
 
     // Form state
-    let mut badge_id = use_signal(|| String::new());
-    let mut name = use_signal(|| String::new());
-    let mut description = use_signal(|| String::new());
-    let mut image_url = use_signal(|| String::new());
-    let mut thumb_url = use_signal(|| String::new());
+    let mut badge_id = use_signal(String::new);
+    let mut name = use_signal(String::new);
+    let mut description = use_signal(String::new);
+    let mut image_url = use_signal(String::new);
+    let mut thumb_url = use_signal(String::new);
 
     // Auto-generate badge ID from name
     let mut auto_id = use_signal(|| true);

--- a/src/routes/badges.rs
+++ b/src/routes/badges.rs
@@ -34,13 +34,13 @@ impl BadgesTab {
 #[component]
 pub fn BadgesHome() -> Element {
     let mut active_tab = use_signal(|| BadgesTab::MyBadges);
-    let mut search_query = use_signal(|| String::new());
+    let mut search_query = use_signal(String::new);
 
     // Data state
-    let mut my_badges = use_signal(|| Vec::<BadgeDefinition>::new());
-    let mut pending_awards = use_signal(|| Vec::<(BadgeAward, Option<BadgeDefinition>)>::new());
-    let mut all_badges = use_signal(|| Vec::<BadgeDefinition>::new());
-    let mut created_badges = use_signal(|| Vec::<BadgeDefinition>::new());
+    let mut my_badges = use_signal(Vec::<BadgeDefinition>::new);
+    let mut pending_awards = use_signal(Vec::<(BadgeAward, Option<BadgeDefinition>)>::new);
+    let mut all_badges = use_signal(Vec::<BadgeDefinition>::new);
+    let mut created_badges = use_signal(Vec::<BadgeDefinition>::new);
 
     // Loading state
     let mut loading = use_signal(|| true);
@@ -405,7 +405,7 @@ fn BadgeCard(badge: BadgeDefinition) -> Element {
 
     rsx! {
         Link {
-            to: Route::BadgeDetail { naddr: naddr },
+            to: Route::BadgeDetail { naddr },
             class: "group block bg-card border border-border rounded-xl overflow-hidden hover:border-primary/50 transition",
 
             // Image

--- a/src/routes/bookmarks.rs
+++ b/src/routes/bookmarks.rs
@@ -7,7 +7,7 @@ use nostr_sdk::Event as NostrEvent;
 #[component]
 pub fn Bookmarks() -> Element {
     let auth = auth_store::AUTH_STATE.read();
-    let mut bookmarked_events = use_signal(|| Vec::<NostrEvent>::new());
+    let mut bookmarked_events = use_signal(Vec::<NostrEvent>::new);
     let mut loading = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
 

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -71,7 +71,7 @@ pub fn Calendar() -> Element {
     // Compute event dates for mini calendar highlights (using filtered events)
     let filtered_event_dates = use_memo(move || {
         filtered_events.read().iter()
-            .map(|e| get_event_date(e))
+            .map(get_event_date)
             .collect::<HashSet<String>>()
     });
 
@@ -304,7 +304,7 @@ pub fn Calendar() -> Element {
                                     button {
                                         class: "hidden sm:flex items-center gap-2 px-3 py-1.5 text-sm font-medium border border-border rounded-lg hover:bg-accent transition",
                                         onclick: {
-                                            let filtered_events = filtered_events.clone();
+                                            let filtered_events = filtered_events;
                                             move |_| {
                                                 // Extract CalendarEvent items from filtered events
                                                 let calendar_events: Vec<CalendarEvent> = filtered_events.read()
@@ -347,7 +347,7 @@ pub fn Calendar() -> Element {
                                     button {
                                         class: "sm:hidden p-2 border border-border rounded-lg hover:bg-accent transition",
                                         onclick: {
-                                            let filtered_events = filtered_events.clone();
+                                            let filtered_events = filtered_events;
                                             move |_| {
                                                 let calendar_events: Vec<CalendarEvent> = filtered_events.read()
                                                     .iter()

--- a/src/routes/calendar_event_new.rs
+++ b/src/routes/calendar_event_new.rs
@@ -23,15 +23,15 @@ pub fn CalendarEventNew() -> Element {
     let mut summary = use_signal(String::new);
     let mut content = use_signal(String::new);
     let mut event_type = use_signal(|| EventType::TimeBased);
-    let mut start_date = use_signal(|| get_today());
+    let mut start_date = use_signal(get_today);
     let mut start_time = use_signal(|| "09:00".to_string());
-    let mut end_date = use_signal(|| get_today());
+    let mut end_date = use_signal(get_today);
     let mut end_time = use_signal(|| "10:00".to_string());
     let mut location = use_signal(String::new);
     let mut locations = use_signal(Vec::<String>::new);
     let mut image_url = use_signal(String::new);
     let mut hashtags_input = use_signal(String::new);
-    let mut timezone = use_signal(|| get_local_timezone());
+    let mut timezone = use_signal(get_local_timezone);
     let mut is_private = use_signal(|| false);
 
     // Publishing state
@@ -74,7 +74,7 @@ pub fn CalendarEventNew() -> Element {
 
     // Handle publish
     let handle_publish = {
-        let navigator = navigator.clone();
+        let navigator = navigator;
         move |_| {
             if !*can_publish.read() {
                 return;
@@ -98,7 +98,7 @@ pub fn CalendarEventNew() -> Element {
             is_publishing.set(true);
             error_message.set(None);
 
-            let nav = navigator.clone();
+            let nav = navigator;
             spawn(async move {
                 // Combine locations
                 let mut all_locations = locations_val;
@@ -108,7 +108,7 @@ pub fn CalendarEventNew() -> Element {
 
                 // Parse hashtags
                 let hashtags: Vec<String> = hashtags_val
-                    .split(|c: char| c == ',' || c == ' ' || c == '#')
+                    .split([',', ' ', '#'])
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty())
                     .collect();
@@ -513,7 +513,7 @@ fn parse_datetime_to_timestamp(date: &str, time: &str) -> u64 {
     let day: i32 = parts[2].parse().unwrap_or(1);
 
     let time_parts: Vec<&str> = time.split(':').collect();
-    let hours: u32 = time_parts.get(0).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let hours: u32 = time_parts.first().and_then(|s| s.parse().ok()).unwrap_or(0);
     let minutes: u32 = time_parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
 
     let js_date = js_sys::Date::new_with_year_month_day(year as u32, month, day);

--- a/src/routes/cashu_wallet.rs
+++ b/src/routes/cashu_wallet.rs
@@ -60,8 +60,8 @@ pub fn CashuWallet() -> Element {
         }
 
         // Terms already checked - if accepted, init wallet
-        if terms == Some(true) {
-            if matches!(*cashu::WALLET_STATUS.read(), cashu::WalletStatus::Uninitialized) {
+        if terms == Some(true)
+            && matches!(*cashu::WALLET_STATUS.read(), cashu::WalletStatus::Uninitialized) {
                 // Mark init as started to prevent duplicate spawns
                 init_started.set(true);
                 spawn(async move {
@@ -70,7 +70,6 @@ pub fn CashuWallet() -> Element {
                     }
                 });
             }
-        }
     });
 
     // Check if we should show setup wizard

--- a/src/routes/citations.rs
+++ b/src/routes/citations.rs
@@ -71,8 +71,8 @@ impl CitationsTab {
 #[component]
 pub fn CitationsHome() -> Element {
     let mut active_tab = use_signal(|| CitationsTab::All);
-    let mut search_query = use_signal(|| String::new());
-    let mut search_results = use_signal(|| Vec::<CachedCitation>::new());
+    let mut search_query = use_signal(String::new);
+    let mut search_results = use_signal(Vec::<CachedCitation>::new);
     let mut is_searching = use_signal(|| false);
 
     // Loading state

--- a/src/routes/code.rs
+++ b/src/routes/code.rs
@@ -22,7 +22,7 @@ use crate::utils::nip34::{Repository, DisplaySnippet};
 #[component]
 pub fn CodeHome() -> Element {
     let mut active_tab = use_signal(|| CodeTab::Repositories);
-    let mut search_query = use_signal(|| String::new());
+    let mut search_query = use_signal(String::new);
 
     rsx! {
         div {

--- a/src/routes/code_import.rs
+++ b/src/routes/code_import.rs
@@ -86,7 +86,7 @@ pub fn CodeImport() -> Element {
     };
 
     let handle_publish = {
-        let _nav = nav.clone();
+        let _nav = nav;
         move |_| {
             let repo = match github_repo.read().clone() {
                 Some(r) => r,

--- a/src/routes/code_repo_settings.rs
+++ b/src/routes/code_repo_settings.rs
@@ -393,7 +393,7 @@ pub fn CodeRepoSettings(naddr: String) -> Element {
                     repo_name: repo_name.read().clone(),
                     on_cancel: move |_| show_delete_confirm.set(false),
                     on_confirm: {
-                        let nav = nav.clone();
+                        let nav = nav;
                         move |_| {
                             // Navigate back to repositories since delete isn't implemented
                             let _ = nav.push(Route::CodeRepositories {});

--- a/src/routes/code_snippets.rs
+++ b/src/routes/code_snippets.rs
@@ -18,7 +18,7 @@ const POPULAR_LANGUAGES: &[&str] = &[
 #[component]
 pub fn CodeSnippets() -> Element {
     let mut language_filter = use_signal(|| None::<String>);
-    let mut search_query = use_signal(|| String::new());
+    let mut search_query = use_signal(String::new);
 
     // Snippets state
     let mut snippets_result = use_signal(|| None::<Result<Vec<DisplaySnippet>, String>>);
@@ -188,8 +188,8 @@ pub fn CodeSnippets() -> Element {
                                     true
                                 } else {
                                     s.code.to_lowercase().contains(&search)
-                                        || s.name.as_ref().map_or(false, |n| n.to_lowercase().contains(&search))
-                                        || s.description.as_ref().map_or(false, |d| d.to_lowercase().contains(&search))
+                                        || s.name.as_ref().is_some_and(|n| n.to_lowercase().contains(&search))
+                                        || s.description.as_ref().is_some_and(|d| d.to_lowercase().contains(&search))
                                 }
                             })
                             .collect();

--- a/src/routes/communities.rs
+++ b/src/routes/communities.rs
@@ -19,16 +19,16 @@ use std::collections::HashSet;
 #[component]
 pub fn Communities() -> Element {
     // Main communities list
-    let mut communities = use_signal(|| Vec::<Community>::new());
+    let mut communities = use_signal(Vec::<Community>::new);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
 
     // User's communities with membership info (sorted by role)
-    let mut user_communities_with_membership = use_signal(|| Vec::<CommunityWithMembership>::new());
+    let mut user_communities_with_membership = use_signal(Vec::<CommunityWithMembership>::new);
     let mut user_communities_loading = use_signal(|| false);
 
     // Pinned communities
-    let mut pinned_communities = use_signal(|| Vec::<CommunityWithMembership>::new());
+    let mut pinned_communities = use_signal(Vec::<CommunityWithMembership>::new);
     let mut pinned_loading = use_signal(|| false);
 
     // Search state

--- a/src/routes/community.rs
+++ b/src/routes/community.rs
@@ -29,9 +29,9 @@ enum CommunityTab {
 #[component]
 pub fn CommunityPage(a_tag: String) -> Element {
     let mut community = use_signal(|| None::<Community>);
-    let mut posts = use_signal(|| Vec::<CommunityPost>::new());
-    let mut thread_tree = use_signal(|| Vec::<CommunityThread>::new());
-    let mut pending_posts = use_signal(|| Vec::<CommunityPost>::new());
+    let mut posts = use_signal(Vec::<CommunityPost>::new);
+    let mut thread_tree = use_signal(Vec::<CommunityThread>::new);
+    let mut pending_posts = use_signal(Vec::<CommunityPost>::new);
     let mut loading_community = use_signal(|| true);
     let mut loading_posts = use_signal(|| true);
     let mut loading_pending = use_signal(|| false);
@@ -41,7 +41,7 @@ pub fn CommunityPage(a_tag: String) -> Element {
     let mut refresh_trigger = use_signal(|| 0u32);
 
     // Interaction counts for posts
-    let mut interaction_counts = use_signal(|| HashMap::<String, InteractionCounts>::new());
+    let mut interaction_counts = use_signal(HashMap::<String, InteractionCounts>::new);
 
     // Pagination state
     let mut oldest_timestamp = use_signal(|| None::<u64>);

--- a/src/routes/community_new.rs
+++ b/src/routes/community_new.rs
@@ -15,7 +15,7 @@ pub fn CommunityNew() -> Element {
     let mut image_url = use_signal(String::new);
     let mut rules = use_signal(String::new);
     let mut moderator_input = use_signal(String::new);
-    let mut moderators = use_signal(|| Vec::<String>::new());
+    let mut moderators = use_signal(Vec::<String>::new);
     let mut creating = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
 

--- a/src/routes/dms.rs
+++ b/src/routes/dms.rs
@@ -62,7 +62,7 @@ pub fn DMs() -> Element {
     let mut error = use_signal(|| None::<String>);
     let mut selected_conversation = use_signal(|| None::<String>);
     let mut new_dm_mode = use_signal(|| false);
-    let _new_recipient = use_signal(|| String::new());
+    let _new_recipient = use_signal(String::new);
     let mut active_tab = use_signal(|| DmTab::DirectMessages);
     let mut selected_mls_group = use_signal(|| None::<String>);
     let mut new_mls_group_mode = use_signal(|| false);
@@ -161,7 +161,7 @@ pub fn DMs() -> Element {
 
     // Manual refresh function
     let refresh_dms = move |_| {
-        if refreshing.read().clone() {
+        if *refreshing.read() {
             return;
         }
 
@@ -556,7 +556,7 @@ fn MlsGroupsList(
                     class: "divide-y divide-border",
                     for group in groups {
                         {
-                            let group_id = hex::encode(&group.nostr_group_id);
+                            let group_id = hex::encode(group.nostr_group_id);
                             let group_id_clone = group_id.clone();
                             let is_selected = selected_group.as_ref() == Some(&group_id);
 
@@ -624,10 +624,10 @@ fn NewMlsGroupComposer(
     on_cancel: EventHandler<()>,
     on_created: EventHandler<String>
 ) -> Element {
-    let mut group_name = use_signal(|| String::new());
-    let mut group_description = use_signal(|| String::new());
-    let mut member_input = use_signal(|| String::new());
-    let mut members = use_signal(|| Vec::<String>::new());
+    let mut group_name = use_signal(String::new);
+    let mut group_description = use_signal(String::new);
+    let mut member_input = use_signal(String::new);
+    let mut members = use_signal(Vec::<String>::new);
     let mut creating = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
 
@@ -692,7 +692,7 @@ fn NewMlsGroupComposer(
 
             match mdk_store::create_mls_group(name, description, member_list, relays).await {
                 Ok(group) => {
-                    let group_id = hex::encode(&group.nostr_group_id);
+                    let group_id = hex::encode(group.nostr_group_id);
                     log::info!("Created MLS group: {}", group_id);
                     on_created.call(group_id);
                 }
@@ -870,7 +870,7 @@ fn NewMlsGroupComposer(
 /// MLS group view component
 #[component]
 fn MlsGroupView(group_id: String) -> Element {
-    let mut message_input = use_signal(|| String::new());
+    let mut message_input = use_signal(String::new);
     let mut sending = use_signal(|| false);
     let mut loading = use_signal(|| true);
     let messages_container_id = use_signal(|| format!("mls-messages-{}", uuid::Uuid::new_v4()));
@@ -1280,9 +1280,9 @@ fn ConversationListItem(
 
 #[component]
 fn ConversationView(pubkey: String) -> Element {
-    let mut message_input = use_signal(|| String::new());
+    let mut message_input = use_signal(String::new);
     let mut sending = use_signal(|| false);
-    let mut decrypted_messages = use_signal(|| Vec::<(ConversationMessage, String)>::new());
+    let mut decrypted_messages = use_signal(Vec::<(ConversationMessage, String)>::new);
     let mut decrypt_loading = use_signal(|| true);
     let mut profile = use_signal(|| None::<profiles::Profile>);
     let messages_container_id = use_signal(|| format!("messages-{}", uuid::Uuid::new_v4()));
@@ -1482,7 +1482,7 @@ fn ConversationView(pubkey: String) -> Element {
                         }
                     }
                     Link {
-                        to: Route::Profile { pubkey: pubkey },
+                        to: Route::Profile { pubkey },
                         class: "text-xs text-blue-500 hover:underline",
                         "View profile"
                     }
@@ -1691,8 +1691,8 @@ fn NewDMComposer(
     on_cancel: EventHandler<()>,
     on_send: EventHandler<String>
 ) -> Element {
-    let mut recipient_input = use_signal(|| String::new());
-    let mut message_input = use_signal(|| String::new());
+    let mut recipient_input = use_signal(String::new);
+    let mut message_input = use_signal(String::new);
     let mut sending = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
 

--- a/src/routes/dvm.rs
+++ b/src/routes/dvm.rs
@@ -19,14 +19,14 @@ pub fn DVM() -> Element {
     let mut refresh_trigger = use_signal(|| 0);
 
     // Interaction counts cache (event_id -> counts) for batch optimization
-    let mut interaction_counts = use_signal(|| HashMap::<String, InteractionCounts>::new());
+    let mut interaction_counts = use_signal(HashMap::<String, InteractionCounts>::new);
     let mut interactions_loaded = use_signal(|| false);
     let mut fetch_in_progress = use_signal(|| false);
 
     let feed_loading = *DVM_FEED_LOADING.read();
     let feed_error = DVM_FEED_ERROR.read().clone();
     let feed_events = DVM_FEED_EVENTS.read().clone();
-    let selected_provider = SELECTED_DVM_PROVIDER.read().clone();
+    let selected_provider = *SELECTED_DVM_PROVIDER.read();
 
     // Load DVMs and feed on mount and when client initializes
     use_effect(move || {

--- a/src/routes/explore.rs
+++ b/src/routes/explore.rs
@@ -19,13 +19,13 @@ pub fn Explore() -> Element {
     let mut refresh_trigger = use_signal(|| 0);
 
     // Interaction counts cache (event_id -> counts) for batch optimization
-    let mut interaction_counts = use_signal(|| HashMap::<String, InteractionCounts>::new());
+    let mut interaction_counts = use_signal(HashMap::<String, InteractionCounts>::new);
     let mut interactions_loaded = use_signal(|| false);
 
     let feed_loading = *DVM_FEED_LOADING.read();
     let feed_error = DVM_FEED_ERROR.read().clone();
     let feed_events = DVM_FEED_EVENTS.read().clone();
-    let selected_provider = SELECTED_DVM_PROVIDER.read().clone();
+    let selected_provider = *SELECTED_DVM_PROVIDER.read();
 
     // Load DVMs and feed on mount and when client initializes
     use_effect(move || {

--- a/src/routes/hashtag.rs
+++ b/src/routes/hashtag.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 #[component]
 pub fn Hashtag(tag: String) -> Element {
     // State for feed events
-    let mut events = use_signal(|| Vec::<Event>::new());
+    let mut events = use_signal(Vec::<Event>::new);
     let mut loading = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
     let mut refresh_trigger = use_signal(|| 0);

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -40,7 +40,7 @@ pub fn Home() -> Element {
     let mut pagination_loading = use_signal(|| false);
 
     // Interaction counts cache (event_id -> counts) for batch optimization
-    let mut interaction_counts = use_signal(|| HashMap::<String, InteractionCounts>::new());
+    let mut interaction_counts = use_signal(HashMap::<String, InteractionCounts>::new);
 
     // Track if this is the first interaction count load (for negentropy optimization)
     // First load: full fetch (no local data to reconcile)
@@ -48,7 +48,7 @@ pub fn Home() -> Element {
     let mut interactions_loaded = use_signal(|| false);
 
     // Buffer for real-time events (Twitter/X pattern: "Show N new posts")
-    let mut pending_posts = use_signal(|| Vec::<FeedItem>::new());
+    let mut pending_posts = use_signal(Vec::<FeedItem>::new);
 
     // Derive pending count from pending_posts to avoid race conditions
     let pending_count = use_memo(move || pending_posts.read().len());
@@ -57,7 +57,7 @@ pub fn Home() -> Element {
     let mut realtime_started = use_signal(|| false);
 
     // Track active subscription IDs for cleanup
-    let mut subscription_ids = use_signal(|| Vec::<nostr_sdk::SubscriptionId>::new());
+    let mut subscription_ids = use_signal(Vec::<nostr_sdk::SubscriptionId>::new);
 
     // Load feed on mount and when refresh is triggered or feed type changes
     use_effect(move || {
@@ -340,7 +340,7 @@ pub fn Home() -> Element {
             const BATCH_DELAY_MS: u64 = 100; // 100ms delay between batches
 
             let total_authors = authors.len();
-            let num_batches = (total_authors + BATCH_SIZE - 1) / BATCH_SIZE;
+            let num_batches = total_authors.div_ceil(BATCH_SIZE);
 
             log::info!("Starting batched real-time subscription for {} followed users in {} batches using gossip",
                 contacts.len(), num_batches);
@@ -1032,9 +1032,9 @@ fn LoginSection() -> Element {
     use nostr::ToBech32;
 
     // State management
-    let mut nsec_input = use_signal(|| String::new());
-    let mut npub_input = use_signal(|| String::new());
-    let mut bunker_uri_input = use_signal(|| String::new());
+    let mut nsec_input = use_signal(String::new);
+    let mut npub_input = use_signal(String::new);
+    let mut bunker_uri_input = use_signal(String::new);
     let mut error = use_signal(|| None::<String>);
     let mut show_advanced = use_signal(|| false);
     let mut show_help_modal = use_signal(|| false);
@@ -1469,7 +1469,7 @@ async fn append_paginated_items(
             });
 
             // Fetch interaction counts for new items and merge with existing
-            let mut counts_signal = interaction_counts.clone();
+            let mut counts_signal = *interaction_counts;
             spawn(async move {
                 let event_ids: Vec<_> = items_for_counts.iter().map(|item| item.event().id).collect();
                 if let Ok(new_counts) = fetch_interaction_counts_batch(event_ids, Duration::from_secs(5)).await {

--- a/src/routes/live_stream_detail.rs
+++ b/src/routes/live_stream_detail.rs
@@ -321,8 +321,7 @@ pub fn LiveStreamDetail(note_id: String) -> Element {
                                                 {
                                                     // Get host-aware identifier (use p tag host if available, otherwise event publisher)
                                                     let event_pubkey = event.pubkey.to_string();
-                                                    let author_identifier = meta.host_pubkey.as_ref()
-                                                        .map(|s| s.as_str())
+                                                    let author_identifier = meta.host_pubkey.as_deref()
                                                         .unwrap_or(&event_pubkey);
 
                                                     let host_verified = meta.host_verified;

--- a/src/routes/live_stream_new.rs
+++ b/src/routes/live_stream_new.rs
@@ -8,11 +8,11 @@ use url::Url;
 #[component]
 pub fn LiveStreamNew() -> Element {
     let navigator = navigator();
-    let mut title = use_signal(|| String::new());
-    let mut summary = use_signal(|| String::new());
-    let mut image_url = use_signal(|| String::new());
-    let mut stream_url = use_signal(|| String::new());
-    let mut hashtags = use_signal(|| String::new());
+    let mut title = use_signal(String::new);
+    let mut summary = use_signal(String::new);
+    let mut image_url = use_signal(String::new);
+    let mut stream_url = use_signal(String::new);
+    let mut hashtags = use_signal(String::new);
     let mut status = use_signal(|| "planned".to_string());
     let mut is_publishing = use_signal(|| false);
     let mut error_message = use_signal(|| Option::<String>::None);
@@ -28,7 +28,7 @@ pub fn LiveStreamNew() -> Element {
 
         !title_val.is_empty()
             && !stream_url_val.is_empty()
-            && Url::parse(&*stream_url_val)
+            && Url::parse(&stream_url_val)
                 .map(|u| {
                     let scheme = u.scheme();
                     scheme == "http" || scheme == "https" || scheme == "rtmp" || scheme == "rtmps"

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -581,7 +581,7 @@ fn Layout() -> Element {
     use crate::stores::{auth_store, notifications as notif_store};
 
     let auth = auth_store::AUTH_STATE.read();
-    let notif_count = use_memo(move || notif_store::get_unread_count());
+    let notif_count = use_memo(notif_store::get_unread_count);
     let mut sidebar_open = use_signal(|| false);
     let mut more_menu_open = use_signal(|| false);
     let mut radial_menu_open = use_signal(|| false);
@@ -671,7 +671,7 @@ fn Layout() -> Element {
                                 if is_home_page {
                                     // Already on home page, scroll to top
                                     if let Some(window) = web_sys::window() {
-                                        let _ = window.scroll_to_with_x_and_y(0.0, 0.0);
+                                        window.scroll_to_with_x_and_y(0.0, 0.0);
                                     }
                                 } else {
                                     // Navigate to home
@@ -701,7 +701,7 @@ fn Layout() -> Element {
                                                 onclick: move |_| {
                                                     if is_home_page {
                                                         if let Some(window) = web_sys::window() {
-                                                            let _ = window.scroll_to_with_x_and_y(0.0, 0.0);
+                                                            window.scroll_to_with_x_and_y(0.0, 0.0);
                                                         }
                                                     } else {
                                                         navigator.push(Route::Home {});
@@ -899,7 +899,7 @@ fn Layout() -> Element {
                                         if is_home_page {
                                             // Already on home page, scroll to top
                                             if let Some(window) = web_sys::window() {
-                                                let _ = window.scroll_to_with_x_and_y(0.0, 0.0);
+                                                window.scroll_to_with_x_and_y(0.0, 0.0);
                                             }
                                         } else {
                                             // Navigate to home
@@ -933,7 +933,7 @@ fn Layout() -> Element {
                                                             sidebar_open.set(false);
                                                             if is_home_page {
                                                                 if let Some(window) = web_sys::window() {
-                                                                    let _ = window.scroll_to_with_x_and_y(0.0, 0.0);
+                                                                    window.scroll_to_with_x_and_y(0.0, 0.0);
                                                                 }
                                                             } else {
                                                                 navigator.push(Route::Home {});

--- a/src/routes/music/album.rs
+++ b/src/routes/music/album.rs
@@ -252,7 +252,7 @@ pub fn MusicAlbum(album_id: String) -> Element {
 
                                                     // Duration
                                                     div { class: "text-sm text-gray-400",
-                                                        {track.duration.map(|d| format_duration(d)).unwrap_or_default()}
+                                                        {track.duration.map(&format_duration).unwrap_or_default()}
                                                     }
 
                                                     // Zap button

--- a/src/routes/music/artist.rs
+++ b/src/routes/music/artist.rs
@@ -240,7 +240,7 @@ fn WavlakeArtistSection(artist_id: String) -> Element {
 #[component]
 fn NostrArtistSection(pubkey: String) -> Element {
     let mut profile = use_signal(|| None::<profiles::Profile>);
-    let mut tracks = use_signal(|| Vec::<nostr_music::NostrTrack>::new());
+    let mut tracks = use_signal(Vec::<nostr_music::NostrTrack>::new);
     let mut loading = use_signal(|| true);
     let mut error_msg = use_signal(|| None::<String>);
 

--- a/src/routes/music/leaderboard.rs
+++ b/src/routes/music/leaderboard.rs
@@ -40,7 +40,7 @@ struct LeaderboardEntry {
 #[component]
 pub fn MusicLeaderboard() -> Element {
     let mut loading = use_signal(|| true);
-    let mut leaderboard = use_signal(|| Vec::<LeaderboardEntry>::new());
+    let mut leaderboard = use_signal(Vec::<LeaderboardEntry>::new);
     let mut error_msg = use_signal(|| None::<String>);
 
     // Fetch vote events and build leaderboard
@@ -310,7 +310,7 @@ async fn fetch_leaderboard_data() -> Result<Vec<LeaderboardEntry>, String> {
                     event.tags
                         .find(TagKind::single_letter(Alphabet::R, false))
                         .and_then(|t| t.content())
-                        .and_then(|url| url.split('/').last())
+                        .and_then(|url| url.split('/').next_back())
                         .map(|s| s.to_string())
                 });
 

--- a/src/routes/music/music_home.rs
+++ b/src/routes/music/music_home.rs
@@ -14,14 +14,14 @@ pub fn MusicHome() -> Element {
     let is_authenticated = auth_store::is_authenticated();
 
     // State signals
-    let mut search_query = use_signal(|| String::new());
+    let mut search_query = use_signal(String::new);
     let mut discovery_tab = use_signal(|| DiscoveryTab::Trending);
     let mut selected_genre = use_signal(|| String::from("all"));
     let mut selected_days = use_signal(|| 7u32);
     let mut selected_platform = use_signal(|| String::from("all")); // "all", "wavlake", "nostr"
 
     // Track state
-    let mut unified_tracks = use_signal(|| Vec::<MusicTrack>::new());
+    let mut unified_tracks = use_signal(Vec::<MusicTrack>::new);
     let mut loading = use_signal(|| true);
     let mut error_msg = use_signal(|| None::<String>);
 
@@ -30,12 +30,10 @@ pub fn MusicHome() -> Element {
         "Classical", "Blues", "Country", "Reggae", "Punk", "Metal"
     ];
 
-    let time_periods = vec![
-        (1, "24h"),
+    let time_periods = [(1, "24h"),
         (7, "7d"),
         (30, "30d"),
-        (90, "90d"),
-    ];
+        (90, "90d")];
 
     // Fetch tracks when filters change
     use_effect(move || {
@@ -433,7 +431,7 @@ pub fn MusicHome() -> Element {
 /// Playlist discovery section
 #[component]
 fn PlaylistSection(platform_filter: String) -> Element {
-    let mut playlists = use_signal(|| Vec::<nostr_music::NostrPlaylist>::new());
+    let mut playlists = use_signal(Vec::<nostr_music::NostrPlaylist>::new);
     let mut loading = use_signal(|| true);
 
     // Fetch playlists - reacts directly to platform_filter prop changes

--- a/src/routes/music/music_search.rs
+++ b/src/routes/music/music_search.rs
@@ -37,8 +37,8 @@ pub fn MusicSearch(q: String) -> Element {
     let mut error = use_signal(|| None::<String>);
 
     // Separate track results to avoid race conditions during parallel search
-    let mut wavlake_tracks = use_signal(|| Vec::<MusicTrack>::new());
-    let mut nostr_tracks = use_signal(|| Vec::<MusicTrack>::new());
+    let mut wavlake_tracks = use_signal(Vec::<MusicTrack>::new);
+    let mut nostr_tracks = use_signal(Vec::<MusicTrack>::new);
     // Compute unified tracks reactively - no race condition
     let unified_tracks = use_memo(move || {
         let mut combined = wavlake_tracks.read().clone();
@@ -46,13 +46,13 @@ pub fn MusicSearch(q: String) -> Element {
         combined
     });
     // Keep separate for Artists/Albums tabs
-    let mut artist_results = use_signal(|| Vec::<WavlakeSearchResult>::new());
-    let mut nostr_artist_results = use_signal(|| Vec::<(String, profiles::Profile)>::new());
+    let mut artist_results = use_signal(Vec::<WavlakeSearchResult>::new);
+    let mut nostr_artist_results = use_signal(Vec::<(String, profiles::Profile)>::new);
     let mut nostr_artist_loading = use_signal(|| true);
-    let mut album_results = use_signal(|| Vec::<WavlakeSearchResult>::new());
+    let mut album_results = use_signal(Vec::<WavlakeSearchResult>::new);
 
     // Playlist state
-    let mut playlist_id_input = use_signal(|| String::new());
+    let mut playlist_id_input = use_signal(String::new);
     let mut playlist = use_signal(|| None::<WavlakePlaylist>);
     let mut playlist_loading = use_signal(|| false);
     let mut playlist_error = use_signal(|| None::<String>);

--- a/src/routes/music/playlist_detail.rs
+++ b/src/routes/music/playlist_detail.rs
@@ -9,7 +9,7 @@ use crate::components::{UnifiedTrackCard, UnifiedTrackCardSkeleton};
 #[component]
 pub fn MusicPlaylistDetail(naddr: String) -> Element {
     let mut playlist = use_signal(|| None::<nostr_music::NostrPlaylist>);
-    let mut tracks = use_signal(|| Vec::<music_player::MusicTrack>::new());
+    let mut tracks = use_signal(Vec::<music_player::MusicTrack>::new);
     let mut creator_name = use_signal(|| String::from("Unknown"));
     let mut loading = use_signal(|| true);
     let mut error_msg = use_signal(|| None::<String>);

--- a/src/routes/music/playlist_new.rs
+++ b/src/routes/music/playlist_new.rs
@@ -17,7 +17,7 @@ pub fn MusicPlaylistNew() -> Element {
     let mut image_url = use_signal(String::new);
     let mut is_public = use_signal(|| true);
     let mut is_collaborative = use_signal(|| false);
-    let mut categories = use_signal(|| Vec::<String>::new());
+    let mut categories = use_signal(Vec::<String>::new);
     let mut category_input = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut error_msg = use_signal(|| None::<String>);

--- a/src/routes/music/radio.rs
+++ b/src/routes/music/radio.rs
@@ -16,12 +16,10 @@ pub fn MusicRadio() -> Element {
         "R&B", "Alternative", "Indie", "Ambient"
     ];
 
-    let time_periods = vec![
-        (1, "24 hours"),
+    let time_periods = [(1, "24 hours"),
         (7, "7 days"),
         (30, "30 days"),
-        (90, "90 days"),
-    ];
+        (90, "90 days")];
 
     // Start radio
     let start_radio = move |_| {

--- a/src/routes/music/track_new.rs
+++ b/src/routes/music/track_new.rs
@@ -16,7 +16,7 @@ pub fn MusicTrackNew() -> Element {
     let mut audio_url = use_signal(String::new);
     let mut image_url = use_signal(String::new);
     let mut duration = use_signal(|| None::<u32>);
-    let mut genres = use_signal(|| Vec::<String>::new());
+    let mut genres = use_signal(Vec::<String>::new);
     let mut genre_input = use_signal(String::new);
     let mut ai_generated = use_signal(|| false);
     let mut is_publishing = use_signal(|| false);

--- a/src/routes/nip19.rs
+++ b/src/routes/nip19.rs
@@ -154,7 +154,7 @@ async fn decode_and_redirect(identifier: &str) -> std::result::Result<Route, Str
                     30311 => {
                         // Live stream events use note_id from event
                         // For now, return error since we need to fetch the actual event
-                        Err(format!("Live stream naddr routing requires event fetch. Please use the event ID directly."))
+                        Err("Live stream naddr routing requires event fetch. Please use the event ID directly.".to_string())
                     },
                     // Calendar events (NIP-52)
                     31922 | 31923 => Ok(Route::CalendarEventDetail {

--- a/src/routes/nip_detail.rs
+++ b/src/routes/nip_detail.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 pub fn NipDetail(nip_id: String) -> Element {
     // State
     let mut nip_content = use_signal(|| None::<String>);
-    let mut nip_title = use_signal(|| String::new());
+    let mut nip_title = use_signal(String::new);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
 
@@ -22,10 +22,10 @@ pub fn NipDetail(nip_id: String) -> Element {
     let mut is_custom = use_signal(|| false);
     let mut custom_event = use_signal(|| None::<NostrEvent>);
     let mut author_metadata = use_signal(|| None::<nostr_sdk::Metadata>);
-    let mut related_kinds = use_signal(|| Vec::<String>::new());
+    let mut related_kinds = use_signal(Vec::<String>::new);
 
     // Comments state
-    let mut comments = use_signal(|| Vec::<NostrEvent>::new());
+    let mut comments = use_signal(Vec::<NostrEvent>::new);
     let mut loading_comments = use_signal(|| false);
     let mut show_comment_composer = use_signal(|| false);
 

--- a/src/routes/nips.rs
+++ b/src/routes/nips.rs
@@ -28,18 +28,18 @@ impl NipsTab {
 pub fn NipsHome() -> Element {
     // Tab and search state
     let mut active_tab = use_signal(|| NipsTab::Official);
-    let mut search_query = use_signal(|| String::new());
-    let mut search_input = use_signal(|| String::new()); // Debounced input
+    let mut search_query = use_signal(String::new);
+    let mut search_input = use_signal(String::new); // Debounced input
 
     // Search results state (overlay)
-    let mut search_results = use_signal(|| Vec::<Event>::new());
+    let mut search_results = use_signal(Vec::<Event>::new);
     let mut search_loading = use_signal(|| false);
     let mut is_searching = use_signal(|| false); // True when search overlay is active
 
     // Data state
-    let mut official_nips = use_signal(|| Vec::<OfficialNip>::new());
-    let mut custom_nips = use_signal(|| Vec::<Event>::new());
-    let mut event_kinds = use_signal(|| Vec::<EventKindInfo>::new());
+    let mut official_nips = use_signal(Vec::<OfficialNip>::new);
+    let mut custom_nips = use_signal(Vec::<Event>::new);
+    let mut event_kinds = use_signal(Vec::<EventKindInfo>::new);
 
     // Loading and pagination state
     let mut loading = use_signal(|| false);
@@ -606,10 +606,10 @@ pub fn NipNew() -> Element {
     });
 
     // Form state
-    let mut title = use_signal(|| String::new());
-    let mut identifier = use_signal(|| String::new());
-    let content = use_signal(|| String::new());
-    let mut related_kinds_input = use_signal(|| String::new());
+    let mut title = use_signal(String::new);
+    let mut identifier = use_signal(String::new);
+    let content = use_signal(String::new);
+    let mut related_kinds_input = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
 

--- a/src/routes/note.rs
+++ b/src/routes/note.rs
@@ -94,10 +94,10 @@ async fn fetch_replies(event_id: EventId) -> std::result::Result<Vec<NostrEvent>
 #[component]
 pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
     // Determine initial is_voice_note from prop (for immediate correct header on deep-link)
-    let initial_is_voice = from_voice.as_ref().map_or(false, |v| v == "true");
+    let initial_is_voice = from_voice.as_ref().is_some_and(|v| v == "true");
     let mut note_data = use_signal(|| None::<NostrEvent>);
-    let mut parent_events = use_signal(|| Vec::<NostrEvent>::new());
-    let mut replies = use_signal(|| Vec::<NostrEvent>::new());
+    let mut parent_events = use_signal(Vec::<NostrEvent>::new);
+    let mut replies = use_signal(Vec::<NostrEvent>::new);
     let mut loading = use_signal(|| true);
     let mut loading_parents = use_signal(|| false);
     let mut loading_replies = use_signal(|| false);
@@ -204,7 +204,7 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
             // Determine back route based on whether this is a voice message
             // Prefer the from_voice prop for immediate correct display, then update from loaded data
             {
-                let data_is_voice = note_data.read().as_ref().map(|e| is_voice_message(e));
+                let data_is_voice = note_data.read().as_ref().map(is_voice_message);
                 let is_voice_note = data_is_voice.unwrap_or(initial_is_voice);
                 let back_route = if is_voice_note { Route::VoiceMessages {} } else { Route::Home {} };
                 let title = if is_voice_note { "Voice Message" } else { "Post" };

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -52,7 +52,7 @@ impl NotificationFilter {
 
 #[component]
 pub fn Notifications() -> Element {
-    let mut notifications = use_signal(|| Vec::<NotificationType>::new());
+    let mut notifications = use_signal(Vec::<NotificationType>::new);
     let mut loading = use_signal(|| false);
     let mut refreshing = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
@@ -81,7 +81,7 @@ pub fn Notifications() -> Element {
             match load_notifications(None).await {
                 Ok(notifs) => {
                     if !notifs.is_empty() {
-                        let oldest = notifs.iter().map(|n| get_timestamp(n)).min();
+                        let oldest = notifs.iter().map(get_timestamp).min();
                         oldest_timestamp.set(oldest);
                         let len = notifs.len();
                         notifications.set(notifs.clone());
@@ -116,7 +116,7 @@ pub fn Notifications() -> Element {
             match load_notifications(None).await {
                 Ok(notifs) => {
                     if !notifs.is_empty() {
-                        let oldest = notifs.iter().map(|n| get_timestamp(n)).min();
+                        let oldest = notifs.iter().map(get_timestamp).min();
                         oldest_timestamp.set(oldest);
                         let len = notifs.len();
                         notifications.set(notifs.clone());
@@ -149,7 +149,7 @@ pub fn Notifications() -> Element {
             match load_notifications(until).await {
                 Ok(new_notifs) => {
                     if !new_notifs.is_empty() {
-                        let oldest = new_notifs.iter().map(|n| get_timestamp(n)).min();
+                        let oldest = new_notifs.iter().map(get_timestamp).min();
                         oldest_timestamp.set(oldest);
 
                         let mut current = notifications.read().clone();
@@ -417,7 +417,7 @@ fn ReactionNotification(event: NostrEvent) -> Element {
         event.tags.iter()
             .find_map(|tag| {
                 let slice = tag.as_slice();
-                if slice.get(0).map(|k| k == "emoji").unwrap_or(false) &&
+                if slice.first().map(|k| k == "emoji").unwrap_or(false) &&
                    slice.get(1).map(|s| s == shortcode).unwrap_or(false) {
                     slice.get(2).cloned()
                 } else {

--- a/src/routes/photo_detail.rs
+++ b/src/routes/photo_detail.rs
@@ -11,7 +11,7 @@ pub fn PhotoDetail(photo_id: String) -> Element {
     let mut photo_event = use_signal(|| None::<Event>);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
-    let mut comments = use_signal(|| Vec::<Event>::new());
+    let mut comments = use_signal(Vec::<Event>::new);
     let mut loading_comments = use_signal(|| false);
     let mut show_comment_composer = use_signal(|| false);
 

--- a/src/routes/photo_new.rs
+++ b/src/routes/photo_new.rs
@@ -5,11 +5,11 @@ use crate::components::MediaUploader;
 #[component]
 pub fn PhotoNew() -> Element {
     let navigator = navigator();
-    let mut title = use_signal(|| String::new());
-    let mut caption = use_signal(|| String::new());
-    let mut image_urls = use_signal(|| Vec::<String>::new());
-    let mut hashtags = use_signal(|| String::new());
-    let mut location = use_signal(|| String::new());
+    let mut title = use_signal(String::new);
+    let mut caption = use_signal(String::new);
+    let mut image_urls = use_signal(Vec::<String>::new);
+    let mut hashtags = use_signal(String::new);
+    let mut location = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut show_image_uploader = use_signal(|| true);
     let mut error_message = use_signal(|| Option::<String>::None);
@@ -19,7 +19,7 @@ pub fn PhotoNew() -> Element {
 
     // Validation
     let can_publish = title.read().chars().count() > 0
-        && image_urls.read().len() > 0
+        && !image_urls.read().is_empty()
         && !*is_publishing.read();
 
     // Handle close
@@ -166,7 +166,7 @@ pub fn PhotoNew() -> Element {
                         }
 
                         // Display uploaded images
-                        if image_urls.read().len() > 0 {
+                        if !image_urls.read().is_empty() {
                             div {
                                 class: "grid grid-cols-2 md:grid-cols-3 gap-4 mb-4",
                                 for (index , url) in image_urls.read().iter().enumerate() {

--- a/src/routes/photos.rs
+++ b/src/routes/photos.rs
@@ -23,7 +23,7 @@ impl FeedType {
 #[component]
 pub fn Photos() -> Element {
     // State for feed events
-    let mut events = use_signal(|| Vec::<Event>::new());
+    let mut events = use_signal(Vec::<Event>::new);
     let mut loading = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
     let mut refresh_trigger = use_signal(|| 0);

--- a/src/routes/pin_board_detail.rs
+++ b/src/routes/pin_board_detail.rs
@@ -24,7 +24,7 @@ pub fn PinBoardDetail(naddr: String) -> Element {
     let naddr_for_edit = naddr.clone();
 
     let mut board = use_signal(|| None::<Pinboard>);
-    let mut pins = use_signal(|| Vec::<Pin>::new());
+    let mut pins = use_signal(Vec::<Pin>::new);
     let mut loading = use_signal(|| true);
     let mut pins_loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
@@ -154,7 +154,7 @@ pub fn PinBoardDetail(naddr: String) -> Element {
             drop(board_ref);
             deleting.set(true);
 
-            let nav = nav.clone();
+            let nav = nav;
             spawn(async move {
                 match delete_pinboard(&board_clone).await {
                     Ok(_) => {

--- a/src/routes/pin_boards.rs
+++ b/src/routes/pin_boards.rs
@@ -20,11 +20,11 @@ const PAGE_SIZE: usize = 30;
 #[component]
 pub fn PinBoardsHome() -> Element {
     // User's own boards
-    let mut my_boards = use_signal(|| Vec::<Pinboard>::new());
+    let mut my_boards = use_signal(Vec::<Pinboard>::new);
     let mut my_boards_loading = use_signal(|| true);
 
     // Discover boards
-    let mut discover_boards = use_signal(|| Vec::<Pinboard>::new());
+    let mut discover_boards = use_signal(Vec::<Pinboard>::new);
     let mut discover_loading = use_signal(|| true);
 
     // Pagination state
@@ -160,7 +160,7 @@ pub fn PinBoardsHome() -> Element {
                 .into_iter()
                 .filter(|b| {
                     b.title.to_lowercase().contains(&query_lower) ||
-                    b.description.as_ref().map_or(false, |d| d.to_lowercase().contains(&query_lower)) ||
+                    b.description.as_ref().is_some_and(|d| d.to_lowercase().contains(&query_lower)) ||
                     b.tags.iter().any(|t| t.to_lowercase().contains(&query_lower))
                 })
                 .collect();

--- a/src/routes/podcast.rs
+++ b/src/routes/podcast.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 /// Podcast home page
 #[component]
 pub fn PodcastHome() -> Element {
-    let mut search_query = use_signal(|| String::new());
+    let mut search_query = use_signal(String::new);
     let mut active_tab = use_signal(|| PodcastTab::Discover);
 
     rsx! {

--- a/src/routes/podcast_episode_detail.rs
+++ b/src/routes/podcast_episode_detail.rs
@@ -229,7 +229,7 @@ fn EpisodeDetailContent(props: EpisodeDetailContentProps) -> Element {
 
     // Format duration
     let duration_str = episode.duration
-        .map(|d| format_duration(d))
+        .map(format_duration)
         .unwrap_or_else(|| "--:--".to_string());
 
     // Track for playback
@@ -720,7 +720,7 @@ async fn fetch_nostr_episode(
     let episode_events = nostr_client::fetch_events_aggregated(episode_filter, Duration::from_secs(10))
         .await?;
 
-    let episode_event = episode_events.iter().next()
+    let episode_event = episode_events.first()
         .ok_or_else(|| "Episode not found".to_string())?;
 
     let episode = podcast::parse_podcast_episode(episode_event)?;
@@ -734,7 +734,7 @@ async fn fetch_nostr_episode(
     let metadata_events = nostr_client::fetch_events_aggregated(metadata_filter, Duration::from_secs(5))
         .await?;
 
-    let metadata = if let Some(meta_event) = metadata_events.iter().next() {
+    let metadata = if let Some(meta_event) = metadata_events.first() {
         podcast::parse_podcast_metadata(meta_event).ok()
     } else {
         None

--- a/src/routes/podcast_nostr_detail.rs
+++ b/src/routes/podcast_nostr_detail.rs
@@ -388,7 +388,7 @@ async fn fetch_nostr_podcast(naddr: &str) -> std::result::Result<(PodcastMetadat
     let metadata_events = nostr_client::fetch_events_aggregated(metadata_filter, Duration::from_secs(10))
         .await?;
 
-    let metadata_event = metadata_events.iter().next()
+    let metadata_event = metadata_events.first()
         .ok_or_else(|| "Podcast not found".to_string())?;
 
     let metadata = podcast::parse_podcast_metadata(metadata_event)?;

--- a/src/routes/poll_new.rs
+++ b/src/routes/poll_new.rs
@@ -8,12 +8,12 @@ use once_cell::sync::Lazy;
 #[component]
 pub fn PollNew() -> Element {
     let navigator = navigator();
-    let nav_close = navigator.clone();
-    let nav_publish = navigator.clone();
-    let nav_effect = navigator.clone();
+    let nav_close = navigator;
+    let nav_publish = navigator;
+    let nav_effect = navigator;
 
     // Form state
-    let mut poll_question = use_signal(|| String::new());
+    let mut poll_question = use_signal(String::new);
     let mut poll_type = use_signal(|| PollType::SingleChoice);
     let mut options = use_signal(|| vec![
         PollOptionData {
@@ -26,8 +26,8 @@ pub fn PollNew() -> Element {
         },
     ]);
     let mut end_time_preset = use_signal(|| String::from("1day"));
-    let mut custom_end_time = use_signal(|| String::new());
-    let mut hashtags_input = use_signal(|| String::new());
+    let mut custom_end_time = use_signal(String::new);
+    let mut hashtags_input = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut error_message = use_signal(|| Option::<String>::None);
 
@@ -72,7 +72,7 @@ pub fn PollNew() -> Element {
         is_publishing.set(true);
         error_message.set(None);
 
-        let nav_spawn = nav_publish.clone();
+        let nav_spawn = nav_publish;
         spawn(async move {
             // Calculate end time
             let ends_at = calculate_end_time(&end_time_preset_val, &custom_end_time_val);

--- a/src/routes/polls.rs
+++ b/src/routes/polls.rs
@@ -23,7 +23,7 @@ impl FeedType {
 #[component]
 pub fn Polls() -> Element {
     // State for feed events
-    let mut events = use_signal(|| Vec::<Event>::new());
+    let mut events = use_signal(Vec::<Event>::new);
     let mut loading = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
     let mut refresh_trigger = use_signal(|| 0);

--- a/src/routes/profile.rs
+++ b/src/routes/profile.rs
@@ -101,7 +101,7 @@ pub fn Profile(pubkey: String) -> Element {
 
     // DM dialog state
     let mut show_dm_dialog = use_signal(|| false);
-    let mut dm_message = use_signal(|| String::new());
+    let mut dm_message = use_signal(String::new);
     let mut dm_sending = use_signal(|| false);
     let mut dm_error = use_signal(|| None::<String>);
 
@@ -109,7 +109,7 @@ pub fn Profile(pubkey: String) -> Element {
     let mut show_info_dialog = use_signal(|| false);
 
     // Pinned notes state
-    let mut pinned_events = use_signal(|| Vec::<NostrEvent>::new());
+    let mut pinned_events = use_signal(Vec::<NostrEvent>::new);
     let mut pinned_loading = use_signal(|| true);
 
     // Clone pubkey for rsx! block usage
@@ -506,7 +506,7 @@ pub fn Profile(pubkey: String) -> Element {
         }
 
         let pubkey_str = pubkey_for_load_more.clone();
-        let mut post_count_clone = post_count.clone();
+        let mut post_count_clone = post_count;
 
         loading_events.set(true);
 
@@ -855,13 +855,13 @@ pub fn Profile(pubkey: String) -> Element {
                                         let year = v.get("year").and_then(|y| y.as_u64());
 
                                         match (month, day, year) {
-                                            (Some(m), Some(d), Some(y)) if m >= 1 && m <= 12 => {
+                                            (Some(m), Some(d), Some(y)) if (1..=12).contains(&m) => {
                                                 Some(format!("{} {}, {}", months[m - 1], d, y))
                                             }
-                                            (Some(m), Some(d), None) if m >= 1 && m <= 12 => {
+                                            (Some(m), Some(d), None) if (1..=12).contains(&m) => {
                                                 Some(format!("{} {}", months[m - 1], d))
                                             }
-                                            (Some(m), None, None) if m >= 1 && m <= 12 => {
+                                            (Some(m), None, None) if (1..=12).contains(&m) => {
                                                 Some(months[m - 1].to_string())
                                             }
                                             _ => None
@@ -1541,7 +1541,7 @@ fn parse_video_meta(event: &NostrEvent) -> VideoMeta {
 fn VertsVideoCard(event: NostrEvent) -> Element {
     let video_meta = parse_video_meta(&event);
     let mut is_hovering = use_signal(|| false);
-    let video_element_id = format!("preview-vert-{}", event.id.to_hex()[..12].to_string());
+    let video_element_id = format!("preview-vert-{}", &event.id.to_hex()[..12]);
     let video_element_id_for_effect = video_element_id.clone();
 
     // Play/pause video on hover (only if no thumbnail)
@@ -1865,7 +1865,7 @@ async fn load_tab_events(pubkey: &str, tab: &ProfileTab, until: Option<u64>) -> 
 
             while all_posts.len() < TARGET_COUNT && total_fetched < MAX_FETCH_LIMIT {
                 let mut filter = Filter::new()
-                    .author(public_key.clone())
+                    .author(public_key)
                     .kinds(vec![Kind::TextNote, Kind::Repost])
                     .limit(100); // Fetch more at once to reduce round trips
 
@@ -1933,7 +1933,7 @@ async fn load_tab_events(pubkey: &str, tab: &ProfileTab, until: Option<u64>) -> 
 
             while all_replies.len() < TARGET_COUNT && total_fetched < MAX_FETCH_LIMIT {
                 let mut filter = Filter::new()
-                    .author(public_key.clone())
+                    .author(public_key)
                     .kind(Kind::TextNote)
                     .limit(100);
 

--- a/src/routes/publication_new.rs
+++ b/src/routes/publication_new.rs
@@ -23,7 +23,7 @@ pub fn PublicationNew() -> Element {
     let mut auto_identifier = use_signal(|| true);
 
     // Section management
-    let mut sections = use_signal(|| Vec::<SectionDraft>::new());
+    let mut sections = use_signal(Vec::<SectionDraft>::new);
     let mut current_section_idx = use_signal(|| None::<usize>);
     let mut show_preview = use_signal(|| false);
 
@@ -356,7 +356,7 @@ pub fn PublicationNew() -> Element {
                                     index: idx,
                                     section: section.clone(),
                                     on_update: {
-                                        let mut sections = sections.clone();
+                                        let mut sections = sections;
                                         move |(idx, updated): (usize, SectionDraft)| {
                                             let mut secs = sections.read().clone();
                                             if idx < secs.len() {
@@ -366,7 +366,7 @@ pub fn PublicationNew() -> Element {
                                         }
                                     },
                                     on_remove: {
-                                        let mut sections = sections.clone();
+                                        let mut sections = sections;
                                         move |idx: usize| {
                                             let mut secs = sections.read().clone();
                                             if idx < secs.len() {

--- a/src/routes/publication_search.rs
+++ b/src/routes/publication_search.rs
@@ -54,7 +54,7 @@ fn parse_query_to_reference(query: &str) -> Option<BookReference> {
 pub fn PublicationSearch(query: String) -> Element {
     let nav = use_navigator();
     let mut loading = use_signal(|| true);
-    let mut results = use_signal(|| Vec::new());
+    let mut results = use_signal(Vec::new);
     let mut error = use_signal(|| None::<String>);
 
     // Parse the query into a book reference

--- a/src/routes/publications.rs
+++ b/src/routes/publications.rs
@@ -20,7 +20,7 @@ enum ViewMode {
 pub fn PublicationsHome() -> Element {
     let mut loading = use_signal(|| true);
     let mut searching = use_signal(|| false);
-    let mut publications = use_signal(|| Vec::new());
+    let mut publications = use_signal(Vec::new);
     let mut search_results = use_signal(|| None::<Vec<PublicationIndex>>);
     let mut search_query = use_signal(String::new);
     let mut committed_query = use_signal(String::new);

--- a/src/routes/recipe_chef.rs
+++ b/src/routes/recipe_chef.rs
@@ -11,7 +11,7 @@ use crate::routes::Route;
 
 #[component]
 pub fn RecipeChef(npub: String) -> Element {
-    let mut recipes = use_signal(|| Vec::<CachedRecipe>::new());
+    let mut recipes = use_signal(Vec::<CachedRecipe>::new);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
 

--- a/src/routes/recipes.rs
+++ b/src/routes/recipes.rs
@@ -18,19 +18,19 @@ use crate::routes::Route;
 #[component]
 pub fn RecipesHome() -> Element {
     // Collections state
-    let mut collections = use_signal(|| Vec::<Collection>::new());
+    let mut collections = use_signal(Vec::<Collection>::new);
     let mut collections_loading = use_signal(|| true);
 
     // Popular chefs state
-    let mut popular_chefs = use_signal(|| Vec::<PopularChef>::new());
+    let mut popular_chefs = use_signal(Vec::<PopularChef>::new);
     let mut chefs_loading = use_signal(|| true);
 
     // Discover recipes state
-    let mut discover_recipes = use_signal(|| Vec::<CachedRecipe>::new());
+    let mut discover_recipes = use_signal(Vec::<CachedRecipe>::new);
     let mut discover_loading = use_signal(|| true);
 
     // Hot tags state
-    let mut popular_tags = use_signal(|| Vec::<TagWithCount>::new());
+    let mut popular_tags = use_signal(Vec::<TagWithCount>::new);
     let mut tags_loading = use_signal(|| true);
 
     // Culture section expand state

--- a/src/routes/recipes_all.rs
+++ b/src/routes/recipes_all.rs
@@ -14,7 +14,7 @@ const PAGE_SIZE: usize = 24;
 #[component]
 pub fn RecipesAll() -> Element {
     // State
-    let mut recipes = use_signal(|| Vec::<CachedRecipe>::new());
+    let mut recipes = use_signal(Vec::<CachedRecipe>::new);
     let mut loading = use_signal(|| true);
     let mut pagination_loading = use_signal(|| false);
     let mut has_more = use_signal(|| true);

--- a/src/routes/recipes_by_tag.rs
+++ b/src/routes/recipes_by_tag.rs
@@ -15,7 +15,7 @@ pub fn RecipesByTag(tag: String) -> Element {
     let tag_for_load_more = tag.clone();
     let tag_for_display = tag.clone();
 
-    let mut recipes = use_signal(|| Vec::<CachedRecipe>::new());
+    let mut recipes = use_signal(Vec::<CachedRecipe>::new);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
 

--- a/src/routes/search.rs
+++ b/src/routes/search.rs
@@ -46,10 +46,10 @@ impl SortOrder {
 #[component]
 pub fn Search(q: String) -> Element {
     let mut active_tab = use_signal(|| SearchTab::TextNotes);
-    let mut results = use_signal(|| Vec::<ContentSearchResult>::new());
+    let mut results = use_signal(Vec::<ContentSearchResult>::new);
     let mut loading = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
-    let mut contact_pubkeys = use_signal(|| Vec::<PublicKey>::new());
+    let mut contact_pubkeys = use_signal(Vec::<PublicKey>::new);
     let mut query = use_signal(|| q.clone());
     let mut search_version = use_signal(|| 0u64);
     let mut sort_order = use_signal(|| SortOrder::FollowingFirst);
@@ -220,7 +220,7 @@ pub fn Search(q: String) -> Element {
             }
 
             // Empty state
-            if !*loading.read() && results.read().is_empty() && query.read().len() > 0 {
+            if !*loading.read() && results.read().is_empty() && !query.read().is_empty() {
                 div {
                     class: "flex flex-col items-center justify-center py-16 px-4",
                     div {

--- a/src/routes/settings.rs
+++ b/src/routes/settings.rs
@@ -18,7 +18,7 @@ pub fn Settings() -> Element {
         // Use peek() to avoid reactive tracking during initialization
         relay_metadata::USER_RELAY_METADATA.peek().as_ref()
             .map(|m| m.relays.clone())
-            .unwrap_or_else(|| relay_metadata::default_relays())
+            .unwrap_or_else(relay_metadata::default_relays)
     });
 
     let mut dm_relays = use_signal(|| {
@@ -39,19 +39,19 @@ pub fn Settings() -> Element {
         }
     });
 
-    let mut new_relay_url = use_signal(|| String::new());
-    let mut new_dm_relay_url = use_signal(|| String::new());
+    let mut new_relay_url = use_signal(String::new);
+    let mut new_dm_relay_url = use_signal(String::new);
     let mut relay_error = use_signal(|| None::<String>);
     let mut dm_relay_error = use_signal(|| None::<String>);
     let mut save_status = use_signal(|| None::<String>);
 
-    let mut new_server_input = use_signal(|| String::new());
+    let mut new_server_input = use_signal(String::new);
     let mut server_error = use_signal(|| None::<String>);
 
     // NWC state
     let mut show_nwc_modal = use_signal(|| false);
     let nwc_status = nwc_store::NWC_STATUS.read().clone();
-    let nwc_balance = nwc_store::NWC_BALANCE.read().clone();
+    let nwc_balance = *nwc_store::NWC_BALANCE.read();
 
     // Reactions modal state
     let mut show_reactions_modal = use_signal(|| false);

--- a/src/routes/settings_blocklist.rs
+++ b/src/routes/settings_blocklist.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 
 #[component]
 pub fn SettingsBlocklist() -> Element {
-    let mut blocked_users = use_signal(|| Vec::<String>::new());
-    let mut user_profiles = use_signal(|| HashMap::<String, profiles::Profile>::new());
+    let mut blocked_users = use_signal(Vec::<String>::new);
+    let mut user_profiles = use_signal(HashMap::<String, profiles::Profile>::new);
     let mut loading = use_signal(|| true);
     let mut error_msg = use_signal(|| None::<String>);
     let refresh_trigger = use_signal(|| 0);

--- a/src/routes/settings_muted.rs
+++ b/src/routes/settings_muted.rs
@@ -4,7 +4,7 @@ use crate::routes::Route;
 
 #[component]
 pub fn SettingsMuted() -> Element {
-    let mut muted_posts = use_signal(|| Vec::<String>::new());
+    let mut muted_posts = use_signal(Vec::<String>::new);
     let mut loading = use_signal(|| true);
     let mut error_msg = use_signal(|| None::<String>);
 

--- a/src/routes/trending.rs
+++ b/src/routes/trending.rs
@@ -8,8 +8,8 @@ use nostr::secp256k1::schnorr::Signature;
 #[component]
 pub fn Trending() -> Element {
     // State for feed events
-    let mut trending_notes = use_signal(|| Vec::<TrendingNote>::new());
-    let mut events = use_signal(|| Vec::<NostrEvent>::new());
+    let mut trending_notes = use_signal(Vec::<TrendingNote>::new);
+    let mut events = use_signal(Vec::<NostrEvent>::new);
     let mut loading = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
     let mut refresh_trigger = use_signal(|| 0);

--- a/src/routes/video_detail.rs
+++ b/src/routes/video_detail.rs
@@ -127,7 +127,7 @@ pub fn VideoDetail(video_id: String) -> Element {
 #[component]
 fn LandscapePlayer(event: Event) -> Element {
     let mut is_muted = use_signal(|| false);
-    let mut comments = use_signal(|| Vec::<Event>::new());
+    let mut comments = use_signal(Vec::<Event>::new);
     let mut loading_comments = use_signal(|| false);
     let mut show_comment_composer = use_signal(|| false);
     let event_id = event.id;
@@ -422,7 +422,7 @@ fn LandscapePlayer(event: Event) -> Element {
 
 #[component]
 fn ShortsPlayer(initial_video_id: String, feed_type: FeedType, initial_event: Option<Event>) -> Element {
-    let mut events = use_signal(|| Vec::<Event>::new());
+    let mut events = use_signal(Vec::<Event>::new);
     let mut loading = use_signal(|| false);
     let mut current_video_index = use_signal(|| 0usize);
     let mut is_muted = use_signal(|| false);
@@ -625,7 +625,7 @@ fn ShortsPlayer(initial_video_id: String, feed_type: FeedType, initial_event: Op
                 }
 
                 // Down button
-                if events.read().len() > 0 && (*current_video_index.read() < events.read().len() - 1 || *has_more.read()) {
+                if !events.read().is_empty() && (*current_video_index.read() < events.read().len() - 1 || *has_more.read()) {
                     button {
                         class: "w-12 h-12 rounded-full bg-white/20 hover:bg-white/30 backdrop-blur-sm flex items-center justify-center text-white transition",
                         onclick: move |_| next_video(),
@@ -656,7 +656,7 @@ fn VerticalVideoPlayer(
     is_muted: bool,
     on_mute_toggle: EventHandler<()>,
 ) -> Element {
-    let video_id = format!("video-{}", event.id.to_hex()[..8].to_string());
+    let video_id = format!("video-{}", &event.id.to_hex()[..8]);
     let video_id_for_effect = video_id.clone();
     let video_meta = parse_video_meta(&event);
 
@@ -741,7 +741,7 @@ fn VideoInfo(
     let mut is_liking = use_signal(|| false);
     let mut show_comments_modal = use_signal(|| false);
     let mut show_comment_composer = use_signal(|| false);
-    let mut comments = use_signal(|| Vec::<Event>::new());
+    let mut comments = use_signal(Vec::<Event>::new);
     let mut loading_comments = use_signal(|| false);
     let mut show_share_modal = use_signal(|| false);
 

--- a/src/routes/video_new_landscape.rs
+++ b/src/routes/video_new_landscape.rs
@@ -5,11 +5,11 @@ use crate::components::MediaUploader;
 #[component]
 pub fn VideoNewLandscape() -> Element {
     let navigator = navigator();
-    let mut title = use_signal(|| String::new());
-    let mut description = use_signal(|| String::new());
+    let mut title = use_signal(String::new);
+    let mut description = use_signal(String::new);
     let mut video_url = use_signal(|| Option::<String>::None);
-    let mut thumbnail_url = use_signal(|| String::new());
-    let mut hashtags = use_signal(|| String::new());
+    let mut thumbnail_url = use_signal(String::new);
+    let mut hashtags = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut show_video_uploader = use_signal(|| true);
     let mut show_thumbnail_uploader = use_signal(|| false);

--- a/src/routes/video_new_portrait.rs
+++ b/src/routes/video_new_portrait.rs
@@ -5,11 +5,11 @@ use crate::components::MediaUploader;
 #[component]
 pub fn VideoNewPortrait() -> Element {
     let navigator = navigator();
-    let mut title = use_signal(|| String::new());
-    let mut description = use_signal(|| String::new());
+    let mut title = use_signal(String::new);
+    let mut description = use_signal(String::new);
     let mut video_url = use_signal(|| Option::<String>::None);
-    let mut thumbnail_url = use_signal(|| String::new());
-    let mut hashtags = use_signal(|| String::new());
+    let mut thumbnail_url = use_signal(String::new);
+    let mut hashtags = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut show_video_uploader = use_signal(|| true);
     let mut show_thumbnail_uploader = use_signal(|| false);

--- a/src/routes/videos.rs
+++ b/src/routes/videos.rs
@@ -23,15 +23,15 @@ impl FeedType {
 #[component]
 pub fn Videos() -> Element {
     // State for featured landscape videos
-    let mut featured_landscape = use_signal(|| Vec::<Event>::new());
+    let mut featured_landscape = use_signal(Vec::<Event>::new);
     let mut loading_featured = use_signal(|| false);
 
     // State for recent verts section
-    let mut recent_verts = use_signal(|| Vec::<Event>::new());
+    let mut recent_verts = use_signal(Vec::<Event>::new);
     let mut loading_recent_verts = use_signal(|| false);
 
     // State for combined feed
-    let mut feed_events = use_signal(|| Vec::<Event>::new());
+    let mut feed_events = use_signal(Vec::<Event>::new);
     let mut loading_feed = use_signal(|| false);
     let mut feed_type = use_signal(|| FeedType::Following);
     let mut show_dropdown = use_signal(|| false);
@@ -459,7 +459,7 @@ fn LandscapeVideoCard(event: Event, feed_type: FeedType) -> Element {
     let mut author_metadata = use_signal(|| None::<nostr_sdk::Metadata>);
     let author_pubkey = event.pubkey.to_string();
     let mut is_hovering = use_signal(|| false);
-    let video_element_id = format!("preview-{}", event.id.to_hex()[..12].to_string());
+    let video_element_id = format!("preview-{}", &event.id.to_hex()[..12]);
     let video_element_id_for_effect = video_element_id.clone();
 
     // Fetch author metadata
@@ -593,7 +593,7 @@ fn LandscapeVideoCard(event: Event, feed_type: FeedType) -> Element {
 fn VertsVideoCard(event: Event, feed_type: FeedType) -> Element {
     let video_meta = parse_video_meta(&event);
     let mut is_hovering = use_signal(|| false);
-    let video_element_id = format!("preview-vert-{}", event.id.to_hex()[..12].to_string());
+    let video_element_id = format!("preview-vert-{}", &event.id.to_hex()[..12]);
     let video_element_id_for_effect = video_element_id.clone();
 
     // Play/pause video on hover (only if no thumbnail)
@@ -748,7 +748,7 @@ async fn load_featured_content() -> Result<Vec<Event>, String> {
     log::info!("Loading featured landscape videos...");
 
     // Try Following feed first
-    let _result = if let Some(pubkey_str) = auth_store::get_pubkey() {
+    if let Some(pubkey_str) = auth_store::get_pubkey() {
         match nostr_client::fetch_contacts(pubkey_str).await {
             Ok(contacts) if !contacts.is_empty() => {
                 let mut authors = Vec::new();

--- a/src/routes/videos_live.rs
+++ b/src/routes/videos_live.rs
@@ -15,14 +15,14 @@ enum StatusFilter {
 #[component]
 pub fn VideosLive() -> Element {
     // Following streams state
-    let mut following_streams = use_signal(|| Vec::<Event>::new());
+    let mut following_streams = use_signal(Vec::<Event>::new);
     let mut loading_following = use_signal(|| false);
     let mut has_more_following = use_signal(|| true);
     let mut oldest_timestamp_following = use_signal(|| None::<u64>);
     let mut error_following = use_signal(|| None::<String>);
 
     // Global streams state
-    let mut global_streams = use_signal(|| Vec::<Event>::new());
+    let mut global_streams = use_signal(Vec::<Event>::new);
     let mut loading_global = use_signal(|| false);
     let mut has_more_global = use_signal(|| true);
     let mut oldest_timestamp_global = use_signal(|| None::<u64>);

--- a/src/routes/videos_live_tag.rs
+++ b/src/routes/videos_live_tag.rs
@@ -29,7 +29,7 @@ impl Drop for ScrollListenerGuard {
 
 #[component]
 pub fn VideosLiveTag(tag: String) -> Element {
-    let mut stream_events = use_signal(|| Vec::<Event>::new());
+    let mut stream_events = use_signal(Vec::<Event>::new);
     let mut loading = use_signal(|| false);
     let mut refresh_trigger = use_signal(|| 0);
     let mut has_more = use_signal(|| true);

--- a/src/routes/voice_message_detail.rs
+++ b/src/routes/voice_message_detail.rs
@@ -11,7 +11,7 @@ pub fn VoiceMessageDetail(voice_id: String) -> Element {
     let mut voice_event = use_signal(|| None::<Event>);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
-    let mut replies = use_signal(|| Vec::<Event>::new());
+    let mut replies = use_signal(Vec::<Event>::new);
     let mut loading_replies = use_signal(|| false);
     let mut show_voice_reply_composer = use_signal(|| false);
 

--- a/src/routes/voice_message_new.rs
+++ b/src/routes/voice_message_new.rs
@@ -6,7 +6,7 @@ use crate::components::VoiceRecorder;
 pub fn VoiceMessageNew() -> Element {
     let navigator = navigator();
     let mut audio_data = use_signal(|| None::<(Vec<u8>, f64, Vec<u8>, String)>); // (bytes, duration, waveform, mime_type)
-    let mut hashtags = use_signal(|| String::new());
+    let mut hashtags = use_signal(String::new);
     let mut is_publishing = use_signal(|| false);
     let mut error_message = use_signal(|| Option::<String>::None);
 

--- a/src/routes/voicemessages.rs
+++ b/src/routes/voicemessages.rs
@@ -23,7 +23,7 @@ impl FeedType {
 #[component]
 pub fn VoiceMessages() -> Element {
     // State for feed events
-    let mut events = use_signal(|| Vec::<Event>::new());
+    let mut events = use_signal(Vec::<Event>::new);
     let mut loading = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
     let mut refresh_trigger = use_signal(|| 0);

--- a/src/routes/webbookmarks.rs
+++ b/src/routes/webbookmarks.rs
@@ -57,7 +57,7 @@ impl SortOrder {
 #[component]
 pub fn WebBookmarks() -> Element {
     // State for feed events
-    let mut bookmarks = use_signal(|| Vec::<Event>::new());
+    let mut bookmarks = use_signal(Vec::<Event>::new);
     let mut loading = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
     let mut refresh_trigger = use_signal(|| 0);
@@ -67,7 +67,7 @@ pub fn WebBookmarks() -> Element {
     // Filter and sort state
     let mut filter_tab = use_signal(|| FilterTab::All);
     let mut sort_order = use_signal(|| SortOrder::DateAdded);
-    let mut search_query = use_signal(|| String::new());
+    let mut search_query = use_signal(String::new);
     let mut selected_tag = use_signal(|| Option::<String>::None);
 
     // Modal state
@@ -76,7 +76,7 @@ pub fn WebBookmarks() -> Element {
     let mut editing_event = use_signal(|| Option::<Event>::None);
 
     // Quick-add state
-    let mut quick_url = use_signal(|| String::new());
+    let mut quick_url = use_signal(String::new);
     let mut quick_adding = use_signal(|| false);
 
     // Pagination state for infinite scroll
@@ -445,7 +445,7 @@ pub fn WebBookmarks() -> Element {
                             value: "{quick_url}",
                             oninput: move |evt| quick_url.set(evt.value().clone()),
                             onkeypress: {
-                                let mut handle_quick = handle_quick_add.clone();
+                                let mut handle_quick = handle_quick_add;
                                 move |evt: dioxus::prelude::Event<KeyboardData>| {
                                     if evt.key() == Key::Enter {
                                         handle_quick(());
@@ -456,7 +456,7 @@ pub fn WebBookmarks() -> Element {
                         button {
                             class: "px-4 py-2 text-sm bg-secondary text-secondary-foreground rounded-lg hover:bg-secondary/90 transition disabled:opacity-50",
                             onclick: {
-                                let mut handle_quick = handle_quick_add.clone();
+                                let mut handle_quick = handle_quick_add;
                                 move |_| handle_quick(())
                             },
                             disabled: *quick_adding.read() || quick_url.read().trim().is_empty(),

--- a/src/routes/wiki.rs
+++ b/src/routes/wiki.rs
@@ -12,7 +12,7 @@ use crate::stores::wiki_store::CachedWikiPage;
 pub fn WikiHome() -> Element {
     let mut loading = use_signal(|| true);
     let mut searching = use_signal(|| false);
-    let mut pages = use_signal(|| Vec::new());
+    let mut pages = use_signal(Vec::new);
     let mut search_results = use_signal(|| None::<Vec<CachedWikiPage>>);
     let mut search_query = use_signal(String::new);
     let mut committed_query = use_signal(String::new);

--- a/src/routes/wiki_author.rs
+++ b/src/routes/wiki_author.rs
@@ -13,7 +13,7 @@ use crate::routes::Route;
 pub fn WikiAuthor(pubkey: String) -> Element {
     let nav = use_navigator();
     let mut loading = use_signal(|| true);
-    let mut pages = use_signal(|| Vec::<CachedWikiPage>::new());
+    let mut pages = use_signal(Vec::<CachedWikiPage>::new);
     let mut error = use_signal(|| None::<String>);
 
     // Get author profile

--- a/src/routes/wiki_detail.rs
+++ b/src/routes/wiki_detail.rs
@@ -353,7 +353,7 @@ fn BacklinksCollapsiblePanel(
 fn MergeRequestsPanel(a_tag: String) -> Element {
     let mut is_expanded = use_signal(|| false);
     let mut is_loading = use_signal(|| false);
-    let mut merge_requests = use_signal(|| Vec::<WikiMergeRequest>::new());
+    let mut merge_requests = use_signal(Vec::<WikiMergeRequest>::new);
     let mut has_fetched = use_signal(|| false);
 
     // Fetch merge requests when expanded for the first time

--- a/src/services/aggregation.rs
+++ b/src/services/aggregation.rs
@@ -1,20 +1,20 @@
-/// Event interaction aggregation service
-///
-/// Provides batch fetching of interaction counts (replies, likes, reposts, zaps)
-/// for multiple events in a single query. This dramatically reduces database
-/// queries compared to fetching counts per-event.
-///
-/// # Performance Impact
-/// - Before: N queries (one per event in feed)
-/// - After: 1 query (batched for all events)
-/// - Example: 100 notes → 99% reduction in queries (100 → 1)
-///
-/// # L2 Caching (Phase 3.5)
-/// Implements in-memory LRU cache for computed interaction counts:
-/// - Cache size: 1000 events
-/// - TTL: 5 minutes per entry
-/// - Automatic eviction of stale/excess entries
-/// - Reduces redundant database queries for recently-viewed events
+//! Event interaction aggregation service
+//!
+//! Provides batch fetching of interaction counts (replies, likes, reposts, zaps)
+//! for multiple events in a single query. This dramatically reduces database
+//! queries compared to fetching counts per-event.
+//!
+//! # Performance Impact
+//! - Before: N queries (one per event in feed)
+//! - After: 1 query (batched for all events)
+//! - Example: 100 notes → 99% reduction in queries (100 → 1)
+//!
+//! # L2 Caching (Phase 3.5)
+//! Implements in-memory LRU cache for computed interaction counts:
+//! - Cache size: 1000 events
+//! - TTL: 5 minutes per entry
+//! - Automatic eviction of stale/excess entries
+//! - Reduces redundant database queries for recently-viewed events
 
 use dioxus::prelude::ReadableExt;
 use lru::LruCache;

--- a/src/services/btc_price.rs
+++ b/src/services/btc_price.rs
@@ -17,7 +17,7 @@ pub struct CoinGeckoResponse {
 
 /// Cached BTC prices by currency (USD, EUR, GBP, etc.)
 pub static BTC_PRICES: GlobalSignal<HashMap<String, f64>> =
-    Signal::global(|| HashMap::new());
+    Signal::global(HashMap::new);
 
 /// Last fetch timestamp (unix seconds)
 pub static PRICE_LAST_FETCH: GlobalSignal<u64> = Signal::global(|| 0);

--- a/src/services/geocoding.rs
+++ b/src/services/geocoding.rs
@@ -182,7 +182,7 @@ async fn query_photon(query: &str) -> Result<Option<GeoLocation>, String> {
         .await
         .map_err(|e| format!("Failed to parse geocode response: {}", e))?;
 
-    Ok(photon.features.first().map(|f| feature_to_location(f)))
+    Ok(photon.features.first().map(feature_to_location))
 }
 
 /// Convert Photon feature to GeoLocation

--- a/src/services/git_hosting/github_import.rs
+++ b/src/services/git_hosting/github_import.rs
@@ -57,7 +57,7 @@ pub fn parse_github_url(url: &str) -> Option<(String, String)> {
 
     if url.contains("github.com") {
         let parts: Vec<&str> = url
-            .split(|c| c == '/' || c == ':')
+            .split(['/', ':'])
             .filter(|s| !s.is_empty() && *s != "https" && *s != "http" && *s != "git@github.com" && *s != "github.com")
             .collect();
 

--- a/src/services/podcast_rss.rs
+++ b/src/services/podcast_rss.rs
@@ -402,11 +402,10 @@ pub fn parse_podcast_feed(xml: &str, feed_url: &str) -> Result<RssPodcast, Strin
                             ep.description = Some(text);
                         }
                     }
-                } else if in_channel {
-                    if current_element == "description" || current_element == "content:encoded" {
+                } else if in_channel
+                    && (current_element == "description" || current_element == "content:encoded") {
                         podcast.description = Some(text);
                     }
-                }
             }
             Ok(Event::Eof) => break,
             Err(e) => return Err(format!("XML parsing error: {}", e)),

--- a/src/services/profile_search.rs
+++ b/src/services/profile_search.rs
@@ -296,9 +296,7 @@ pub async fn get_user_relays() -> Vec<String> {
 
     // Get connected relays from the pool
     let relays = client.pool().relays().await;
-    let relay_urls: Vec<String> = relays
-        .into_iter()
-        .map(|(url, _)| url.to_string())
+    let relay_urls: Vec<String> = relays.into_keys().map(|url| url.to_string())
         .take(3) // Limit to 3 relay hints
         .collect();
 

--- a/src/stores/auth_store.rs
+++ b/src/stores/auth_store.rs
@@ -18,6 +18,7 @@ use nostr_sdk::nips::nip46::NostrConnectURI;
 
 /// Authentication state
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default)]
 pub struct AuthState {
     pub pubkey: Option<String>,
     pub is_authenticated: bool,
@@ -32,15 +33,6 @@ pub enum LoginMethod {
     RemoteSigner,      // NIP-46 (nostr-connect)
 }
 
-impl Default for AuthState {
-    fn default() -> Self {
-        Self {
-            pubkey: None,
-            is_authenticated: false,
-            login_method: None,
-        }
-    }
-}
 
 /// Global authentication state
 pub static AUTH_STATE: GlobalSignal<AuthState> = Signal::global(AuthState::default);
@@ -531,7 +523,7 @@ pub fn sign_message(message: &str) -> Result<String, String> {
 /// Export private key as nsec
 pub fn export_nsec() -> Result<String, String> {
     let keys = get_keys().ok_or("Not logged in with private key")?;
-    Ok(keys.secret_key().to_bech32().map_err(|e| e.to_string())?)
+    keys.secret_key().to_bech32().map_err(|e| e.to_string())
 }
 
 /// Export public key as npub

--- a/src/stores/cashu/auth.rs
+++ b/src/stores/cashu/auth.rs
@@ -38,7 +38,7 @@ pub use cdk_common::{
 
 /// Global cache for mint auth states
 pub static MINT_AUTH_STATES: GlobalSignal<HashMap<String, MintAuthState>> =
-    GlobalSignal::new(|| HashMap::new());
+    GlobalSignal::new(HashMap::new);
 
 /// Get auth state for a mint (from cache)
 pub fn get_mint_auth_state(mint_url: &str) -> Option<MintAuthState> {

--- a/src/stores/cashu/cache.rs
+++ b/src/stores/cashu/cache.rs
@@ -508,7 +508,7 @@ pub fn parse_cache_control(header: Option<&str>) -> Option<u64> {
             let part = part.trim();
             if let Some(rest) = part.strip_prefix("max-age") {
                 // Handle "max-age=123", "max-age = 123", "max-age=\"123\""
-                let rest = rest.trim_start_matches(|c| c == '=' || c == ' ' || c == '"');
+                let rest = rest.trim_start_matches(['=', ' ', '"']);
                 let rest = rest.trim_end_matches('"');
                 if let Ok(val) = rest.parse::<u64>() {
                     return Some(val);

--- a/src/stores/cashu/dust.rs
+++ b/src/stores/cashu/dust.rs
@@ -199,7 +199,7 @@ pub async fn consolidate_dust(
         .swap(
             None, // Swap all
             SplitTarget::default(),
-            cdk_proofs.into(),
+            cdk_proofs,
             None,  // No spending conditions
             false, // Don't include fee in output
         )

--- a/src/stores/cashu/events.rs
+++ b/src/stores/cashu/events.rs
@@ -303,12 +303,12 @@ pub async fn fetch_tokens() -> Result<(), String> {
     // Build deletion filter with since if incremental
     let deletion_filter = if is_incremental {
         Filter::new()
-            .author(pubkey.clone())
+            .author(pubkey)
             .kind(Kind::from(5))
             .since(Timestamp::from(last_sync_ts))
     } else {
         Filter::new()
-            .author(pubkey.clone())
+            .author(pubkey)
             .kind(Kind::from(5))
     };
 

--- a/src/stores/cashu/fees.rs
+++ b/src/stores/cashu/fees.rs
@@ -156,7 +156,7 @@ pub async fn estimate_p2pk_send_fee(
     let witness_fee = if witness_size > 0 {
         // Estimate 1 sat per 100 bytes of witness data per proof
         // Use ceiling division: (n + 99) / 100 rounds up
-        let fee_per_proof = ((witness_size + 99) / 100).max(1) as u64;
+        let fee_per_proof = witness_size.div_ceil(100).max(1) as u64;
         fee_per_proof * proof_count as u64
     } else {
         0
@@ -209,7 +209,7 @@ pub async fn estimate_p2pk_receive_fee(
         // Assume single-sig P2PK if witness present
         // Use ceiling division: (n + 99) / 100 rounds up
         let witness_size = P2PK_WITNESS_OVERHEAD;
-        ((witness_size + 99) / 100).max(1) as u64 * proof_count as u64
+        witness_size.div_ceil(100).max(1) as u64 * proof_count as u64
     } else {
         0
     };

--- a/src/stores/cashu/history.rs
+++ b/src/stores/cashu/history.rs
@@ -100,7 +100,7 @@ pub async fn fetch_history() -> Result<(), String> {
 
                                 for pair in pairs {
                                     // Use safe indexing with .get() for defensive parsing
-                                    let key = match pair.get(0) {
+                                    let key = match pair.first() {
                                         Some(k) => k.as_str(),
                                         None => continue,
                                     };

--- a/src/stores/cashu/init.rs
+++ b/src/stores/cashu/init.rs
@@ -168,7 +168,7 @@ pub async fn init_wallet() -> Result<(), String> {
                         *WALLET_STATE.write() = Some(WalletState {
                             privkey: Some(wallet_data.privkey.clone()),
                             // Normalize mint URLs on load to ensure consistent lookups
-                            mints: wallet_data.mints.iter().map(|u| normalize_mint_url(&u.to_string())).collect(),
+                            mints: wallet_data.mints.iter().map(|u| normalize_mint_url(u.as_ref())).collect(),
                             initialized: true,
                         });
 

--- a/src/stores/cashu/internal.rs
+++ b/src/stores/cashu/internal.rs
@@ -316,7 +316,7 @@ pub(crate) async fn validate_proofs_with_mint(
 
     // NUT-07: Check proof states with mint
     let states = wallet
-        .check_proofs_spent(proofs.clone().into())
+        .check_proofs_spent(proofs.clone())
         .await
         .map_err(|e| format!("Failed to check proof states: {}", e))?;
 
@@ -390,7 +390,7 @@ pub(crate) async fn cleanup_spent_proofs_internal(mint_url: &str) -> Result<(usi
             .collect();
 
         let cdk_proofs: Result<Vec<_>, _> =
-            all_proofs.iter().map(|p| proof_data_to_cdk_proof(p)).collect();
+            all_proofs.iter().map(proof_data_to_cdk_proof).collect();
 
         (cdk_proofs?, event_ids, all_proofs)
     };

--- a/src/stores/cashu/keyset.rs
+++ b/src/stores/cashu/keyset.rs
@@ -335,7 +335,7 @@ pub async fn migrate_inactive_proofs(mint_url: &str) -> Result<KeysetMigrationRe
     let swap_result = wallet.swap(
         None, // No specific amount, swap all
         SplitTarget::default(),
-        cdk_proofs.clone().into(),
+        cdk_proofs.clone(),
         None, // No spending conditions
         true, // Include fee
     ).await

--- a/src/stores/cashu/lightning.rs
+++ b/src/stores/cashu/lightning.rs
@@ -187,7 +187,7 @@ pub async fn mint_tokens_from_quote(mint_url: String, quote_id: String) -> Resul
     log::info!("Minted {} sats", amount_minted);
 
     // Convert to ProofData
-    let proof_data: Vec<ProofData> = proofs.iter().map(|p| cdk_proof_to_proof_data(p)).collect();
+    let proof_data: Vec<ProofData> = proofs.iter().map(cdk_proof_to_proof_data).collect();
 
     // Create token event
     let extended_proofs: Vec<ExtendedCashuProof> = proof_data
@@ -646,7 +646,7 @@ async fn publish_melt_events(
 
     // Publish token event with remaining proofs
     if !keep_proofs.is_empty() {
-        let proof_data: Vec<ProofData> = keep_proofs.iter().map(|p| cdk_proof_to_proof_data(p)).collect();
+        let proof_data: Vec<ProofData> = keep_proofs.iter().map(cdk_proof_to_proof_data).collect();
 
         let extended_proofs: Vec<ExtendedCashuProof> = proof_data
             .iter()
@@ -737,7 +737,7 @@ fn update_local_state_after_melt(
 
     // Add new token with remaining proofs
     if let Some(ref event_id) = new_event_id {
-        let proof_data: Vec<ProofData> = keep_proofs.iter().map(|p| cdk_proof_to_proof_data(p)).collect();
+        let proof_data: Vec<ProofData> = keep_proofs.iter().map(cdk_proof_to_proof_data).collect();
 
         tokens_write.push(TokenData {
             event_id: event_id.clone(),

--- a/src/stores/cashu/mint_mgmt.rs
+++ b/src/stores/cashu/mint_mgmt.rs
@@ -79,9 +79,7 @@ pub async fn check_keyset_collision(new_mint_url: &str) -> Result<Vec<KeysetColl
                 // Extract keyset ID from proof if available
                 // The proof's `id` field contains the keyset ID
                 if let Some(keyset_id) = extract_keyset_id_from_proof(proof) {
-                    if !existing_keyset_to_mint.contains_key(&keyset_id) {
-                        existing_keyset_to_mint.insert(keyset_id, token.mint.clone());
-                    }
+                    existing_keyset_to_mint.entry(keyset_id).or_insert_with(|| token.mint.clone());
                 }
             }
         }
@@ -953,7 +951,7 @@ pub async fn consolidate_proofs(mint_url: String) -> Result<ConsolidationResult,
 
     // Convert new proofs to ProofData
     let proof_data: Vec<ProofData> = new_proofs.iter()
-        .map(|p| cdk_proof_to_proof_data(p))
+        .map(cdk_proof_to_proof_data)
         .collect();
 
     // Create extended proofs for NIP-60 event

--- a/src/stores/cashu/mpp.rs
+++ b/src/stores/cashu/mpp.rs
@@ -31,7 +31,7 @@ use crate::stores::{auth_store, nostr_client};
 
 /// Cache for mint MPP support: mint_url -> (timestamp_ms, supports_mpp)
 /// TTL is 5 minutes (300,000 ms)
-pub static MINT_MPP_CACHE: GlobalSignal<HashMap<String, (f64, bool)>> = Signal::global(|| HashMap::new());
+pub static MINT_MPP_CACHE: GlobalSignal<HashMap<String, (f64, bool)>> = Signal::global(HashMap::new);
 pub const MINT_INFO_CACHE_TTL_MS: f64 = 300_000.0; // 5 minutes
 
 // =============================================================================
@@ -354,7 +354,7 @@ pub async fn execute_mpp_melt(
             if let Some(proofs) = remaining_proofs.get(&mint_url_parsed) {
                 if !proofs.is_empty() {
                     let proof_data: Vec<ProofData> = proofs.iter()
-                        .map(|p| cdk_proof_to_proof_data(p))
+                        .map(cdk_proof_to_proof_data)
                         .collect();
 
                     let extended_proofs: Vec<ExtendedCashuProof> = proof_data.iter()

--- a/src/stores/cashu/pagination.rs
+++ b/src/stores/cashu/pagination.rs
@@ -253,7 +253,7 @@ impl ProofPaginator {
 
     /// Get number of batches
     pub fn batch_count(&self) -> usize {
-        (self.proofs.len() + self.batch_size - 1) / self.batch_size
+        self.proofs.len().div_ceil(self.batch_size)
     }
 
     /// Get current batch index

--- a/src/stores/cashu/receive.rs
+++ b/src/stores/cashu/receive.rs
@@ -291,7 +291,7 @@ pub async fn receive_tokens_with_options(
         .map_err(|e| format!("Failed to get proofs: {}", e))?;
 
     // Convert to ProofData
-    let proof_data: Vec<ProofData> = new_proofs.iter().map(|p| cdk_proof_to_proof_data(p)).collect();
+    let proof_data: Vec<ProofData> = new_proofs.iter().map(cdk_proof_to_proof_data).collect();
 
     // Create extended token event with P2PK support
     let extended_proofs: Vec<ExtendedCashuProof> = proof_data

--- a/src/stores/cashu/recovery.rs
+++ b/src/stores/cashu/recovery.rs
@@ -517,7 +517,7 @@ pub async fn recover_mint_quote(mint_url: &str, quote_id: &str) -> CashuResult<R
             let proofs = wallet
                 .mint(quote_id, cdk::amount::SplitTarget::default(), None)
                 .await
-                .map_err(|e| super::errors::CashuWalletError::Cdk(e))?;
+                .map_err(super::errors::CashuWalletError::Cdk)?;
 
             let amount: u64 = proofs
                 .iter()
@@ -628,7 +628,7 @@ async fn recover_unrecorded_proofs(mint_url: &str) -> CashuResult<RecoveryResult
     let cdk_proofs = wallet
         .get_unspent_proofs()
         .await
-        .map_err(|e| super::errors::CashuWalletError::Cdk(e))?;
+        .map_err(super::errors::CashuWalletError::Cdk)?;
 
     // Get our known proof secrets
     let known_proofs = get_all_proofs_for_mint(mint_url);
@@ -1187,7 +1187,7 @@ pub async fn process_pending_mint_quotes() -> Result<(usize, usize, u64), String
         let _ = cashu_cdk_bridge::sync_wallet_state().await;
     }
 
-    Ok((checked, paid, total_minted as u64))
+    Ok((checked, paid, total_minted))
 }
 
 /// Check and process all pending melt quotes

--- a/src/stores/cashu/send.rs
+++ b/src/stores/cashu/send.rs
@@ -629,7 +629,7 @@ async fn publish_send_events(
 
     // Publish token event with remaining proofs
     if !keep_proofs.is_empty() {
-        let proof_data: Vec<ProofData> = keep_proofs.iter().map(|p| cdk_proof_to_proof_data(p)).collect();
+        let proof_data: Vec<ProofData> = keep_proofs.iter().map(cdk_proof_to_proof_data).collect();
 
         let extended_proofs: Vec<ExtendedCashuProof> = proof_data
             .iter()
@@ -740,7 +740,7 @@ fn update_local_state_after_send(
     // Add new token with remaining proofs
     if let Some(ref event_id) = new_event_id {
         let keep_proof_data: Vec<ProofData> =
-            keep_proofs.iter().map(|p| cdk_proof_to_proof_data(p)).collect();
+            keep_proofs.iter().map(cdk_proof_to_proof_data).collect();
 
         tokens_write.push(TokenData {
             event_id: event_id.clone(),

--- a/src/stores/cashu/signals.rs
+++ b/src/stores/cashu/signals.rs
@@ -36,7 +36,7 @@ pub static WALLET_STATUS: GlobalSignal<WalletStatus> =
 
 /// Global signal for detailed balance breakdown
 pub static WALLET_BALANCES: GlobalSignal<WalletBalances> =
-    Signal::global(|| WalletBalances::default());
+    Signal::global(WalletBalances::default);
 
 /// Global signal for terms acceptance status
 /// None = not yet checked, Some(true) = accepted, Some(false) = not accepted
@@ -49,17 +49,17 @@ pub static TERMS_ACCEPTED: GlobalSignal<Option<bool>> = Signal::global(|| None);
 /// Operation lock to prevent concurrent wallet operations on the same mint
 /// Uses GlobalSignal with HashSet to track mints currently being operated on
 pub static MINT_OPERATION_LOCK: GlobalSignal<HashSet<String>> =
-    Signal::global(|| HashSet::new());
+    Signal::global(HashSet::new);
 
 /// Proof-to-EventId mapping for fast lookup of which Nostr event contains each proof
 /// Key: proof secret, Value: event_id of the token event containing this proof
 /// This enables correct deletion events when spending proofs
 pub static PROOF_EVENT_MAP: GlobalSignal<HashMap<String, String>> =
-    Signal::global(|| HashMap::new());
+    Signal::global(HashMap::new);
 
 /// Global signal for active transactions (local-only tracking)
 pub static ACTIVE_TRANSACTIONS: GlobalSignal<Vec<ActiveTransaction>> =
-    Signal::global(|| Vec::new());
+    Signal::global(Vec::new);
 
 /// Proof secrets that the mint has reported as PENDING state
 /// Different from local pending (is_pending flag) - this tracks proofs
@@ -68,7 +68,7 @@ pub static ACTIVE_TRANSACTIONS: GlobalSignal<Vec<ActiveTransaction>> =
 /// CDK best practice: Track timestamps for TTL cleanup to prevent stale entries
 /// Key: proof secret, Value: timestamp when registered (seconds since epoch)
 pub static PENDING_BY_MINT_SECRETS: GlobalSignal<HashMap<String, u64>> =
-    Signal::global(|| HashMap::new());
+    Signal::global(HashMap::new);
 
 // =============================================================================
 // Sync State Signals
@@ -94,7 +94,7 @@ pub static SHARED_LOCALSTORE: GlobalSignal<
 
 /// Pending Nostr events (offline queue)
 pub static PENDING_NOSTR_EVENTS: GlobalSignal<Vec<PendingNostrEvent>> =
-    Signal::global(|| Vec::new());
+    Signal::global(Vec::new);
 
 /// Global signal for pending mint quotes (lightning receive)
 pub static PENDING_MINT_QUOTES: GlobalSignal<Store<PendingMintQuotesStore>> =
@@ -120,7 +120,7 @@ pub static PAYMENT_REQUEST_PROGRESS: GlobalSignal<Option<PaymentRequestProgress>
 
 /// Global signal for pending payment requests waiting for payment
 pub static PENDING_PAYMENT_REQUESTS: GlobalSignal<HashMap<String, NostrPaymentWaitInfo>> =
-    Signal::global(|| HashMap::new());
+    Signal::global(HashMap::new);
 
 // =============================================================================
 // Counter Backup Signal
@@ -129,7 +129,7 @@ pub static PENDING_PAYMENT_REQUESTS: GlobalSignal<HashMap<String, NostrPaymentWa
 /// Counter backups for mint removal/re-addition
 /// When a mint is removed, its proof counters are backed up here
 /// When the same mint is re-added, counters are restored
-pub static COUNTER_BACKUPS: GlobalSignal<Vec<CounterBackup>> = Signal::global(|| Vec::new());
+pub static COUNTER_BACKUPS: GlobalSignal<Vec<CounterBackup>> = Signal::global(Vec::new);
 
 // =============================================================================
 // Constants

--- a/src/stores/cashu/swap.rs
+++ b/src/stores/cashu/swap.rs
@@ -132,7 +132,7 @@ pub async fn execute_swap(
         .swap(
             amount,
             split_target,
-            cdk_proofs.into(),
+            cdk_proofs,
             options.conditions,
             options.include_fee,
         )

--- a/src/stores/cashu/token.rs
+++ b/src/stores/cashu/token.rs
@@ -95,7 +95,7 @@ pub fn get_token_info(token_str: &str) -> Result<TokenInfo, String> {
 
     let value = token.value()
         .ok()
-        .map(|a| u64::from(a));
+        .map(u64::from);
 
     let unit = token.unit()
         .map(|u| u.to_string());
@@ -140,7 +140,7 @@ pub fn create_token(
     // CDK's Token::new() creates V4 format by default
     let token = Token::new(
         mint_url,
-        proofs.into(),
+        proofs,
         memo,
         CurrencyUnit::Sat,
     );

--- a/src/stores/cashu/utils.rs
+++ b/src/stores/cashu/utils.rs
@@ -98,7 +98,7 @@ pub async fn validate_proofs_batched(
         );
 
         // Check proof states with mint (NUT-07)
-        let states = match wallet.check_proofs_spent(batch.to_vec().into()).await {
+        let states = match wallet.check_proofs_spent(batch.to_vec()).await {
             Ok(s) => s,
             Err(e) => {
                 log::warn!("Failed to check proof states for batch {}: {}", batch_idx, e);

--- a/src/stores/cashu_cdk_bridge.rs
+++ b/src/stores/cashu_cdk_bridge.rs
@@ -40,7 +40,7 @@ pub struct WalletBalances {
 }
 
 /// Global signal for balance breakdown
-pub static WALLET_BALANCES: GlobalSignal<WalletBalances> = Signal::global(|| WalletBalances::default());
+pub static WALLET_BALANCES: GlobalSignal<WalletBalances> = Signal::global(WalletBalances::default);
 
 /// Initialize the MultiMintWallet with the given seed and localstore
 pub async fn init_multi_wallet(

--- a/src/stores/citation_store.rs
+++ b/src/stores/citation_store.rs
@@ -314,7 +314,7 @@ pub async fn fetch_citations_by_type(
         Ok(events) => {
             let citations: Vec<CachedCitation> = events
                 .iter()
-                .filter_map(|e| parse_citation_event(e))
+                .filter_map(parse_citation_event)
                 .collect();
 
             cache_citations(&citations);
@@ -566,7 +566,7 @@ pub async fn publish_internal_citation(
 
     // Generate d-tag from title or address
     let d_tag = title
-        .map(|t| crate::utils::nip54::normalize_wiki_dtag(t))
+        .map(crate::utils::nip54::normalize_wiki_dtag)
         .unwrap_or_else(|| format!("citation-{}", &cited_address[..8.min(cited_address.len())]));
 
     let mut tags: Vec<Tag> = vec![
@@ -615,7 +615,7 @@ pub async fn publish_external_citation(
     }
 
     let d_tag = title
-        .map(|t| crate::utils::nip54::normalize_wiki_dtag(t))
+        .map(crate::utils::nip54::normalize_wiki_dtag)
         .unwrap_or_else(|| format!("web-{}", &url[..20.min(url.len())].replace([':', '/'], "-")));
 
     let mut tags: Vec<Tag> = vec![

--- a/src/stores/community_store.rs
+++ b/src/stores/community_store.rs
@@ -754,7 +754,7 @@ pub async fn fetch_communities(limit: usize) -> std::result::Result<Vec<Communit
         Ok(events) => {
             let communities: Vec<Community> = events
                 .iter()
-                .filter_map(|e| parse_community_event(e))
+                .filter_map(parse_community_event)
                 .collect();
 
             // Cache communities
@@ -860,7 +860,7 @@ pub async fn fetch_community_posts(
         let mut approvals_cache = APPROVALS_CACHE.write();
         for event in &approval_events {
             if let Some((post_id, approval)) = parse_approval_event(event) {
-                approvals_cache.entry(post_id).or_insert_with(Vec::new).push(approval);
+                approvals_cache.entry(post_id).or_default().push(approval);
             }
         }
     }
@@ -1193,11 +1193,10 @@ pub async fn fetch_user_communities(user_pubkey: &str) -> std::result::Result<Ve
     for event in mod_events.into_iter() {
         if let Some(community) = parse_community_event(&event) {
             // Verify user is actually a moderator (has p-tag with "moderator" role)
-            if community.moderators.iter().any(|m| m.to_lowercase() == user_pk_str) {
-                if seen.insert(community.a_tag.clone()) {
+            if community.moderators.iter().any(|m| m.to_lowercase() == user_pk_str)
+                && seen.insert(community.a_tag.clone()) {
                     communities.push(community);
                 }
-            }
         }
     }
 

--- a/src/stores/directory_store.rs
+++ b/src/stores/directory_store.rs
@@ -566,7 +566,7 @@ pub async fn fetch_drives(limit: usize, until: Option<u64>) -> StdResult<Vec<Dri
         Ok(events) => {
             let drives: Vec<DriveEvent> = events
                 .iter()
-                .filter_map(|e| parse_drive_event(e))
+                .filter_map(parse_drive_event)
                 .collect();
 
             cache_drives(&drives);
@@ -680,7 +680,7 @@ pub async fn fetch_drives_by_author(pubkey_hex: &str, limit: usize) -> StdResult
         Ok(events) => {
             let drives: Vec<DriveEvent> = events
                 .iter()
-                .filter_map(|e| parse_drive_event(e))
+                .filter_map(parse_drive_event)
                 .collect();
 
             cache_drives(&drives);

--- a/src/stores/dms.rs
+++ b/src/stores/dms.rs
@@ -250,7 +250,7 @@ pub async fn init_dms() -> Result<(), String> {
                     .cloned();
 
                 if let Some(other_pk) = other_pubkey {
-                    let group_id_hex = hex::encode(&group.nostr_group_id);
+                    let group_id_hex = hex::encode(group.nostr_group_id);
                     let mls_messages = mdk_store::get_messages(&group_id_hex);
 
                     log::info!("Integrating {} MLS messages from 1:1 group with {}",
@@ -286,7 +286,7 @@ pub async fn init_dms() -> Result<(), String> {
 
     // Sort messages in each conversation by timestamp (uses actual rumor timestamp for NIP-17)
     for conversation in conversations.values_mut() {
-        conversation.messages.sort_by(|a, b| a.created_at().cmp(&b.created_at()));
+        conversation.messages.sort_by_key(|a| a.created_at());
     }
 
     log::info!("Organized into {} conversations", conversations.len());

--- a/src/stores/embedding_store.rs
+++ b/src/stores/embedding_store.rs
@@ -135,7 +135,7 @@ pub fn cache_embeddings(source_event_id: &str, embeddings: Vec<EmbeddingEvent>) 
 /// Add a single embedding to cache
 pub fn add_embedding_to_cache(embedding: EmbeddingEvent) {
     let mut cache = EMBEDDINGS_CACHE.write();
-    let entry = cache.entry(embedding.source_event_id.clone()).or_insert_with(Vec::new);
+    let entry = cache.entry(embedding.source_event_id.clone()).or_default();
 
     // Don't add duplicates
     if !entry.iter().any(|e| e.event_id == embedding.event_id) {
@@ -307,7 +307,7 @@ pub async fn fetch_embeddings_for_event(source_event_id: &str) -> StdResult<Vec<
         Ok(events) => {
             let embeddings: Vec<EmbeddingEvent> = events
                 .iter()
-                .filter_map(|e| parse_embedding_event(e))
+                .filter_map(parse_embedding_event)
                 .collect();
 
             cache_embeddings(source_event_id, embeddings.clone());
@@ -341,7 +341,7 @@ pub async fn fetch_embeddings_by_author(pubkey_hex: &str, limit: usize) -> StdRe
         Ok(events) => {
             let embeddings: Vec<EmbeddingEvent> = events
                 .iter()
-                .filter_map(|e| parse_embedding_event(e))
+                .filter_map(parse_embedding_event)
                 .collect();
 
             // Cache each embedding

--- a/src/stores/indexeddb_database.rs
+++ b/src/stores/indexeddb_database.rs
@@ -39,9 +39,7 @@
 
 // This module is only fully implemented for wasm32 targets
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports, unused_variables))]
-
-// Allow dead_code for keyset counter methods not yet wired to UI
-#![allow(dead_code)]
+#![cfg_attr(target_arch = "wasm32", allow(dead_code))]
 
 // ============================================================================
 // Native stub (non-wasm32)
@@ -70,8 +68,7 @@ mod native_stub {
 
     impl IndexedDbDatabase {
         fn make_error(msg: String) -> database::Error {
-            database::Error::Database(Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            database::Error::Database(Box::new(std::io::Error::other(
                 msg,
             )))
         }

--- a/src/stores/mdk_store.rs
+++ b/src/stores/mdk_store.rs
@@ -59,10 +59,10 @@ pub struct MlsMessage {
 static MDK_INSTANCE: RwLock<Option<MDK<MdkMemoryStorage>>> = RwLock::new(None);
 
 /// Active MLS groups cache
-pub static MLS_GROUPS: GlobalSignal<HashMap<String, MlsGroupInfo>> = Signal::global(|| HashMap::new());
+pub static MLS_GROUPS: GlobalSignal<HashMap<String, MlsGroupInfo>> = Signal::global(HashMap::new);
 
 /// MLS messages by group (nostr_group_id hex -> messages)
-pub static MLS_MESSAGES: GlobalSignal<HashMap<String, Vec<MlsMessage>>> = Signal::global(|| HashMap::new());
+pub static MLS_MESSAGES: GlobalSignal<HashMap<String, Vec<MlsMessage>>> = Signal::global(HashMap::new);
 
 /// Whether MDK has been initialized
 pub static MDK_INITIALIZED: GlobalSignal<bool> = Signal::global(|| false);
@@ -416,7 +416,7 @@ pub async fn create_mls_group(
     }
 
     // Update cache
-    let group_id_hex = hex::encode(&group_info.nostr_group_id);
+    let group_id_hex = hex::encode(group_info.nostr_group_id);
     MLS_GROUPS.write().insert(group_id_hex, group_info.clone());
 
     log::info!("Created MLS group: {}", name);
@@ -448,7 +448,7 @@ pub fn process_mls_message(event: &SdkEvent) -> Result<Option<MlsMessage>, Strin
             let group_id_hex = hex::encode(msg.mls_group_id.as_slice());
             MLS_MESSAGES.write()
                 .entry(group_id_hex)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(mls_msg.clone());
 
             Ok(Some(mls_msg))
@@ -519,7 +519,7 @@ pub async fn send_mls_message(
 
         MLS_MESSAGES.write()
             .entry(hex::encode(ngid))
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(msg);
     }
 
@@ -618,7 +618,7 @@ pub fn process_welcome(
     };
 
     // Add to cache
-    let group_id_hex = hex::encode(&group_info.nostr_group_id);
+    let group_id_hex = hex::encode(group_info.nostr_group_id);
     MLS_GROUPS.write().insert(group_id_hex, group_info.clone());
 
     log::info!("Joined MLS group via welcome: {}", welcome.group_name);

--- a/src/stores/nostr_client.rs
+++ b/src/stores/nostr_client.rs
@@ -908,7 +908,7 @@ pub async fn publish_contacts(contacts: Vec<String>) -> std::result::Result<Stri
             PublicKey::from_hex(&contact_str)
                 .or_else(|_| PublicKey::parse(&contact_str))
                 .ok()
-                .map(|pubkey| Contact::new(pubkey))
+                .map(Contact::new)
         })
         .collect();
 
@@ -1889,7 +1889,7 @@ fn detect_mime_type(url: &str) -> Option<String> {
     let path = url_lower
         .split('?').next()?  // Remove query string
         .split('#').next()?; // Remove fragment
-    let extension = path.split('.').last()?;
+    let extension = path.split('.').next_back()?;
 
     match extension {
         // Image types

--- a/src/stores/notifications.rs
+++ b/src/stores/notifications.rs
@@ -118,7 +118,7 @@ async fn publish_checked_at_if_enabled(timestamp: i64) {
 
     match client.send_event_builder(builder).await {
         Ok(output) => {
-            log::info!("Published notification checked_at to NIP-78: {}", output.id().to_string());
+            log::info!("Published notification checked_at to NIP-78: {}", output.id());
             *LAST_PUBLISHED_AT.write() = timestamp;
         }
         Err(e) => {
@@ -291,7 +291,7 @@ pub async fn start_realtime_subscription() {
             log::info!("Real-time notification subscription started: {:?}", sub_id);
 
             // Spawn task to listen for incoming notification events
-            let my_pubkey_clone = my_pubkey.clone();
+            let my_pubkey_clone = my_pubkey;
             spawn(async move {
                 let mut notifications = client.notifications();
 

--- a/src/stores/p2p_store.rs
+++ b/src/stores/p2p_store.rs
@@ -559,7 +559,7 @@ pub fn derive_market_price(orders: &[P2POrder]) -> Option<f64> {
             let market_price = raw_price / (1.0 + premium / 100.0);
 
             // Sanity check: reject absurd prices (less than $1k or more than $1M per BTC)
-            if market_price >= 1_000.0 && market_price <= 1_000_000.0 {
+            if (1_000.0..=1_000_000.0).contains(&market_price) {
                 Some(market_price)
             } else {
                 None
@@ -576,7 +576,7 @@ pub fn derive_market_price(orders: &[P2POrder]) -> Option<f64> {
     implied_prices.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let mid = implied_prices.len() / 2;
 
-    if implied_prices.len() % 2 == 0 && implied_prices.len() > 1 {
+    if implied_prices.len().is_multiple_of(2) && implied_prices.len() > 1 {
         // Even count: average of two middle values
         Some((implied_prices[mid - 1] + implied_prices[mid]) / 2.0)
     } else {

--- a/src/stores/pending_comments.rs
+++ b/src/stores/pending_comments.rs
@@ -98,7 +98,7 @@ impl PendingComment {
 /// Global store for pending comments
 /// Key: target_event_id (hex string) -> Vec<PendingComment>
 pub static PENDING_COMMENTS: GlobalSignal<HashMap<String, Vec<PendingComment>>> =
-    Signal::global(|| HashMap::new());
+    Signal::global(HashMap::new);
 
 /// Add a pending comment to the store
 ///
@@ -110,7 +110,7 @@ pub fn add_pending_comment(comment: PendingComment) {
     log::debug!("Adding pending comment {} for target {}", comment.local_id, target_id);
 
     let mut store = PENDING_COMMENTS.write();
-    let comments = store.entry(target_id).or_insert_with(Vec::new);
+    let comments = store.entry(target_id).or_default();
 
     // Prevent duplicates: check if we already have a pending or failed comment with same content
     let already_exists = comments.iter().any(|c|
@@ -313,7 +313,7 @@ pub fn retry_pending_comment(local_id: &str) {
                 }
                 Err(e) => {
                     log::error!("Failed to retry reply: {}", e);
-                    update_pending_status(&local_id, CommentStatus::Failed(format!("{}", e)));
+                    update_pending_status(&local_id, CommentStatus::Failed(e.to_string()));
                 }
             }
         }

--- a/src/stores/pin_boards_store.rs
+++ b/src/stores/pin_boards_store.rs
@@ -502,7 +502,7 @@ pub fn parse_pinboard_event(
 
     // Determine ownership
     let pubkey_hex = event.pubkey.to_hex();
-    let is_owner = current_user_pubkey.map_or(false, |p| p == pubkey_hex);
+    let is_owner = current_user_pubkey.is_some_and(|p| p == pubkey_hex);
 
     Some(Pinboard {
         d_tag,
@@ -780,7 +780,7 @@ pub async fn fetch_pins_for_board(board_a_tag: &str) -> std::result::Result<Vec<
 
     let events = nostr_client::fetch_events_aggregated(filter, Duration::from_secs(15)).await?;
 
-    let mut pins: Vec<Pin> = events.iter().filter_map(|e| parse_pin_event(e)).collect();
+    let mut pins: Vec<Pin> = events.iter().filter_map(parse_pin_event).collect();
 
     // Sort by created_at descending (newest first)
     pins.sort_by(|a, b| b.created_at.cmp(&a.created_at));
@@ -801,7 +801,7 @@ pub async fn fetch_owner_pins_for_board(
 
     let events = nostr_client::fetch_events_aggregated(filter, Duration::from_secs(15)).await?;
 
-    let mut pins: Vec<Pin> = events.iter().filter_map(|e| parse_pin_event(e)).collect();
+    let mut pins: Vec<Pin> = events.iter().filter_map(parse_pin_event).collect();
 
     pins.sort_by(|a, b| b.created_at.cmp(&a.created_at));
 
@@ -848,7 +848,7 @@ pub async fn fetch_pins_for_board_filtered(
 
     let events = nostr_client::fetch_events_aggregated(filter, Duration::from_secs(15)).await?;
 
-    let mut pins: Vec<Pin> = events.iter().filter_map(|e| parse_pin_event(e)).collect();
+    let mut pins: Vec<Pin> = events.iter().filter_map(parse_pin_event).collect();
 
     // Sort by created_at descending (newest first)
     pins.sort_by(|a, b| b.created_at.cmp(&a.created_at));
@@ -926,7 +926,7 @@ pub async fn fetch_my_pins() -> std::result::Result<Vec<Pin>, String> {
 
     let events = nostr_client::fetch_events_aggregated(filter, Duration::from_secs(15)).await?;
 
-    let mut pins: Vec<Pin> = events.iter().filter_map(|e| parse_pin_event(e)).collect();
+    let mut pins: Vec<Pin> = events.iter().filter_map(parse_pin_event).collect();
 
     pins.sort_by(|a, b| b.created_at.cmp(&a.created_at));
 
@@ -947,7 +947,7 @@ pub fn search_pinboards_local(query: &str) -> Vec<Pinboard> {
                 || board
                     .description
                     .as_ref()
-                    .map_or(false, |d| d.to_lowercase().contains(&query_lower))
+                    .is_some_and(|d| d.to_lowercase().contains(&query_lower))
                 || board
                     .tags
                     .iter()

--- a/src/stores/profiles.rs
+++ b/src/stores/profiles.rs
@@ -27,16 +27,16 @@ impl Birthday {
         ];
 
         match (self.month, self.day, self.year) {
-            (Some(m), Some(d), Some(y)) if m >= 1 && m <= 12 => {
+            (Some(m), Some(d), Some(y)) if (1..=12).contains(&m) => {
                 Some(format!("{} {}, {}", months[(m - 1) as usize], d, y))
             }
-            (Some(m), Some(d), None) if m >= 1 && m <= 12 => {
+            (Some(m), Some(d), None) if (1..=12).contains(&m) => {
                 Some(format!("{} {}", months[(m - 1) as usize], d))
             }
-            (Some(m), None, Some(y)) if m >= 1 && m <= 12 => {
+            (Some(m), None, Some(y)) if (1..=12).contains(&m) => {
                 Some(format!("{} {}", months[(m - 1) as usize], y))
             }
-            (Some(m), None, None) if m >= 1 && m <= 12 => {
+            (Some(m), None, None) if (1..=12).contains(&m) => {
                 Some(months[(m - 1) as usize].to_string())
             }
             (None, None, Some(y)) => Some(y.to_string()),

--- a/src/stores/publication_store.rs
+++ b/src/stores/publication_store.rs
@@ -650,7 +650,7 @@ pub async fn fetch_publications(limit: usize, until: Option<u64>) -> StdResult<V
         Ok(events) => {
             let publications: Vec<PublicationIndex> = events
                 .iter()
-                .filter_map(|e| parse_publication_index(e))
+                .filter_map(parse_publication_index)
                 .collect();
 
             cache_publications(&publications);
@@ -778,7 +778,7 @@ pub async fn fetch_publications_by_author(pubkey_hex: &str, limit: usize) -> Std
         Ok(events) => {
             let publications: Vec<PublicationIndex> = events
                 .iter()
-                .filter_map(|e| parse_publication_index(e))
+                .filter_map(parse_publication_index)
                 .collect();
 
             cache_publications(&publications);
@@ -803,7 +803,7 @@ pub async fn search_publications_with_filter(filter: Filter, limit: usize) -> St
         Ok(events) => {
             let publications: Vec<PublicationIndex> = events
                 .iter()
-                .filter_map(|e| parse_publication_index(e))
+                .filter_map(parse_publication_index)
                 .collect();
 
             cache_publications(&publications);

--- a/src/stores/recipe_store.rs
+++ b/src/stores/recipe_store.rs
@@ -285,7 +285,7 @@ pub async fn fetch_recipes(limit: usize, until: Option<u64>) -> StdResult<Vec<Ca
         Ok(events) => {
             let recipes: Vec<CachedRecipe> = events
                 .iter()
-                .filter_map(|e| parse_recipe_event(e))
+                .filter_map(parse_recipe_event)
                 .collect();
 
             cache_recipes(&recipes);
@@ -317,7 +317,7 @@ pub async fn fetch_recipes_by_tag(tag: &str, limit: usize, until: Option<u64>) -
         Ok(events) => {
             let recipes: Vec<CachedRecipe> = events
                 .iter()
-                .filter_map(|e| parse_recipe_event(e))
+                .filter_map(parse_recipe_event)
                 .collect();
 
             cache_recipes(&recipes);
@@ -350,7 +350,7 @@ pub async fn fetch_recipes_by_author(pubkey_hex: &str, limit: usize, until: Opti
         Ok(events) => {
             let recipes: Vec<CachedRecipe> = events
                 .iter()
-                .filter_map(|e| parse_recipe_event(e))
+                .filter_map(parse_recipe_event)
                 .collect();
 
             cache_recipes(&recipes);
@@ -424,7 +424,7 @@ pub async fn fetch_recipe_engagement(a_tag: &str) -> StdResult<RecipeEngagement,
                 e.tags.iter()
                     .find(|t| t.kind().to_string() == "bolt11")
                     .and_then(|t| t.content())
-                    .and_then(|_| {
+                    .and({
                         // Parse amount from bolt11 - simplified
                         // Real implementation would use lightning-invoice crate
                         None::<u64>

--- a/src/stores/relay_metadata.rs
+++ b/src/stores/relay_metadata.rs
@@ -1,8 +1,8 @@
-/// NIP-65: Relay List Metadata (kind 10002)
-/// NIP-17: Private Direct Message Relay Lists (kind 10050)
-///
-/// This module provides centralized relay management using Nostr-native relay lists.
-/// It implements the Outbox model for intelligent relay routing.
+//! NIP-65: Relay List Metadata (kind 10002)
+//! NIP-17: Private Direct Message Relay Lists (kind 10050)
+//!
+//! This module provides centralized relay management using Nostr-native relay lists.
+//! It implements the Outbox model for intelligent relay routing.
 
 use dioxus::prelude::*;
 use dioxus::signals::ReadableExt;

--- a/src/stores/relay_store.rs
+++ b/src/stores/relay_store.rs
@@ -8,7 +8,7 @@ use nostr_sdk::prelude::*;
 use std::time::Duration;
 
 /// Global key package relays for MLS
-pub static KEY_PACKAGE_RELAYS: GlobalSignal<Vec<String>> = Signal::global(|| vec![]);
+pub static KEY_PACKAGE_RELAYS: GlobalSignal<Vec<String>> = Signal::global(std::vec::Vec::new);
 
 /// Fetch key package relays (kind 10051) for a user
 pub async fn fetch_key_package_relays(pubkey: &str) -> std::result::Result<(), String> {

--- a/src/stores/settings_store.rs
+++ b/src/stores/settings_store.rs
@@ -183,7 +183,7 @@ pub async fn save_settings(settings: &AppSettings) -> Result<(), String> {
 #[allow(dead_code)] // Called from theme_store.rs
 pub async fn update_theme(theme: theme_store::Theme) {
     // Apply theme locally (using internal function to avoid recursion)
-    theme_store::set_theme_internal(theme.clone());
+    theme_store::set_theme_internal(theme);
 
     // Update settings
     let mut settings = SETTINGS.read().clone();

--- a/src/stores/theme_store.rs
+++ b/src/stores/theme_store.rs
@@ -4,17 +4,14 @@ use gloo_storage::{LocalStorage, Storage};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default)]
 pub enum Theme {
     Light,
     Dark,
+    #[default]
     System,
 }
 
-impl Default for Theme {
-    fn default() -> Self {
-        Theme::System
-    }
-}
 
 impl Theme {
     pub fn as_str(&self) -> &'static str {

--- a/src/stores/voice_messages_store.rs
+++ b/src/stores/voice_messages_store.rs
@@ -49,7 +49,7 @@ pub static VOICE_PLAYBACK: GlobalSignal<VoicePlaybackState> = Signal::global(Voi
 
 /// Global recording state signal
 #[allow(dead_code)]
-pub static RECORDING_STATE: GlobalSignal<RecordingState> = Signal::global(|| RecordingState::default());
+pub static RECORDING_STATE: GlobalSignal<RecordingState> = Signal::global(RecordingState::default);
 
 /// Play a voice message (pauses any currently playing)
 #[allow(dead_code)]
@@ -157,7 +157,7 @@ pub fn generate_waveform(samples: &[f32], target_points: usize) -> Vec<u8> {
 
     // Guard against samples.len() < target_points by using ceiling division
     // and ensuring chunk_size is at least 1
-    let chunk_size = ((samples.len() + target_points - 1) / target_points).max(1);
+    let chunk_size = samples.len().div_ceil(target_points).max(1);
     let mut waveform = Vec::with_capacity(target_points);
 
     for i in 0..target_points {

--- a/src/stores/wiki_store.rs
+++ b/src/stores/wiki_store.rs
@@ -351,7 +351,7 @@ pub async fn fetch_wiki_pages(limit: usize, until: Option<u64>) -> StdResult<Vec
         Ok(events) => {
             let pages: Vec<CachedWikiPage> = events
                 .iter()
-                .filter_map(|e| parse_wiki_page_event(e))
+                .filter_map(parse_wiki_page_event)
                 .collect();
 
             cache_wiki_pages(&pages);
@@ -467,7 +467,7 @@ pub async fn fetch_wiki_backlinks(identifier: &str, limit: usize) -> StdResult<V
         Ok(events) => {
             let pages: Vec<CachedWikiPage> = events
                 .iter()
-                .filter_map(|e| parse_wiki_page_event(e))
+                .filter_map(parse_wiki_page_event)
                 .collect();
 
             // Cache backlinks
@@ -504,7 +504,7 @@ pub async fn fetch_wiki_pages_by_author(pubkey_hex: &str, limit: usize) -> StdRe
         Ok(events) => {
             let pages: Vec<CachedWikiPage> = events
                 .iter()
-                .filter_map(|e| parse_wiki_page_event(e))
+                .filter_map(parse_wiki_page_event)
                 .collect();
 
             cache_wiki_pages(&pages);
@@ -625,7 +625,7 @@ pub async fn publish_wiki_page(
 
     // Generate or use provided identifier
     let d_tag = identifier
-        .map(|s| normalize_wiki_dtag(s))
+        .map(normalize_wiki_dtag)
         .unwrap_or_else(|| normalize_wiki_dtag(title));
 
     // Build tags

--- a/src/utils/content_parser.rs
+++ b/src/utils/content_parser.rs
@@ -10,7 +10,7 @@ static URL_PATTERN: Lazy<Regex> = Lazy::new(|| {
 
 /// Clean trailing punctuation from URLs that may have been captured by regex
 fn clean_url_trailing_punctuation(url: &str) -> &str {
-    url.trim_end_matches(|c| matches!(c, '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '\'' | '"' | '>'))
+    url.trim_end_matches(['.', ',', ';', ':', '!', '?', ')', ']', '}', '\'', '"', '>'])
 }
 // Nostr URI pattern - matches nostr: followed by valid NIP-19 prefixes
 // Permissive alphanumeric match; SDK validation via Nip19::from_bech32 handles bech32 correctness

--- a/src/utils/data_state.rs
+++ b/src/utils/data_state.rs
@@ -26,8 +26,10 @@
 /// ```
 
 #[derive(Debug, Clone, PartialEq)]
+#[derive(Default)]
 pub enum DataState<T> {
     /// Initial state, no action taken yet
+    #[default]
     Pending,
 
     /// Currently loading/fetching data
@@ -120,11 +122,6 @@ impl<T> DataState<T> {
     }
 }
 
-impl<T> Default for DataState<T> {
-    fn default() -> Self {
-        DataState::Pending
-    }
-}
 
 /// Helper to convert Result into DataState
 impl<T, E: std::fmt::Display> From<Result<T, E>> for DataState<T> {

--- a/src/utils/list_kinds.rs
+++ b/src/utils/list_kinds.rs
@@ -1,7 +1,7 @@
-/// Nostr List Event Kinds and Utilities
-///
-/// NIP-51: Lists
-/// Reference: https://github.com/nostr-protocol/nips/blob/master/51.md
+//! Nostr List Event Kinds and Utilities
+//!
+//! NIP-51: Lists
+//! Reference: https://github.com/nostr-protocol/nips/blob/master/51.md
 
 /// NIP-51 List kinds (parameterized replaceable events)
 pub const NAMED_PEOPLE: u16 = 30000;     // People list

--- a/src/utils/nip54.rs
+++ b/src/utils/nip54.rs
@@ -349,7 +349,7 @@ pub fn parse_wiki_redirect(event: &Event) -> Result<WikiRedirect, String> {
         normalize_wiki_dtag(&event.content)
     } else {
         get_tag_value(event, "a")
-            .and_then(|coord| coord.split(':').last().map(|s| s.to_string()))
+            .and_then(|coord| coord.split(':').next_back().map(|s| s.to_string()))
             .ok_or("Missing redirect target")?
     };
 

--- a/src/utils/nkbip06.rs
+++ b/src/utils/nkbip06.rs
@@ -268,9 +268,9 @@ pub fn mime_type_for_kind(kind: u16) -> NostrMimeType {
                 REPLACEABILITY_NONREPLACEABLE
             };
 
-            let category = if kind >= 30000 && kind < 40000 {
+            let category = if (30000..40000).contains(&kind) {
                 CATEGORY_ARTICLE // Addressable events are often articles
-            } else if kind >= 10000 && kind < 20000 {
+            } else if (10000..20000).contains(&kind) {
                 CATEGORY_METADATA // Replaceable lists are often metadata
             } else {
                 CATEGORY_NOTE
@@ -285,7 +285,7 @@ pub fn mime_type_for_kind(kind: u16) -> NostrMimeType {
 pub fn is_replaceable_kind(kind: u16) -> bool {
     // Regular replaceable: 10000-19999
     // Addressable/parameterized replaceable: 30000-39999
-    (kind >= 10000 && kind < 20000) || (kind >= 30000 && kind < 40000)
+    (10000..20000).contains(&kind) || (30000..40000).contains(&kind)
 }
 
 /// Generate m and M tags for an event kind

--- a/src/utils/notification_nip78.rs
+++ b/src/utils/notification_nip78.rs
@@ -1,7 +1,7 @@
-/// NIP-78: Application Data Storage for Notification Tracking
-///
-/// This module provides functions to create and parse NIP-78 events
-/// for syncing notification read status across devices.
+//! NIP-78: Application Data Storage for Notification Tracking
+//!
+//! This module provides functions to create and parse NIP-78 events
+//! for syncing notification read status across devices.
 
 use nostr_sdk::{Event, EventBuilder, Kind, Tag, Timestamp};
 

--- a/src/utils/podcast.rs
+++ b/src/utils/podcast.rs
@@ -430,7 +430,7 @@ pub fn parse_podcast_metadata(event: &Event) -> Result<PodcastMetadata, String> 
     // Parse value block from JSON or tags
     let value = content_json.as_ref()
         .and_then(|j| j.get("value"))
-        .and_then(|v| parse_value_block_from_json(v))
+        .and_then(parse_value_block_from_json)
         .or_else(|| parse_value_block(event));
 
     Ok(PodcastMetadata {
@@ -613,7 +613,7 @@ fn parse_value_block(event: &Event) -> Option<ValueBlock> {
         .filter_map(|t| {
             let slice = t.as_slice();
             // Format: ["valueRecipient", name, type, address, split, custom_key?, custom_value?, fee?]
-            let name = slice.get(1).map(|s| if s.is_empty() { None } else { Some(s.to_string()) }).flatten();
+            let name = slice.get(1).and_then(|s| if s.is_empty() { None } else { Some(s.to_string()) });
             let recipient_type = slice.get(2)?.to_string();
             let address = slice.get(3)?.to_string();
             let split: u32 = slice.get(4)?.parse().ok()?;

--- a/src/utils/recipe.rs
+++ b/src/utils/recipe.rs
@@ -17,6 +17,7 @@ pub struct RecipeDetails {
 
 /// Parsed recipe content from markdown
 #[derive(Clone, Debug, PartialEq)]
+#[derive(Default)]
 pub struct ParsedRecipe {
     pub chef_notes: Option<String>,
     pub details: RecipeDetails,
@@ -25,17 +26,6 @@ pub struct ParsedRecipe {
     pub additional_resources: Option<String>,
 }
 
-impl Default for ParsedRecipe {
-    fn default() -> Self {
-        Self {
-            chef_notes: None,
-            details: RecipeDetails::default(),
-            ingredients: Vec::new(),
-            directions: Vec::new(),
-            additional_resources: None,
-        }
-    }
-}
 
 /// Recipe metadata extracted from event tags
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -161,8 +151,7 @@ pub fn parse_recipe(markdown: &str) -> Result<ParsedRecipe, ValidationError> {
 fn parse_details(content: &str, details: &mut RecipeDetails) -> Result<(), ValidationError> {
     for line in content.lines() {
         let line = line.trim();
-        if line.starts_with("- ") {
-            let rest = &line[2..];
+        if let Some(rest) = line.strip_prefix("- ") {
             if let Some((key, value)) = rest.split_once(": ") {
                 let value = value.trim();
                 match key {

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -84,7 +84,7 @@ pub fn format_relative_time_ex(timestamp: Timestamp, include_ago: bool, use_long
         _ => {
             // For older than 7 days, show the date
             let dt = DateTime::from_timestamp(ts as i64, 0)
-                .unwrap_or_else(|| Utc::now());
+                .unwrap_or_else(Utc::now);
             dt.format("%b %d").to_string()
         }
     }
@@ -100,7 +100,7 @@ pub fn format_relative_time(timestamp: Timestamp) -> String {
 #[allow(dead_code)]
 pub fn format_datetime(timestamp: Timestamp) -> String {
     let dt = DateTime::from_timestamp(timestamp.as_secs() as i64, 0)
-        .unwrap_or_else(|| Utc::now());
+        .unwrap_or_else(Utc::now);
     dt.format("%Y-%m-%d %H:%M:%S").to_string()
 }
 

--- a/src/utils/timed_serializer.rs
+++ b/src/utils/timed_serializer.rs
@@ -1,22 +1,22 @@
-/// Timed serializer with debouncing for LocalStorage operations
-///
-/// Reduces frequent write operations by batching updates within a time window.
-/// Inspired by Notedeck's approach to minimize storage I/O.
-///
-/// # Benefits
-/// - Reduces LocalStorage writes from dozens per second to one per interval
-/// - Prevents UI jank from synchronous storage operations
-/// - Saves battery on mobile devices
-/// - Reduces wear on storage (especially important for embedded devices)
-///
-/// # Example
-/// ```
-/// // Instead of saving on every bookmark toggle:
-/// bookmarks.save_immediately(); // Called 10x per second = 10 writes
-///
-/// // Use debounced saving:
-/// bookmarks.request_save(); // Called 10x per second = 1 write after 1s delay
-/// ```
+//! Timed serializer with debouncing for LocalStorage operations
+//!
+//! Reduces frequent write operations by batching updates within a time window.
+//! Inspired by Notedeck's approach to minimize storage I/O.
+//!
+//! # Benefits
+//! - Reduces LocalStorage writes from dozens per second to one per interval
+//! - Prevents UI jank from synchronous storage operations
+//! - Saves battery on mobile devices
+//! - Reduces wear on storage (especially important for embedded devices)
+//!
+//! # Example
+//! ```
+//! // Instead of saving on every bookmark toggle:
+//! bookmarks.save_immediately(); // Called 10x per second = 10 writes
+//!
+//! // Use debounced saving:
+//! bookmarks.request_save(); // Called 10x per second = 1 write after 1s delay
+//! ```
 
 use gloo_timers::callback::Timeout;
 use std::cell::RefCell;


### PR DESCRIPTION
- Convert outer doc comments (///) to inner doc comments (//!) for module-level docs
- Fix redundant field names in struct initialization (pubkey: pubkey -> pubkey)
- Remove duplicated allow(dead_code) attribute in indexeddb_database.rs
- Replace redundant closures with function references:
  - || String::new() -> String::new
  - || Vec::<T>::new() -> Vec::<T>::new
  - || HashMap::<...>::new() -> HashMap::<...>::new
  - unwrap_or_else(|| Utc::now()) -> unwrap_or_else(Utc::now)
- Remove .clone() on Copy types (Signal, Toasts, Navigator, Callback, etc.)
- Collapse else { if } blocks to else if
- Remove needless return statements
- Replace or_insert_with(Vec::new) with or_default()
- Fix various other clippy suggestions

Reduces clippy warnings from thousands to ~60 remaining (mostly stylistic suggestions requiring larger refactoring like too_many_arguments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)