### PR TITLE
Release 0.8.12: Relay feeds, performance overhaul, video thumbnails, profile enhancements & bug fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Validate docs submodules
+        run: |
+          for dir in public/docs/nips public/docs/nuts public/docs/blossom public/docs/NKBIPs public/docs/market-spec; do
+            count=$(find "$dir" -type f 2>/dev/null | wc -l)
+            if [ "$count" -eq 0 ]; then
+              echo "ERROR: Submodule $dir is empty or missing" >&2
+              exit 1
+            fi
+          done
+          echo "All docs submodules populated"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -58,6 +71,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Validate docs submodules
+        run: |
+          for dir in public/docs/nips public/docs/nuts public/docs/blossom public/docs/NKBIPs public/docs/market-spec; do
+            count=$(find "$dir" -type f 2>/dev/null | wc -l)
+            if [ "$count" -eq 0 ]; then
+              echo "ERROR: Submodule $dir is empty or missing" >&2
+              exit 1
+            fi
+          done
+          echo "All docs submodules populated"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -134,6 +160,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Validate docs submodules
+        run: |
+          for dir in public/docs/nips public/docs/nuts public/docs/blossom public/docs/NKBIPs public/docs/market-spec; do
+            count=$(find "$dir" -type f 2>/dev/null | wc -l)
+            if [ "$count" -eq 0 ]; then
+              echo "ERROR: Submodule $dir is empty or missing" >&2
+              exit 1
+            fi
+          done
+          echo "All docs submodules populated"
 
       - name: Setup Java
         uses: actions/setup-java@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "nostrblue"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "ammonia",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ web-sys = { version = "0.3", optional = true, features = [
     "AbortSignal",
     "ReadableStream",
     "ReadableStreamDefaultReader",
+    "Location",
 ] }
 gloo-storage = { version = "0.3", optional = true }
 gloo-timers = { version = "0.3", features = ["futures"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostrblue"
-version = "0.8.11"
+version = "0.8.12"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Patrick Ulrich"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A multi-platform Nostr client built using **Rust + Dioxus + rust-nostr** with integrated CDK wallet.
 
-![Version](https://img.shields.io/badge/version-0.8.11-blue)
+![Version](https://img.shields.io/badge/version-0.8.12-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Rust](https://img.shields.io/badge/rust-1.82+-orange)
 ![Platforms](https://img.shields.io/badge/platforms-Web%20%7C%20Android%20%7C%20Desktop-blue)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostrblue",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Nostr.blue Rust client",
   "scripts": {
     "dev": "npm run build:assets && dx serve",

--- a/public/docs/changelogs/0.8.12.md
+++ b/public/docs/changelogs/0.8.12.md
@@ -1,0 +1,14 @@
+- Relay Feeds — Add relay feed and relay set feed types with real-time subscriptions for per-relay content browsing
+- Interaction Loading Performance — Optimize with larger batches, local DB fast-path, combined queries, streaming, and a global queue
+- Instant Reply Loading — DB-first architecture for reply loading with parallel fetching and event batching
+- Video Thumbnails — Cross-platform video thumbnails via blurhash + canvas capture
+- Video Preloading — Add media fragment and preload metadata to videos without thumbnails
+- Relay Connection Fix — Fix detail pages failing with "too many relays" error (closes #318)
+- Post-Login Init — Await user relays before NIP-78 loads and parallelize post-login initialization
+- AI Chat Tool Use — Prevent AI chat tool use content from overflowing message bubbles
+- Pinboard Routing — Fix pinboard routing for kind 30067, remove dead code, eliminate podcast double-fetch
+- Reactivity Fixes — Fix reactive bugs, per-message hook overhead, hardcoded is_owner, and blocked-user UX
+- Blobbi Cleanup — Remove unused visual_effect feature and fix is_sleeping serialization
+- CI Docs Submodules — Populate docs submodules in CI and resolve relative URLs for reqwest WASM
+- Improved performance and stability
+- Bug fixes

--- a/src/components/article_content.rs
+++ b/src/components/article_content.rs
@@ -1,52 +1,91 @@
+use crate::components::rich_content::NostrUriRenderer;
 use crate::components::SensitiveContent;
-use crate::utils::markdown::render_markdown;
+use crate::utils::markdown::{extract_nostr_uris, render_markdown};
 use dioxus::prelude::*;
+
+const PROSE_CLASSES: &str = "article-content prose prose-lg prose-neutral dark:prose-invert max-w-none break-words
+    [&_h1]:text-4xl [&_h1]:font-bold [&_h1]:mt-8 [&_h1]:mb-4
+    [&_h2]:text-3xl [&_h2]:font-bold [&_h2]:mt-6 [&_h2]:mb-3
+    [&_h3]:text-2xl [&_h3]:font-semibold [&_h3]:mt-5 [&_h3]:mb-2
+    [&_p]:my-4 [&_p]:leading-relaxed
+    [&_a]:text-primary [&_a]:underline hover:[&_a]:text-primary/80
+    [&_ul]:my-4 [&_ul]:pl-6 [&_ul]:list-disc
+    [&_ol]:my-4 [&_ol]:pl-6 [&_ol]:list-decimal
+    [&_li]:my-2
+    [&_blockquote]:border-l-4 [&_blockquote]:border-primary [&_blockquote]:pl-4 [&_blockquote]:my-4 [&_blockquote]:italic
+    [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-sm
+    [&_pre]:bg-muted [&_pre]:p-4 [&_pre]:rounded-lg [&_pre]:overflow-x-auto [&_pre]:my-4
+    [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-lg [&_img]:my-6
+    [&_table]:w-full [&_table]:my-4
+    [&_th]:border [&_th]:border-border [&_th]:bg-muted [&_th]:px-4 [&_th]:py-2 [&_th]:font-semibold
+    [&_td]:border [&_td]:border-border [&_td]:px-4 [&_td]:py-2";
+
+enum ContentSegment {
+    Html(String),
+    NostrUri(usize),
+}
+
+fn split_html_on_markers(html: &str, uri_count: usize) -> Vec<ContentSegment> {
+    let mut segments = Vec::new();
+    let mut remaining = html;
+    for idx in 0..uri_count {
+        let marker = format!("%%NOSTR_BLUE_EMBED_{}%%", idx);
+        if let Some(pos) = remaining.find(&marker) {
+            if pos > 0 {
+                segments.push(ContentSegment::Html(remaining[..pos].to_string()));
+            }
+            segments.push(ContentSegment::NostrUri(idx));
+            remaining = &remaining[pos + marker.len()..];
+        }
+    }
+    if !remaining.is_empty() {
+        segments.push(ContentSegment::Html(remaining.to_string()));
+    }
+    segments
+}
+
 #[component]
-pub fn ArticleContent(content: String, #[props(default)] content_warning: Option<Option<String>>) -> Element {
-    let html_content = render_markdown(&content);
-    rsx! {
-        if let Some(reason) = content_warning {
-            SensitiveContent { reason,
-                div {
-                    dangerous_inner_html: "{html_content}",
-                    class: "article-content prose prose-lg prose-neutral dark:prose-invert max-w-none
-                           [&_h1]:text-4xl [&_h1]:font-bold [&_h1]:mt-8 [&_h1]:mb-4
-                           [&_h2]:text-3xl [&_h2]:font-bold [&_h2]:mt-6 [&_h2]:mb-3
-                           [&_h3]:text-2xl [&_h3]:font-semibold [&_h3]:mt-5 [&_h3]:mb-2
-                           [&_p]:my-4 [&_p]:leading-relaxed
-                           [&_a]:text-primary [&_a]:underline hover:[&_a]:text-primary/80
-                           [&_ul]:my-4 [&_ul]:pl-6 [&_ul]:list-disc
-                           [&_ol]:my-4 [&_ol]:pl-6 [&_ol]:list-decimal
-                           [&_li]:my-2
-                           [&_blockquote]:border-l-4 [&_blockquote]:border-primary [&_blockquote]:pl-4 [&_blockquote]:my-4 [&_blockquote]:italic
-                           [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-sm
-                           [&_pre]:bg-muted [&_pre]:p-4 [&_pre]:rounded-lg [&_pre]:overflow-x-auto [&_pre]:my-4
-                           [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-lg [&_img]:my-6
-                           [&_table]:w-full [&_table]:my-4
-                           [&_th]:border [&_th]:border-border [&_th]:bg-muted [&_th]:px-4 [&_th]:py-2 [&_th]:font-semibold
-                           [&_td]:border [&_td]:border-border [&_td]:px-4 [&_td]:py-2",
+pub fn ArticleContent(
+    content: String,
+    #[props(default)] content_warning: Option<Option<String>>,
+) -> Element {
+    let (content_with_markers, nostr_uris) = extract_nostr_uris(&content);
+    let html_content = render_markdown(&content_with_markers);
+    let segments = split_html_on_markers(&html_content, nostr_uris.len());
+
+    let rendered = rsx! {
+        for (seg_idx, segment) in segments.into_iter().enumerate() {
+            match segment {
+                ContentSegment::Html(html) => {
+                    let key = format!("html-{seg_idx}");
+                    rsx! {
+                        div {
+                            key: "{key}",
+                            dangerous_inner_html: "{html}",
+                            class: PROSE_CLASSES,
+                        }
+                    }
+                }
+                ContentSegment::NostrUri(idx) => {
+                    let uri = nostr_uris[idx].clone();
+                    let key = format!("nostr-{idx}");
+                    rsx! {
+                        div {
+                            key: "{key}",
+                            class: "my-2",
+                            NostrUriRenderer { uri }
+                        }
+                    }
                 }
             }
+        }
+    };
+
+    rsx! {
+        if let Some(reason) = content_warning {
+            SensitiveContent { reason, {rendered} }
         } else {
-            div {
-                dangerous_inner_html: "{html_content}",
-                class: "article-content prose prose-lg prose-neutral dark:prose-invert max-w-none
-                       [&_h1]:text-4xl [&_h1]:font-bold [&_h1]:mt-8 [&_h1]:mb-4
-                       [&_h2]:text-3xl [&_h2]:font-bold [&_h2]:mt-6 [&_h2]:mb-3
-                       [&_h3]:text-2xl [&_h3]:font-semibold [&_h3]:mt-5 [&_h3]:mb-2
-                       [&_p]:my-4 [&_p]:leading-relaxed
-                       [&_a]:text-primary [&_a]:underline hover:[&_a]:text-primary/80
-                       [&_ul]:my-4 [&_ul]:pl-6 [&_ul]:list-disc
-                       [&_ol]:my-4 [&_ol]:pl-6 [&_ol]:list-decimal
-                       [&_li]:my-2
-                       [&_blockquote]:border-l-4 [&_blockquote]:border-primary [&_blockquote]:pl-4 [&_blockquote]:my-4 [&_blockquote]:italic
-                       [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-sm
-                       [&_pre]:bg-muted [&_pre]:p-4 [&_pre]:rounded-lg [&_pre]:overflow-x-auto [&_pre]:my-4
-                       [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-lg [&_img]:my-6
-                       [&_table]:w-full [&_table]:my-4
-                       [&_th]:border [&_th]:border-border [&_th]:bg-muted [&_th]:px-4 [&_th]:py-2 [&_th]:font-semibold
-                       [&_td]:border [&_td]:border-border [&_td]:px-4 [&_td]:py-2",
-            }
+            {rendered}
         }
     }
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -29,6 +29,7 @@ pub mod media;
 pub mod media_uploader;
 pub mod mention_autocomplete;
 pub mod mobile_search_slideout;
+pub mod nip05_badge;
 pub mod nip_card;
 pub mod note;
 pub mod note_card;
@@ -167,6 +168,7 @@ pub use code::{
 };
 pub use external_content_card::ExternalContentList;
 pub use external_identities::ExternalIdentitiesSection;
+pub use nip05_badge::Nip05Badge;
 pub use nip_card::{CustomNipCard, DocSpecCard, NipCardSkeleton, OfficialNipCard};
 pub use profile_badges::ProfileBadgesSection;
 pub mod p2p;

--- a/src/components/music/mod.rs
+++ b/src/components/music/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! This module contains components for music playback,
 //! discovery, albums, artists, tracks, and radio.
+
+pub const FALLBACK_ART_URL: &str = "https://api.dicebear.com/7.x/shapes/svg?seed=music";
+
 pub mod album_card;
 pub mod artist_card;
 pub mod player;

--- a/src/components/music/player/player_bar.rs
+++ b/src/components/music/player/player_bar.rs
@@ -198,6 +198,7 @@ pub fn PlayerBar() -> Element {
                                 alt: "Album art",
                                 class: "w-full h-full object-cover",
                                 loading: "lazy",
+                                referrerpolicy: "no-referrer",
                             }
                         }
                     }

--- a/src/components/music/player/player_bar.rs
+++ b/src/components/music/player/player_bar.rs
@@ -5,8 +5,7 @@ use crate::stores::music_player::{self, MusicPlayerStateStoreExt, MUSIC_PLAYER, 
 use dioxus::prelude::*;
 
 use super::format_time;
-
-const FALLBACK_ART_URL: &str = "https://api.dicebear.com/7.x/shapes/svg?seed=music";
+use super::super::FALLBACK_ART_URL;
 
 #[component]
 pub fn PlayerBar() -> Element {

--- a/src/components/music/player/player_bar.rs
+++ b/src/components/music/player/player_bar.rs
@@ -6,6 +6,8 @@ use dioxus::prelude::*;
 
 use super::format_time;
 
+const FALLBACK_ART_URL: &str = "https://api.dicebear.com/7.x/shapes/svg?seed=music";
+
 #[component]
 pub fn PlayerBar() -> Element {
     let store = MUSIC_PLAYER.resolve();
@@ -19,6 +21,19 @@ pub fn PlayerBar() -> Element {
     let playback_speed = store.playback_speed().cloned();
     let now_playing = store.now_playing().cloned();
     let playback_error = store.playback_error().cloned();
+
+    let art_url = track
+        .album_art_url
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| FALLBACK_ART_URL.to_string());
+    let mut img_src = use_signal(|| art_url.clone());
+    {
+        let url_for_sync = art_url.clone();
+        use_effect(use_reactive((&url_for_sync,), move |(url,)| {
+            img_src.set(url);
+        }));
+    }
 
     let progress = if duration > 0.0 {
         (current_time / duration * 100.0).clamp(0.0, 100.0)
@@ -192,14 +207,13 @@ pub fn PlayerBar() -> Element {
                 // LEFT: Album art + title/artist
                 div { class: "flex items-center gap-3 min-w-0 flex-1 md:flex-initial md:w-80",
                     div { class: "w-12 h-12 rounded-lg overflow-hidden bg-muted shrink-0",
-                        if let Some(art_url) = &track.album_art_url {
-                            img {
-                                src: "{art_url}",
-                                alt: "Album art",
-                                class: "w-full h-full object-cover",
-                                loading: "lazy",
-                                referrerpolicy: "no-referrer",
-                            }
+                        img {
+                            src: "{img_src}",
+                            alt: "Album art",
+                            class: "w-full h-full object-cover",
+                            loading: "lazy",
+                            referrerpolicy: "no-referrer",
+                            onerror: move |_| img_src.set(FALLBACK_ART_URL.to_string()),
                         }
                     }
                     div { class: "flex flex-col min-w-0",

--- a/src/components/music/player/player_expanded.rs
+++ b/src/components/music/player/player_expanded.rs
@@ -6,6 +6,8 @@ use dioxus::prelude::*;
 
 use super::ExpandedSeekBar;
 
+const FALLBACK_ART_URL: &str = "https://api.dicebear.com/7.x/shapes/svg?seed=music";
+
 #[component]
 pub fn PlayerExpanded() -> Element {
     let store = MUSIC_PLAYER.resolve();
@@ -21,6 +23,19 @@ pub fn PlayerExpanded() -> Element {
     let duration = *store.duration().read();
 
     let mut show_share_modal = use_signal(|| false);
+
+    let art_url = track
+        .album_art_url
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| FALLBACK_ART_URL.to_string());
+    let mut img_src = use_signal(|| art_url.clone());
+    {
+        let url_for_sync = art_url.clone();
+        use_effect(use_reactive((&url_for_sync,), move |(url,)| {
+            img_src.set(url);
+        }));
+    }
 
     let share_url = track.share_url();
     let share_content_type = match &track.source {
@@ -54,17 +69,12 @@ pub fn PlayerExpanded() -> Element {
 
                 // Album artwork
                 div { class: "w-64 h-64 lg:w-80 lg:h-80 rounded-2xl overflow-hidden bg-muted shadow-2xl mb-8 shrink-0",
-                    if let Some(art_url) = &track.album_art_url {
-                        img {
-                            src: "{art_url}",
-                            alt: "Album art",
-                            class: "w-full h-full object-cover",
-                            referrerpolicy: "no-referrer",
-                        }
-                    } else {
-                        div { class: "w-full h-full flex items-center justify-center text-muted-foreground",
-                            div { dangerous_inner_html: icons::MUSIC_NOTE }
-                        }
+                    img {
+                        src: "{img_src}",
+                        alt: "Album art",
+                        class: "w-full h-full object-cover",
+                        referrerpolicy: "no-referrer",
+                        onerror: move |_| img_src.set(FALLBACK_ART_URL.to_string()),
                     }
                 }
 

--- a/src/components/music/player/player_expanded.rs
+++ b/src/components/music/player/player_expanded.rs
@@ -59,6 +59,7 @@ pub fn PlayerExpanded() -> Element {
                             src: "{art_url}",
                             alt: "Album art",
                             class: "w-full h-full object-cover",
+                            referrerpolicy: "no-referrer",
                         }
                     } else {
                         div { class: "w-full h-full flex items-center justify-center text-muted-foreground",

--- a/src/components/music/player/player_expanded.rs
+++ b/src/components/music/player/player_expanded.rs
@@ -5,8 +5,7 @@ use crate::stores::music_player::{self, MusicPlayerStateStoreExt, PlayerViewMode
 use dioxus::prelude::*;
 
 use super::ExpandedSeekBar;
-
-const FALLBACK_ART_URL: &str = "https://api.dicebear.com/7.x/shapes/svg?seed=music";
+use super::super::FALLBACK_ART_URL;
 
 #[component]
 pub fn PlayerExpanded() -> Element {

--- a/src/components/music/unified_track_card.rs
+++ b/src/components/music/unified_track_card.rs
@@ -149,6 +149,7 @@ pub fn UnifiedTrackCard(props: UnifiedTrackCardProps) -> Element {
                     alt: "Album art",
                     class: "w-14 h-14 rounded object-cover",
                     loading: "lazy",
+                    referrerpolicy: "no-referrer",
                 }
                 if props.show_source_badge {
                     div {

--- a/src/components/music/unified_track_card.rs
+++ b/src/components/music/unified_track_card.rs
@@ -6,6 +6,8 @@ use crate::stores::nostr_music::TrackSource;
 use crate::stores::profiles;
 use dioxus::prelude::*;
 use std::sync::Arc;
+
+const FALLBACK_ART_URL: &str = "https://api.dicebear.com/7.x/shapes/svg?seed=music";
 #[derive(Props, Clone, PartialEq)]
 pub struct UnifiedTrackCardProps {
     pub track: MusicTrack,
@@ -103,10 +105,18 @@ pub fn UnifiedTrackCard(props: UnifiedTrackCardProps) -> Element {
         TrackSource::Radio { .. } => ("LIVE", "Internet Radio", "bg-red-500/20 text-red-400"),
         TrackSource::Bible { .. } => ("B", "Bible", "bg-blue-500/20 text-blue-400"),
     };
-    let artwork_url = track
+    let art_url = track
         .album_art_url
         .clone()
-        .unwrap_or_else(|| "https://api.dicebear.com/7.x/shapes/svg?seed=music".to_string());
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| FALLBACK_ART_URL.to_string());
+    let mut img_src = use_signal(|| art_url.clone());
+    {
+        let url_for_sync = art_url.clone();
+        use_effect(use_reactive((&url_for_sync,), move |(url,)| {
+            img_src.set(url);
+        }));
+    }
     let share_url = track.share_url();
     let share_content_type = match &track.source {
         TrackSource::NostrPodcast { .. } | TrackSource::RssPodcast { .. } => ContentType::PodcastEpisode,
@@ -145,11 +155,12 @@ pub fn UnifiedTrackCard(props: UnifiedTrackCardProps) -> Element {
             onclick: handle_play,
             div { class: "relative shrink-0",
                 img {
-                    src: "{artwork_url}",
+                    src: "{img_src}",
                     alt: "Album art",
                     class: "w-14 h-14 rounded object-cover",
                     loading: "lazy",
                     referrerpolicy: "no-referrer",
+                    onerror: move |_| img_src.set(FALLBACK_ART_URL.to_string()),
                 }
                 if props.show_source_badge {
                     div {

--- a/src/components/music/unified_track_card.rs
+++ b/src/components/music/unified_track_card.rs
@@ -4,10 +4,10 @@ use crate::routes::Route;
 use crate::stores::music_player::{self, MusicPlayerStateStoreExt, MusicTrack};
 use crate::stores::nostr_music::TrackSource;
 use crate::stores::profiles;
+use super::FALLBACK_ART_URL;
 use dioxus::prelude::*;
 use std::sync::Arc;
 
-const FALLBACK_ART_URL: &str = "https://api.dicebear.com/7.x/shapes/svg?seed=music";
 #[derive(Props, Clone, PartialEq)]
 pub struct UnifiedTrackCardProps {
     pub track: MusicTrack,

--- a/src/components/nip05_badge.rs
+++ b/src/components/nip05_badge.rs
@@ -1,0 +1,114 @@
+use crate::services::nip05::{self, Nip05Status};
+use dioxus::prelude::*;
+
+#[derive(Props, Clone, PartialEq)]
+pub struct Nip05BadgeProps {
+    pub pubkey: String,
+    pub nip05: String,
+}
+
+#[component]
+pub fn Nip05Badge(props: Nip05BadgeProps) -> Element {
+    let mut status = use_signal(|| Nip05Status::Unknown);
+    let pubkey_for_effect = props.pubkey.clone();
+    let nip05_for_effect = props.nip05.clone();
+
+    use_effect(use_reactive(
+        (&props.pubkey, &props.nip05),
+        move |(pubkey, nip05)| {
+            let current = nip05::get_nip05_status(&pubkey, &nip05);
+            status.set(current.clone());
+            if matches!(current, Nip05Status::Unknown) {
+                nip05::verify_nip05(&pubkey, &nip05);
+            }
+        },
+    ));
+
+    use_future(move || {
+        let pk = pubkey_for_effect.clone();
+        let nip = nip05_for_effect.clone();
+        async move {
+            loop {
+                crate::platform::timer::sleep_ms(200).await;
+                let current = nip05::get_nip05_status(&pk, &nip);
+                if *status.read() != current {
+                    status.set(current);
+                }
+            }
+        }
+    });
+
+    let s = status.read().clone();
+    match s {
+        Nip05Status::Verified => rsx! {
+            span {
+                class: "inline-flex items-center gap-1 text-green-500",
+                title: "NIP-05 verified",
+                svg {
+                    class: "w-4 h-4",
+                    xmlns: "http://www.w3.org/2000/svg",
+                    view_box: "0 0 24 24",
+                    fill: "none",
+                    stroke: "currentColor",
+                    stroke_width: "2",
+                    stroke_linecap: "round",
+                    stroke_linejoin: "round",
+                    path { d: "M22 11.08V12a10 10 0 1 1-5.93-9.14" }
+                    polyline { points: "22 4 12 14.01 9 11.01" }
+                }
+            }
+        },
+        Nip05Status::Impersonator => rsx! {
+            span {
+                class: "inline-flex items-center gap-1 text-red-500",
+                title: "NIP-05 verification failed: pubkey mismatch",
+                svg {
+                    class: "w-4 h-4",
+                    xmlns: "http://www.w3.org/2000/svg",
+                    view_box: "0 0 24 24",
+                    fill: "none",
+                    stroke: "currentColor",
+                    stroke_width: "2",
+                    stroke_linecap: "round",
+                    stroke_linejoin: "round",
+                    circle { cx: "12", cy: "12", r: "10" }
+                    line { x1: "15", y1: "9", x2: "9", y2: "15" }
+                    line { x1: "9", y1: "9", x2: "15", y2: "15" }
+                }
+            }
+        },
+        Nip05Status::Error => {
+            let pk = props.pubkey.clone();
+            let nip = props.nip05.clone();
+            rsx! {
+                span {
+                    class: "inline-flex items-center gap-1 text-orange-500 cursor-pointer",
+                    title: "NIP-05 verification failed. Click to retry.",
+                    onclick: move |_| {
+                        nip05::retry_nip05(&pk, &nip);
+                    },
+                    svg {
+                        class: "w-4 h-4",
+                        xmlns: "http://www.w3.org/2000/svg",
+                        view_box: "0 0 24 24",
+                        fill: "none",
+                        stroke: "currentColor",
+                        stroke_width: "2",
+                        stroke_linecap: "round",
+                        stroke_linejoin: "round",
+                        path { d: "M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" }
+                        line { x1: "12", y1: "9", x2: "12", y2: "13" }
+                        line { x1: "12", y1: "17", x2: "12.01", y2: "17" }
+                    }
+                }
+            }
+        }
+        Nip05Status::Verifying => rsx! {
+            span {
+                class: "inline-flex items-center",
+                span { class: "inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin text-muted-foreground" }
+            }
+        },
+        Nip05Status::Unknown => rsx! {},
+    }
+}

--- a/src/components/nip05_badge.rs
+++ b/src/components/nip05_badge.rs
@@ -32,7 +32,10 @@ pub fn Nip05Badge(props: Nip05BadgeProps) -> Element {
                 crate::platform::timer::sleep_ms(200).await;
                 let current = nip05::get_nip05_status(&pk, &nip);
                 if *status.read() != current {
-                    status.set(current);
+                    status.set(current.clone());
+                }
+                if matches!(&current, Nip05Status::Verified | Nip05Status::Impersonator) {
+                    break;
                 }
             }
         }

--- a/src/components/note_card.rs
+++ b/src/components/note_card.rs
@@ -7,6 +7,7 @@ use crate::components::{
     RichContent, SensitiveContent, ZapModal,
 };
 use crate::hooks::use_reaction;
+use crate::hooks::use_global_interaction::{get_global_interaction, UseGlobalInteraction};
 use crate::routes::Route;
 use crate::services::aggregation::InteractionCounts;
 use crate::stores::bookmarks;
@@ -203,12 +204,22 @@ pub fn NoteCard(
         }
     }));
     let has_precomputed = precomputed_counts.is_some();
+    let event_id_for_global = event_id.clone();
     use_effect(use_reactive(
         &(event_id_counts, has_precomputed),
         move |(event_id_for_counts, has_precomputed)| {
             let current_gen = count_request_gen.peek().wrapping_add(1);
             count_request_gen.set(current_gen);
             if has_precomputed {
+                return;
+            }
+            if let Some(global_counts) = get_global_interaction(&event_id_for_counts) {
+                reply_count.set(global_counts.replies);
+                repost_count.set(global_counts.reposts);
+                zap_amount_sats.set(global_counts.zap_amount_sats);
+                is_reposted.set(global_counts.user_reposted.unwrap_or(false));
+                user_repost_id.set(global_counts.user_repost_id.clone());
+                is_zapped.set(global_counts.user_zapped.unwrap_or(false));
                 return;
             }
             reply_count.set(0);
@@ -511,6 +522,7 @@ pub fn NoteCard(
     let is_hidden = (is_muted.read().unwrap_or(false) || is_author_blocked.read().unwrap_or(false))
         && !*show_hidden_anyway.read();
     rsx! {
+        UseGlobalInteraction { event_id: event_id_for_global }
         article {
             "data-event-id": "{event.id}",
             class: "border-b border-border p-4 hover:bg-accent/50 transition-colors cursor-pointer",

--- a/src/components/podcast/chapters.rs
+++ b/src/components/podcast/chapters.rs
@@ -149,6 +149,7 @@ fn ChapterItem(props: ChapterItemProps) -> Element {
                         src: "{img_url}",
                         alt: chapter.title.as_deref().unwrap_or("Chapter"),
                         class: "w-12 h-12 rounded object-cover shrink-0",
+                        referrerpolicy: "no-referrer",
                     }
                 }
             }

--- a/src/components/podcast/episode_card.rs
+++ b/src/components/podcast/episode_card.rs
@@ -404,6 +404,7 @@ pub fn PodcastEpisodeCard(props: PodcastEpisodeCardProps) -> Element {
                     alt: "{episode.title}",
                     class: "w-16 h-16 rounded-lg object-cover",
                     loading: "lazy",
+                    referrerpolicy: "no-referrer",
                 }
                 div { class: "absolute -top-1 -right-1 w-4 h-4 rounded-full flex items-center justify-center text-[9px] font-bold {source_badge.1}",
                     "{source_badge.0}"

--- a/src/components/rich_content/mentions.rs
+++ b/src/components/rich_content/mentions.rs
@@ -38,7 +38,7 @@ const INTERACTIVE_ELEMENT_SELECTOR: &str =
     "a, button, input, textarea, select, summary, [role='button'], [role='link']:not([data-embedded-note]), [contenteditable='true'], video, audio, iframe, [data-interactive]";
 
 #[component]
-pub(super) fn MentionRenderer(mention: String) -> Element {
+pub fn MentionRenderer(mention: String) -> Element {
     let lower = mention.to_lowercase();
     let identifier = lower.strip_prefix("nostr:").unwrap_or(&lower);
     let pubkey_result: Option<nostr_sdk::PublicKey> =
@@ -149,7 +149,7 @@ fn try_extract_event_id_from_nevent(identifier: &str) -> Option<EventId> {
 }
 
 #[component]
-pub(super) fn EventMentionRenderer(mention: String) -> Element {
+pub fn EventMentionRenderer(mention: String) -> Element {
     let lower = mention.to_lowercase();
     let identifier = lower.strip_prefix("nostr:").unwrap_or(&lower);
     let nip19_result = Nip19::from_bech32(identifier).ok();
@@ -455,7 +455,7 @@ pub(super) fn render_embedded_note(event: &Event, metadata: Option<&Metadata>) -
 }
 
 #[component]
-pub(super) fn NaddrMentionRenderer(mention: String) -> Element {
+pub fn NaddrMentionRenderer(mention: String) -> Element {
     let lower = mention.to_lowercase();
     let identifier = lower.strip_prefix("nostr:").unwrap_or(&lower);
     let coord_data = nostr_sdk::nips::nip19::Nip19Coordinate::from_bech32(identifier)

--- a/src/components/rich_content/mod.rs
+++ b/src/components/rich_content/mod.rs
@@ -469,13 +469,15 @@ fn render_token(token: &ContentToken, emoji_map: &HashMap<String, String>) -> El
             }
         }
         ContentToken::Video(url) => {
+            let video_src = format!("{}#t=0.1", url);
             rsx! {
                 div {
                     class: "my-2 rounded-lg overflow-hidden border border-border",
                     onclick: move |e: MouseEvent| e.stop_propagation(),
                     video {
-                        src: "{url}",
+                        src: "{video_src}",
                         controls: true,
+                        preload: "metadata",
                         class: "max-w-full h-auto",
                         "Your browser does not support the video tag."
                     }

--- a/src/components/rich_content/mod.rs
+++ b/src/components/rich_content/mod.rs
@@ -249,6 +249,17 @@ fn image_gallery_key(items: &[(usize, &ContentToken)]) -> String {
     format!("gallery-{}-{:x}", first_idx, hash_str(&urls))
 }
 
+#[component]
+pub fn NostrUriRenderer(uri: String) -> Element {
+    let lower = uri.to_lowercase();
+    let identifier = lower.strip_prefix("nostr:").unwrap_or(&lower);
+    if identifier.starts_with("npub1") || identifier.starts_with("nprofile1") {
+        rsx! { MentionRenderer { mention: uri } }
+    } else {
+        rsx! { EventMentionRenderer { mention: uri } }
+    }
+}
+
 fn render_image_gallery(items: &[(usize, &ContentToken)]) -> Element {
     let images: Vec<LightboxImage> = items
         .iter()

--- a/src/components/rich_content/mod.rs
+++ b/src/components/rich_content/mod.rs
@@ -424,6 +424,59 @@ fn render_cashu_token(token: &str) -> Element {
     rsx! { span { class: "text-xs text-muted-foreground font-mono break-all", "{token}" } }
 }
 
+#[component]
+fn InlineVideoPlayer(url: String) -> Element {
+    let video_src = format!("{}#t=0.1", url);
+    let url_hash = {
+        use std::hash::Hasher;
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        std::hash::Hash::hash(&url, &mut hasher);
+        format!("{:x}", hasher.finish())
+    };
+    let video_id = format!("iv-{}", url_hash);
+    let mut captured_poster: Signal<Option<String>> = use_signal(|| None);
+    let vid_for_capture = video_id.clone();
+    use_effect(move || {
+        if captured_poster.read().is_some() {
+            return;
+        }
+        let vid = vid_for_capture.clone();
+        spawn(async move {
+            crate::platform::timer::sleep_ms(1500).await;
+            let js = format!(
+                r#"return (function() {{ var v = document.getElementById("{vid}"); if (!v || !v.videoWidth) return null; try {{ var c = document.createElement('canvas'); c.width = v.videoWidth; c.height = v.videoHeight; c.getContext('2d').drawImage(v, 0, 0); return c.toDataURL('image/jpeg', 0.7); }} catch(e) {{ return null; }} }})()"#
+            );
+            if let Some(data_url) = document::eval(&js)
+                .await
+                .ok()
+                .and_then(|v| v.as_str().map(|s| s.to_string()))
+            {
+                captured_poster.set(Some(data_url));
+            }
+        });
+    });
+    rsx! {
+        div {
+            class: "my-2 rounded-lg overflow-hidden border border-border relative bg-black",
+            onclick: move |e: MouseEvent| e.stop_propagation(),
+            if let Some(ref bg) = *captured_poster.read() {
+                img {
+                    src: "{bg}",
+                    class: "absolute inset-0 w-full h-full object-contain",
+                }
+            }
+            video {
+                id: "{video_id}",
+                src: "{video_src}",
+                controls: true,
+                preload: "metadata",
+                class: "max-w-full h-auto relative z-10",
+                "Your browser does not support the video tag."
+            }
+        }
+    }
+}
+
 fn render_token(token: &ContentToken, emoji_map: &HashMap<String, String>) -> Element {
     match token {
         ContentToken::Text(text) => {
@@ -469,19 +522,8 @@ fn render_token(token: &ContentToken, emoji_map: &HashMap<String, String>) -> El
             }
         }
         ContentToken::Video(url) => {
-            let video_src = format!("{}#t=0.1", url);
             rsx! {
-                div {
-                    class: "my-2 rounded-lg overflow-hidden border border-border",
-                    onclick: move |e: MouseEvent| e.stop_propagation(),
-                    video {
-                        src: "{video_src}",
-                        controls: true,
-                        preload: "metadata",
-                        class: "max-w-full h-auto",
-                        "Your browser does not support the video tag."
-                    }
-                }
+                InlineVideoPlayer { url: url.clone() }
             }
         }
         ContentToken::Mention(mention) => {

--- a/src/components/rich_content/nostr_blue_renderers.rs
+++ b/src/components/rich_content/nostr_blue_renderers.rs
@@ -1165,7 +1165,7 @@ pub(super) fn NostrBlueRssMusicAlbumRenderer(feed_id: String) -> Element {
                                     if let Some(Ok((f, eps))) = resource.read_unchecked().as_ref() {
                                         let tracks: Vec<MusicTrack> = eps
                                             .iter()
-                                            .map(|ep| MusicTrack::from_rss_music_track(ep, f))
+                                            .map(|ep| MusicTrack::from_rss_music_track(ep, f, None))
                                             .collect();
                                         if let Some(first) = tracks.first().cloned() {
                                             music_player::play_track(first, Some(tracks), Some(0));

--- a/src/components/threaded_comment.rs
+++ b/src/components/threaded_comment.rs
@@ -1,6 +1,7 @@
 use crate::components::icons::{BookmarkIcon, MessageCircleIcon, Repeat2Icon, ZapIcon};
 use crate::components::{ReactionButton, ReplyComposer, RichContent, SensitiveContent, ZapModal};
 use crate::hooks::{use_author_metadata, use_reaction};
+use crate::hooks::use_global_interaction::{get_global_interaction, UseGlobalInteraction};
 use crate::routes::Route;
 use crate::services::aggregation::InteractionCounts;
 use crate::stores::bookmarks;
@@ -167,6 +168,13 @@ pub fn ThreadedComment(
             if skip {
                 return;
             }
+            if let Some(global_counts) = get_global_interaction(&event_id_counts) {
+                reply_count.set(global_counts.replies);
+                repost_count.set(global_counts.reposts);
+                zap_amount_sats.set(global_counts.zap_amount_sats);
+                is_reposted.set(global_counts.user_reposted.unwrap_or(false));
+                return;
+            }
             let event_id_for_counts = event_id_counts.clone();
             spawn(async move {
                 let client = match get_client() {
@@ -178,73 +186,60 @@ pub fn ThreadedComment(
                         Ok(id) => id,
                         Err(_) => return,
                     };
-                let reply_filter = Filter::new()
-                    .kind(Kind::TextNote)
+                let current_user_pubkey = SIGNER_INFO
+                    .read()
+                    .as_ref()
+                    .map(|info| info.public_key.clone());
+                let combined_filter = Filter::new()
+                    .kinds(vec![Kind::TextNote, Kind::Repost, Kind::ZapReceipt])
                     .event(event_id_parsed)
-                    .limit(500);
-                if let Ok(replies) = client
-                    .fetch_events(reply_filter, Duration::from_secs(5))
+                    .limit(2000);
+                if let Ok(events) = client
+                    .fetch_events(combined_filter, Duration::from_secs(5))
                     .await
                 {
-                    reply_count.set(replies.len());
-                }
-                let repost_filter = Filter::new()
-                    .kind(Kind::Repost)
-                    .event(event_id_parsed)
-                    .limit(500);
-                if let Ok(reposts) = client
-                    .fetch_events(repost_filter, Duration::from_secs(5))
-                    .await
-                {
-                    let current_user_pubkey = SIGNER_INFO
-                        .read()
-                        .as_ref()
-                        .map(|info| info.public_key.clone());
+                    let mut replies = 0usize;
+                    let mut reposts = 0usize;
+                    let mut total_sats = 0u64;
                     let mut user_has_reposted = false;
-                    if let Some(ref user_pk) = current_user_pubkey {
-                        for repost in reposts.iter() {
-                            if repost.pubkey.to_string() == *user_pk {
-                                user_has_reposted = true;
-                                break;
+                    for event in events {
+                        match event.kind {
+                            Kind::TextNote => replies += 1,
+                            Kind::Repost => {
+                                reposts += 1;
+                                if let Some(ref user_pk) = current_user_pubkey {
+                                    if event.pubkey.to_string() == *user_pk {
+                                        user_has_reposted = true;
+                                    }
+                                }
                             }
-                        }
-                    }
-                    repost_count.set(reposts.len());
-                    is_reposted.set(user_has_reposted);
-                }
-                let zap_filter = Filter::new()
-                    .kind(Kind::ZapReceipt)
-                    .event(event_id_parsed)
-                    .limit(500);
-                if let Ok(zaps) = client
-                    .fetch_events(zap_filter, Duration::from_secs(5))
-                    .await
-                {
-                    let total_sats: u64 = zaps
-                        .iter()
-                        .filter_map(|zap_event| {
-                            zap_event.tags.iter().find_map(|tag| {
-                                let tag_vec = tag.clone().to_vec();
-                                if tag_vec.first()?.as_str() == "description" {
-                                    let zap_request_json = tag_vec.get(1)?.as_str();
-                                    if let Ok(zap_request) =
-                                        serde_json::from_str::<serde_json::Value>(zap_request_json)
-                                    {
-                                        if let Some(tags) =
-                                            zap_request.get("tags").and_then(|t| t.as_array())
+                            Kind::ZapReceipt => {
+                                if let Some(amount) = event.tags.iter().find_map(|tag| {
+                                    let slice = tag.as_slice();
+                                    if slice.first()?.as_str() == "description" {
+                                        let zap_request_json = slice.get(1)?.as_str();
+                                        if let Ok(zap_request) =
+                                            serde_json::from_str::<serde_json::Value>(
+                                                zap_request_json,
+                                            )
                                         {
-                                            for tag_array in tags {
-                                                if let Some(tag_vals) = tag_array.as_array() {
-                                                    if tag_vals.first().and_then(|v| v.as_str())
-                                                        == Some("amount")
-                                                    {
-                                                        if let Some(amount_str) =
-                                                            tag_vals.get(1).and_then(|v| v.as_str())
+                                            if let Some(tags) =
+                                                zap_request.get("tags").and_then(|t| t.as_array())
+                                            {
+                                                for tag_array in tags {
+                                                    if let Some(tag_vals) = tag_array.as_array() {
+                                                        if tag_vals.first().and_then(|v| v.as_str())
+                                                            == Some("amount")
                                                         {
-                                                            if let Ok(millisats) =
-                                                                amount_str.parse::<u64>()
+                                                            if let Some(amount_str) = tag_vals
+                                                                .get(1)
+                                                                .and_then(|v| v.as_str())
                                                             {
-                                                                return Some(millisats / 1000);
+                                                                if let Ok(millisats) =
+                                                                    amount_str.parse::<u64>()
+                                                                {
+                                                                    return Some(millisats / 1000);
+                                                                }
                                                             }
                                                         }
                                                     }
@@ -252,11 +247,17 @@ pub fn ThreadedComment(
                                             }
                                         }
                                     }
+                                    None
+                                }) {
+                                    total_sats += amount;
                                 }
-                                None
-                            })
-                        })
-                        .sum();
+                            }
+                            _ => {}
+                        }
+                    }
+                    reply_count.set(replies);
+                    repost_count.set(reposts);
+                    is_reposted.set(user_has_reposted);
                     zap_amount_sats.set(total_sats);
                 }
             });
@@ -373,6 +374,7 @@ pub fn ThreadedComment(
         && !*show_hidden_anyway.read();
 
     rsx! {
+        UseGlobalInteraction { event_id: event_id.clone() }
         div { class: "comment-thread", style: "margin-left: {margin_left}px;",
             if is_hidden {
                 div { class: "border-l-2 border-border pl-3 py-2",

--- a/src/components/video_card.rs
+++ b/src/components/video_card.rs
@@ -1,4 +1,4 @@
-use crate::components::icons::{BookmarkIcon, MessageCircleIcon, ZapIcon};
+use crate::components::icons::{BookmarkIcon, MessageCircleIcon, PlayIcon, ZapIcon};
 use crate::components::{ReactionButton, SensitiveContent, ZapModal};
 use crate::hooks::use_reaction;
 use crate::routes::Route;
@@ -323,6 +323,12 @@ pub fn VideoCard(event: Event) -> Element {
     let formatted_duration = first_video
         .duration
         .map(|d| format_duration_timecode_padded(d as u64));
+    let video_src = if first_video.thumbnail.is_none() {
+        format!("{}#t=0.1", &first_video.url)
+    } else {
+        first_video.url.clone()
+    };
+    let has_thumbnail = first_video.thumbnail.is_some();
     rsx! {
         div { class: "border-b border-border hover:bg-accent/5 transition",
             div { class: "p-4 flex items-center gap-3",
@@ -362,7 +368,7 @@ pub fn VideoCard(event: Event) -> Element {
                                     preload: "metadata",
                                     poster: first_video.thumbnail.as_deref(),
                                     source {
-                                        src: "{first_video.url}",
+                                        src: "{video_src}",
                                         r#type: first_video.mime_type.as_deref().unwrap_or("video/mp4"),
                                     }
                                     for fallback_url in &first_video.fallback_urls {
@@ -373,6 +379,13 @@ pub fn VideoCard(event: Event) -> Element {
                                 if let Some(dur) = &formatted_duration {
                                     div { class: "absolute bottom-2 right-2 bg-black/75 text-white text-xs px-2 py-1 rounded",
                                         "{dur}"
+                                    }
+                                }
+                                if !has_thumbnail {
+                                    div { class: "absolute inset-0 flex items-center justify-center pointer-events-none",
+                                        div { class: "w-16 h-16 rounded-full bg-white/20 backdrop-blur-sm flex items-center justify-center",
+                                            PlayIcon { class: "w-8 h-8 text-white ml-1" }
+                                        }
                                     }
                                 }
                             }
@@ -387,7 +400,7 @@ pub fn VideoCard(event: Event) -> Element {
                                 preload: "metadata",
                                 poster: first_video.thumbnail.as_deref(),
                                 source {
-                                    src: "{first_video.url}",
+                                    src: "{video_src}",
                                     r#type: first_video.mime_type.as_deref().unwrap_or("video/mp4"),
                                 }
                                 for fallback_url in &first_video.fallback_urls {
@@ -398,6 +411,13 @@ pub fn VideoCard(event: Event) -> Element {
                             if let Some(dur) = &formatted_duration {
                                 div { class: "absolute bottom-2 right-2 bg-black/75 text-white text-xs px-2 py-1 rounded",
                                     "{dur}"
+                                }
+                            }
+                            if !has_thumbnail {
+                                div { class: "absolute inset-0 flex items-center justify-center pointer-events-none",
+                                    div { class: "w-16 h-16 rounded-full bg-white/20 backdrop-blur-sm flex items-center justify-center",
+                                        PlayIcon { class: "w-8 h-8 text-white ml-1" }
+                                    }
                                 }
                             }
                         }

--- a/src/components/video_card.rs
+++ b/src/components/video_card.rs
@@ -44,6 +44,7 @@ pub struct VideoMeta {
     pub duration: Option<f64>,
     pub dim: Option<(u32, u32)>,
     pub thumbnail: Option<String>,
+    pub blurhash: Option<String>,
     pub fallback_urls: Vec<String>,
 }
 /// Parse imeta tags from NIP-71 video events
@@ -58,6 +59,7 @@ pub fn parse_video_imeta_tags(event: &Event) -> Vec<VideoMeta> {
                 duration: None,
                 dim: None,
                 thumbnail: None,
+                blurhash: None,
                 fallback_urls: Vec::new(),
             };
             for field in tag_vec.iter().skip(1) {
@@ -80,6 +82,9 @@ pub fn parse_video_imeta_tags(event: &Event) -> Vec<VideoMeta> {
                         "image" if video.thumbnail.is_none() => {
                             video.thumbnail = Some(value.to_string());
                         }
+                        "blurhash" => {
+                            video.blurhash = Some(value.to_string());
+                        }
                         "fallback" => {
                             video.fallback_urls.push(value.to_string());
                         }
@@ -94,6 +99,112 @@ pub fn parse_video_imeta_tags(event: &Event) -> Vec<VideoMeta> {
     }
     videos
 }
+
+fn blurhash_js(hash: &str, width: u32, height: u32) -> String {
+    format!(
+        r#"
+        return (function() {{
+            var Base83 = {{
+                chars: "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$",
+                decode: function(str) {{
+                    var v = 0;
+                    for (var i = 0; i < str.length; i++) {{
+                        var c = this.chars.indexOf(str[i]);
+                        if (c === -1) return 0;
+                        v = v * 83 + c;
+                    }}
+                    return v;
+                }}
+            }};
+            function signPow(val, exp) {{ return Math.sign(val) * Math.pow(Math.abs(val), exp); }}
+            function sRGBToLinear(value) {{ var v = Math.max(0, Math.min(1, value)); return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4); }}
+            function tosRGB(value) {{ var v = Math.max(0, Math.min(1, value)); return v <= 0.0031308 ? Math.round(v * 12.92 * 255 + 0.5) : Math.round((1.055 * Math.pow(v, 1.0 / 2.4) - 0.055) * 255 + 0.5); }}
+            try {{
+                var size_flag = Base83.decode("{hash}"[0]);
+                var num_y = Math.floor(size_flag / 9) + 1;
+                var num_x = (size_flag % 9) + 1;
+                var quant_max_value = Base83.decode("{hash}"[1]);
+                var max_value = (quant_max_value + 1) / 166.0;
+                var colors = [];
+                for (var i = 0; i < num_x * num_y; i++) {{
+                    if (i === 0) {{
+                        var value = Base83.decode("{hash}".substring(2, 6));
+                        colors.push([sRGBToLinear((value >> 16) / 255.0), sRGBToLinear(((value >> 8) & 255) / 255.0), sRGBToLinear((value & 255) / 255.0)]);
+                    }} else {{
+                        var value = Base83.decode("{hash}".substring(4 + i * 2, 6 + i * 2));
+                        colors.push([
+                            signPow((Math.floor(value / (19 * 19)) - 9.0) / 9.0, 2.0) * max_value,
+                            signPow(((Math.floor(value / 19) % 19) - 9.0) / 9.0, 2.0) * max_value,
+                            signPow(((value % 19) - 9.0) / 9.0, 2.0) * max_value
+                        ]);
+                    }}
+                }}
+                var pixelsPerRow = [];
+                for (var y = 0; y < {height}; y++) {{
+                    for (var x = 0; x < {width}; x++) {{
+                        var r = 0, g = 0, b = 0;
+                        for (var j = 0; j < num_y; j++) {{
+                            for (var i = 0; i < num_x; i++) {{
+                                var basis = Math.cos((Math.PI * x * i) / {width}) * Math.cos((Math.PI * y * j) / {height});
+                                r += colors[i + j * num_x][0] * basis;
+                                g += colors[i + j * num_x][1] * basis;
+                                b += colors[i + j * num_x][2] * basis;
+                            }}
+                        }}
+                        pixelsPerRow.push(tosRGB(r), tosRGB(g), tosRGB(b));
+                    }}
+                }}
+                var c = document.createElement('canvas');
+                c.width = {width}; c.height = {height};
+                var ctx = c.getContext('2d');
+                var id = ctx.createImageData({width}, {height});
+                for (var i = 0, j = 0; i < pixelsPerRow.length; i += 3, j += 4) {{
+                    id.data[j] = pixelsPerRow[i];
+                    id.data[j + 1] = pixelsPerRow[i + 1];
+                    id.data[j + 2] = pixelsPerRow[i + 2];
+                    id.data[j + 3] = 255;
+                }}
+                ctx.putImageData(id, 0, 0);
+                return c.toDataURL('image/jpeg', 0.7);
+            }} catch(e) {{ return null; }}
+        }})()
+        "#
+    )
+}
+
+async fn eval_blurhash(hash: &str, width: u32, height: u32) -> Option<String> {
+    let js = blurhash_js(hash, width, height);
+    document::eval(&js)
+        .await
+        .ok()
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+}
+
+fn capture_frame_js(element_id: &str) -> String {
+    format!(
+        r#"
+        return (function() {{
+            var v = document.getElementById("{element_id}");
+            if (!v || !v.videoWidth) return null;
+            try {{
+                var c = document.createElement('canvas');
+                c.width = v.videoWidth; c.height = v.videoHeight;
+                c.getContext('2d').drawImage(v, 0, 0);
+                return c.toDataURL('image/jpeg', 0.7);
+            }} catch(e) {{ return null; }}
+        }})()
+        "#
+    )
+}
+
+async fn eval_capture_frame(element_id: &str) -> Option<String> {
+    let js = capture_frame_js(element_id);
+    document::eval(&js)
+        .await
+        .ok()
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+}
+
 /// Get the title from NIP-71 video events
 pub fn get_video_title(event: &Event) -> Option<String> {
     for tag in event.tags.iter() {
@@ -104,6 +215,7 @@ pub fn get_video_title(event: &Event) -> Option<String> {
     }
     None
 }
+
 #[component]
 pub fn VideoCard(event: Event) -> Element {
     let videos = parse_video_imeta_tags(&event);
@@ -329,6 +441,38 @@ pub fn VideoCard(event: Event) -> Element {
         first_video.url.clone()
     };
     let has_thumbnail = first_video.thumbnail.is_some();
+    let video_element_id = format!("vc-{}", &event_id[..8]);
+    let blurhash_str = first_video.blurhash.clone();
+    let mut captured_poster: Signal<Option<String>> = use_signal(|| None);
+    let video_element_id_for_capture = video_element_id.clone();
+    let has_no_thumbnail = !has_thumbnail;
+    use_effect(move || {
+        if let Some(ref bh) = blurhash_str {
+            let bh = bh.clone();
+            spawn(async move {
+                if let Some(data_url) = eval_blurhash(&bh, 32, 32).await {
+                    captured_poster.set(Some(data_url));
+                }
+            });
+        }
+    });
+    use_effect(move || {
+        if !has_no_thumbnail || captured_poster.read().is_some() {
+            return;
+        }
+        let vid = video_element_id_for_capture.clone();
+        spawn(async move {
+            crate::platform::timer::sleep_ms(1500).await;
+            if let Some(data_url) = eval_capture_frame(&vid).await {
+                captured_poster.set(Some(data_url));
+            }
+        });
+    });
+    let effective_poster = first_video
+        .thumbnail
+        .clone()
+        .or_else(|| captured_poster.read().clone());
+    let show_play_overlay = !has_thumbnail && captured_poster.read().is_none();
     rsx! {
         div { class: "border-b border-border hover:bg-accent/5 transition",
             div { class: "p-4 flex items-center gap-3",
@@ -362,11 +506,18 @@ pub fn VideoCard(event: Event) -> Element {
                     rsx! {
                         SensitiveContent { reason,
                             div { class: "relative bg-black",
+                                if let Some(ref bg) = *captured_poster.read() {
+                                    img {
+                                        src: "{bg}",
+                                        class: "absolute inset-0 w-full h-full object-contain",
+                                    }
+                                }
                                 video {
-                                    class: "w-full max-h-[600px] object-contain",
+                                    id: "{video_element_id}",
+                                    class: "w-full max-h-[600px] object-contain relative z-10",
                                     controls: true,
                                     preload: "metadata",
-                                    poster: first_video.thumbnail.as_deref(),
+                                    poster: effective_poster.as_deref(),
                                     source {
                                         src: "{video_src}",
                                         r#type: first_video.mime_type.as_deref().unwrap_or("video/mp4"),
@@ -377,12 +528,12 @@ pub fn VideoCard(event: Event) -> Element {
                                     "Your browser does not support the video tag."
                                 }
                                 if let Some(dur) = &formatted_duration {
-                                    div { class: "absolute bottom-2 right-2 bg-black/75 text-white text-xs px-2 py-1 rounded",
+                                    div { class: "absolute bottom-2 right-2 bg-black/75 text-white text-xs px-2 py-1 rounded z-20",
                                         "{dur}"
                                     }
                                 }
-                                if !has_thumbnail {
-                                    div { class: "absolute inset-0 flex items-center justify-center pointer-events-none",
+                                if show_play_overlay {
+                                    div { class: "absolute inset-0 flex items-center justify-center pointer-events-none z-20",
                                         div { class: "w-16 h-16 rounded-full bg-white/20 backdrop-blur-sm flex items-center justify-center",
                                             PlayIcon { class: "w-8 h-8 text-white ml-1" }
                                         }
@@ -394,11 +545,18 @@ pub fn VideoCard(event: Event) -> Element {
                 } else {
                     rsx! {
                         div { class: "relative bg-black",
+                            if let Some(ref bg) = *captured_poster.read() {
+                                img {
+                                    src: "{bg}",
+                                    class: "absolute inset-0 w-full h-full object-contain",
+                                }
+                            }
                             video {
-                                class: "w-full max-h-[600px] object-contain",
+                                id: "{video_element_id}",
+                                class: "w-full max-h-[600px] object-contain relative z-10",
                                 controls: true,
                                 preload: "metadata",
-                                poster: first_video.thumbnail.as_deref(),
+                                poster: effective_poster.as_deref(),
                                 source {
                                     src: "{video_src}",
                                     r#type: first_video.mime_type.as_deref().unwrap_or("video/mp4"),
@@ -409,12 +567,12 @@ pub fn VideoCard(event: Event) -> Element {
                                 "Your browser does not support the video tag."
                             }
                             if let Some(dur) = &formatted_duration {
-                                div { class: "absolute bottom-2 right-2 bg-black/75 text-white text-xs px-2 py-1 rounded",
+                                div { class: "absolute bottom-2 right-2 bg-black/75 text-white text-xs px-2 py-1 rounded z-20",
                                     "{dur}"
                                 }
                             }
-                            if !has_thumbnail {
-                                div { class: "absolute inset-0 flex items-center justify-center pointer-events-none",
+                            if show_play_overlay {
+                                div { class: "absolute inset-0 flex items-center justify-center pointer-events-none z-20",
                                     div { class: "w-16 h-16 rounded-full bg-white/20 backdrop-blur-sm flex items-center justify-center",
                                         PlayIcon { class: "w-8 h-8 text-white ml-1" }
                                     }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -4,9 +4,11 @@ mod use_community;
 pub mod use_composer_editor;
 pub mod use_fetch_event_by_coordinate;
 pub mod use_fetch_event_by_id;
+pub mod use_global_interaction;
 pub mod use_infinite_scroll;
 pub mod use_lists;
 pub mod use_mute_block_cache;
+pub mod use_profile;
 pub mod use_reaction;
 pub mod use_relay_subscription;
 pub mod use_unsaved_changes;
@@ -16,6 +18,11 @@ pub use use_author_metadata::use_author_metadata;
 pub use use_composer_editor::{use_composer_editor, ComposerConfig, UseComposerEditor};
 pub use use_fetch_event_by_coordinate::use_fetch_event_by_coordinate_with_message;
 pub use use_fetch_event_by_id::use_fetch_event_by_id;
+#[allow(unused_imports)]
+pub use use_global_interaction::{
+    enqueue_interaction_fetch, get_global_interaction, GlobalInteractionProcessor,
+    UseGlobalInteraction,
+};
 pub use use_infinite_scroll::use_infinite_scroll;
 pub use use_lists::{delete_list, use_user_lists, UserList};
 pub use use_mute_block_cache::use_mute_block_cache;

--- a/src/hooks/use_global_interaction.rs
+++ b/src/hooks/use_global_interaction.rs
@@ -1,0 +1,77 @@
+use crate::services::aggregation::{
+    fetch_interaction_counts_batch, fetch_local_db_counts, InteractionCounts,
+};
+use dioxus::prelude::*;
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+static INTERACTION_QUEUE: GlobalSignal<HashSet<String>> = Signal::global(HashSet::new);
+static INTERACTION_GLOBAL_CACHE: GlobalSignal<HashMap<String, InteractionCounts>> =
+    Signal::global(HashMap::new);
+
+pub fn get_global_interaction(event_id: &str) -> Option<InteractionCounts> {
+    INTERACTION_GLOBAL_CACHE.read().get(event_id).cloned()
+}
+
+pub fn enqueue_interaction_fetch(event_id: &str) {
+    let mut queue = INTERACTION_QUEUE.write();
+    if !queue.contains(event_id) {
+        queue.insert(event_id.to_string());
+    }
+}
+
+pub fn remove_from_interaction_queue(event_id: &str) {
+    INTERACTION_QUEUE.write().remove(event_id);
+}
+
+pub async fn process_interaction_queue() {
+    let ids: Vec<String> = {
+        let mut queue = INTERACTION_QUEUE.write();
+        let ids: Vec<String> = queue.drain().collect();
+        ids
+    };
+    if ids.is_empty() {
+        return;
+    }
+    let parsed: Vec<nostr_sdk::EventId> = ids
+        .iter()
+        .filter_map(|id| nostr_sdk::EventId::from_hex(id).ok())
+        .collect();
+    if parsed.is_empty() {
+        return;
+    }
+
+    let local_counts = fetch_local_db_counts(&parsed).await;
+    if !local_counts.is_empty() {
+        INTERACTION_GLOBAL_CACHE.write().extend(local_counts);
+    }
+
+    if let Ok(counts) = fetch_interaction_counts_batch(parsed, Duration::from_secs(5)).await {
+        INTERACTION_GLOBAL_CACHE.write().extend(counts);
+    }
+}
+
+#[component]
+pub fn GlobalInteractionProcessor() -> Element {
+    use_future(move || async move {
+        loop {
+            crate::platform::timer::sleep_ms(300).await;
+            process_interaction_queue().await;
+        }
+    });
+
+    rsx! {}
+}
+
+#[component]
+pub fn UseGlobalInteraction(event_id: String) -> Element {
+    let event_id_drop = event_id.clone();
+    use_hook(move || {
+        enqueue_interaction_fetch(&event_id);
+    });
+    use_drop(move || {
+        remove_from_interaction_queue(&event_id_drop);
+    });
+
+    rsx! {}
+}

--- a/src/hooks/use_lists.rs
+++ b/src/hooks/use_lists.rs
@@ -87,6 +87,7 @@ pub fn use_user_lists() -> (
         let client_ready = *nostr_client::CLIENT_INITIALIZED.read();
         let has_signer = *nostr_client::HAS_SIGNER.read();
         let auth = auth_store::AUTH_STATE.read();
+        let relays_applied = *crate::stores::relay::USER_RELAYS_APPLIED.read();
         if !auth.is_authenticated {
             lists.set(Vec::new());
             return;
@@ -116,6 +117,10 @@ pub fn use_user_lists() -> (
         };
         if requires_signer && !has_signer {
             log::debug!("Waiting for signer before fetching lists...");
+            return;
+        }
+        if requires_signer && !relays_applied {
+            log::debug!("Waiting for user relay lists before fetching lists...");
             return;
         }
         let pubkey_str = match &auth.pubkey {

--- a/src/hooks/use_relay_subscription.rs
+++ b/src/hooks/use_relay_subscription.rs
@@ -20,10 +20,18 @@ fn spawn_dispatched_listener(
 ) {
     spawn(async move {
         let mut rx = rx;
+        let mut buffer = Vec::new();
         while let Some(event) = rx.recv().await {
-            if let Ok(mut cb) = on_event.lock() {
-                cb(&event);
+            buffer.push(event);
+            while let Ok(event) = rx.try_recv() {
+                buffer.push(event);
             }
+            if let Ok(mut cb) = on_event.lock() {
+                for event in &buffer {
+                    cb(event);
+                }
+            }
+            buffer.clear();
         }
     });
 }
@@ -123,6 +131,7 @@ pub fn use_relay_subscription_opts(
 fn spawn_fallback_listener(client: Arc<Client>, sub_id: SubscriptionId, on_event: OnEvent) {
     spawn(async move {
         let mut notifications = client.notifications();
+        let mut buffer = Vec::new();
         while let Ok(notification) = notifications.recv().await {
             if let nostr_sdk::RelayPoolNotification::Event {
                 subscription_id,
@@ -131,9 +140,25 @@ fn spawn_fallback_listener(client: Arc<Client>, sub_id: SubscriptionId, on_event
             } = notification
             {
                 if subscription_id == sub_id {
-                    if let Ok(mut cb) = on_event.lock() {
-                        cb(&event);
+                    buffer.push(event);
+                    while let Ok(notification) = notifications.try_recv() {
+                        if let nostr_sdk::RelayPoolNotification::Event {
+                            subscription_id: sid,
+                            event,
+                            ..
+                        } = notification
+                        {
+                            if sid == sub_id {
+                                buffer.push(event);
+                            }
+                        }
                     }
+                    if let Ok(mut cb) = on_event.lock() {
+                        for event in &buffer {
+                            cb(event);
+                        }
+                    }
+                    buffer.clear();
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,7 @@ fn App() -> Element {
         if let Some(css) = tailwind_css {
             document::Stylesheet { href: css }
         }
+        hooks::GlobalInteractionProcessor {}
         ToastProvider { Router::<routes::Route> {} }
         components::password_modal::PasswordModal {}
         components::MediaLightbox {}

--- a/src/routes/ai_chat.rs
+++ b/src/routes/ai_chat.rs
@@ -1019,7 +1019,7 @@ pub fn AIChat() -> Element {
             div {
                 id: "{messages_container_id}",
                 class: "flex-1 overflow-y-auto",
-                div { class: "mx-auto flex max-w-5xl flex-col gap-6 px-4 py-6",
+                div { class: "mx-auto flex max-w-5xl flex-col gap-6 overflow-hidden px-4 py-6",
                     if ppq_blocked {
                         PpqSetupGate {
                             loading: ppq_bootstrap_loading,
@@ -1295,11 +1295,11 @@ fn MessageBubble(message: DisplayMessage) -> Element {
     };
 
     rsx! {
-        div { class: if is_user { "flex justify-end" } else { "flex justify-start" },
+        div { class: if is_user { "flex min-w-0 justify-end" } else { "flex min-w-0 justify-start" },
             div { class: if is_user {
-                    "max-w-3xl rounded-2xl bg-primary px-4 py-3 text-sm text-primary-foreground shadow-sm"
+                    "max-w-3xl min-w-0 overflow-hidden rounded-2xl bg-primary px-4 py-3 text-sm text-primary-foreground shadow-sm"
                 } else {
-                    "max-w-3xl rounded-2xl border border-border bg-card px-4 py-3 text-sm text-foreground shadow-sm"
+                    "max-w-3xl min-w-0 overflow-hidden rounded-2xl border border-border bg-card px-4 py-3 text-sm text-foreground shadow-sm"
                 },
                 if is_user {
                     p { class: "whitespace-pre-wrap break-words", "{message.content}" }

--- a/src/routes/articles/article_detail.rs
+++ b/src/routes/articles/article_detail.rs
@@ -39,12 +39,13 @@ pub fn ArticleDetail(naddr: String) -> Element {
             loading.set(true);
             error.set(None);
             match crate::utils::nip19::parse_naddr(&naddr_str) {
-                Ok((pubkey, identifier)) => {
-                    crate::stores::profiles::PROFILE_CACHE.write().pop(&pubkey);
-                    match nostr_client::fetch_event_by_coordinate(
-                        nostr_sdk::Kind::LongFormTextNote.as_u16(),
-                        pubkey.clone(),
-                        identifier,
+                Ok(parsed) => {
+                    crate::stores::profiles::PROFILE_CACHE.write().pop(&parsed.pubkey);
+                    match nostr_client::fetch_event_by_coordinate_with_relays(
+                        parsed.kind,
+                        parsed.pubkey.clone(),
+                        parsed.identifier,
+                        parsed.relay_hints,
                     )
                     .await
                     {
@@ -55,7 +56,7 @@ pub fn ArticleDetail(naddr: String) -> Element {
                             spawn(async move {
                                 profile_prefetch::prefetch_event_authors(&[event]).await;
                                 if let Some(profile) =
-                                    crate::stores::profiles::get_cached_profile(&pubkey)
+                                    crate::stores::profiles::get_cached_profile(&parsed.pubkey)
                                 {
                                     let mut metadata = nostr_sdk::Metadata::new();
                                     if let Some(name) = profile.name {

--- a/src/routes/articles/article_detail.rs
+++ b/src/routes/articles/article_detail.rs
@@ -26,20 +26,35 @@ pub fn ArticleDetail(naddr: String) -> Element {
     let mut is_liking = use_signal(|| false);
     let mut is_liked = use_signal(|| false);
     let mut like_count = use_signal(|| 0usize);
+    let mut load_generation = use_signal(|| 0u32);
     let has_signer = *nostr_client::HAS_SIGNER.read();
     let (cached_muted_posts, cached_blocked_users) = use_mute_block_cache();
-    use_effect(move || {
+
+    use_effect(use_reactive!(|naddr| {
         let naddr_str = naddr.clone();
+        let gen = load_generation.peek().wrapping_add(1);
+        load_generation.set(gen);
+
+        article.set(None);
+        loading.set(true);
+        error.set(None);
+        author_metadata.set(None);
+        comments.set(Vec::new());
+        loading_comments.set(false);
+        is_liked.set(false);
+        like_count.set(0);
+
         let client_initialized = *nostr_client::CLIENT_INITIALIZED.read();
         if !client_initialized {
             log::info!("Waiting for client initialization before loading article...");
             return;
         }
+
+        let lg = load_generation;
         spawn(async move {
-            loading.set(true);
-            error.set(None);
             match crate::utils::nip19::parse_naddr(&naddr_str) {
                 Ok(parsed) => {
+                    let author_pubkey_for_meta = parsed.pubkey.clone();
                     match nostr_client::fetch_event_by_coordinate_with_relays(
                         parsed.kind,
                         parsed.pubkey.clone(),
@@ -49,13 +64,24 @@ pub fn ArticleDetail(naddr: String) -> Element {
                     .await
                     {
                         Ok(Some(event)) => {
+                            if *lg.peek() != gen {
+                                return;
+                            }
                             article.set(Some(event.clone()));
                             loading.set(false);
-                            use crate::utils::profile_prefetch;
+
+                            let lg2 = lg;
+                            let gen2 = gen;
+                            let event_for_meta = event.clone();
+                            let author_pk = author_pubkey_for_meta.clone();
                             spawn(async move {
-                                profile_prefetch::prefetch_event_authors(&[event]).await;
+                                use crate::utils::profile_prefetch;
+                                profile_prefetch::prefetch_event_authors(&[event_for_meta]).await;
+                                if *lg2.peek() != gen2 {
+                                    return;
+                                }
                                 if let Some(profile) =
-                                    crate::stores::profiles::get_cached_profile(&parsed.pubkey)
+                                    crate::stores::profiles::get_cached_profile(&author_pk)
                                 {
                                     let mut metadata = nostr_sdk::Metadata::new();
                                     if let Some(name) = profile.name {
@@ -75,45 +101,117 @@ pub fn ArticleDetail(naddr: String) -> Element {
                                     author_metadata.set(Some(metadata));
                                 }
                             });
+
+                            let event_id = event.id;
+                            let lg3 = lg;
+                            let gen3 = gen;
+                            spawn(async move {
+                                loading_comments.set(true);
+                                let filter =
+                                    Filter::new().kind(Kind::Comment).event(event_id).limit(500);
+                                match nostr_client::fetch_events_aggregated(
+                                    filter,
+                                    Duration::from_secs(10),
+                                )
+                                .await
+                                {
+                                    Ok(mut comment_events) => {
+                                        if *lg3.peek() != gen3 {
+                                            return;
+                                        }
+                                        comment_events.sort_by_key(|a| a.created_at);
+                                        log::info!(
+                                            "Loaded {} NIP-22 comments",
+                                            comment_events.len()
+                                        );
+                                        comments.set(comment_events);
+                                    }
+                                    Err(e) => {
+                                        log::error!("Failed to fetch comments: {}", e);
+                                    }
+                                }
+                                if *lg3.peek() != gen3 {
+                                    return;
+                                }
+                                loading_comments.set(false);
+                            });
+
+                            let event_id = event.id;
+                            let current_user_pubkey = crate::stores::signer::SIGNER_INFO
+                                .read()
+                                .as_ref()
+                                .map(|info| info.public_key.clone());
+                            let lg4 = lg;
+                            let gen4 = gen;
+                            spawn(async move {
+                                let filter = Filter::new()
+                                    .kind(Kind::Reaction)
+                                    .event(event_id)
+                                    .limit(500);
+                                match nostr_client::fetch_events_aggregated(
+                                    filter,
+                                    Duration::from_secs(10),
+                                )
+                                .await
+                                {
+                                    Ok(reaction_events) => {
+                                        if *lg4.peek() != gen4 {
+                                            return;
+                                        }
+                                        let mut likes = 0;
+                                        let mut user_has_liked = false;
+                                        for reaction in &reaction_events {
+                                            if reaction.content != "-" {
+                                                likes += 1;
+                                            }
+                                            if let Some(ref user_pk) = current_user_pubkey {
+                                                if reaction.pubkey.to_hex() == *user_pk
+                                                    && reaction.content != "-"
+                                                {
+                                                    user_has_liked = true;
+                                                }
+                                            }
+                                        }
+                                        like_count.set(likes);
+                                        is_liked.set(user_has_liked);
+                                        log::info!(
+                                            "Loaded {} reactions for article, user has liked: {}",
+                                            likes,
+                                            user_has_liked
+                                        );
+                                    }
+                                    Err(e) => {
+                                        log::error!("Failed to fetch reactions: {}", e);
+                                    }
+                                }
+                            });
                         }
                         Ok(None) => {
+                            if *lg.peek() != gen {
+                                return;
+                            }
                             error.set(Some("Article not found".to_string()));
                             loading.set(false);
                         }
                         Err(e) => {
+                            if *lg.peek() != gen {
+                                return;
+                            }
                             error.set(Some(e));
                             loading.set(false);
                         }
                     }
                 }
                 Err(e) => {
+                    if *lg.peek() != gen {
+                        return;
+                    }
                     error.set(Some(e));
                     loading.set(false);
                 }
             }
         });
-    });
-    use_effect(move || {
-        let article_data = article.read();
-        if let Some(event) = article_data.as_ref() {
-            let event_id = event.id;
-            spawn(async move {
-                loading_comments.set(true);
-                let filter = Filter::new().kind(Kind::Comment).event(event_id).limit(500);
-                match nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10)).await {
-                    Ok(mut comment_events) => {
-                        comment_events.sort_by_key(|a| a.created_at);
-                        log::info!("Loaded {} NIP-22 comments", comment_events.len());
-                        comments.set(comment_events);
-                    }
-                    Err(e) => {
-                        log::error!("Failed to fetch comments: {}", e);
-                    }
-                }
-                loading_comments.set(false);
-            });
-        }
-    });
+    }));
 
     {
         let comment_filter = article.read().as_ref().map(|event| {
@@ -135,48 +233,6 @@ pub fn ArticleDetail(naddr: String) -> Element {
         });
     }
 
-    use_effect(move || {
-        let article_data = article.read();
-        if let Some(event) = article_data.as_ref() {
-            let event_id = event.id;
-            let current_user_pubkey = crate::stores::signer::SIGNER_INFO
-                .read()
-                .as_ref()
-                .map(|info| info.public_key.clone());
-            spawn(async move {
-                let filter = Filter::new()
-                    .kind(Kind::Reaction)
-                    .event(event_id)
-                    .limit(500);
-                match nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10)).await {
-                    Ok(reaction_events) => {
-                        let mut likes = 0;
-                        let mut user_has_liked = false;
-                        for reaction in &reaction_events {
-                            if reaction.content != "-" {
-                                likes += 1;
-                            }
-                            if let Some(ref user_pk) = current_user_pubkey {
-                                if reaction.pubkey.to_hex() == *user_pk && reaction.content != "-" {
-                                    user_has_liked = true;
-                                }
-                            }
-                        }
-                        like_count.set(likes);
-                        is_liked.set(user_has_liked);
-                        log::info!(
-                            "Loaded {} reactions for article, user has liked: {}",
-                            likes,
-                            user_has_liked
-                        );
-                    }
-                    Err(e) => {
-                        log::error!("Failed to fetch reactions: {}", e);
-                    }
-                }
-            });
-        }
-    });
     rsx! {
         div { class: "min-h-screen",
             div { class: "sticky top-0 z-20 bg-background/80 backdrop-blur-sm border-b border-border",

--- a/src/routes/articles/article_detail.rs
+++ b/src/routes/articles/article_detail.rs
@@ -40,7 +40,6 @@ pub fn ArticleDetail(naddr: String) -> Element {
             error.set(None);
             match crate::utils::nip19::parse_naddr(&naddr_str) {
                 Ok(parsed) => {
-                    crate::stores::profiles::PROFILE_CACHE.write().pop(&parsed.pubkey);
                     match nostr_client::fetch_event_by_coordinate_with_relays(
                         parsed.kind,
                         parsed.pubkey.clone(),

--- a/src/routes/blossom/blossom_home.rs
+++ b/src/routes/blossom/blossom_home.rs
@@ -609,8 +609,9 @@ fn FileDetailModal(
                         } else if is_video {
                             video {
                                 class: "max-h-[400px]",
-                                src: "{item.url}",
+                                src: "{item.url}#t=0.1",
                                 controls: true,
+                                preload: "metadata",
                             }
                         } else if is_audio {
                             div { class: "p-8",

--- a/src/routes/home/engagement.rs
+++ b/src/routes/home/engagement.rs
@@ -1,6 +1,6 @@
 use crate::services::aggregation::{
-    fetch_interaction_counts_batch, stream_interaction_counts, sync_interaction_counts,
-    InteractionCounts, InteractionStreamHandle,
+    fetch_interaction_counts_batch, fetch_local_db_counts, stream_interaction_counts,
+    sync_interaction_counts, InteractionCounts, InteractionStreamHandle,
 };
 use crate::utils::FeedItem;
 use dioxus::prelude::*;
@@ -21,6 +21,12 @@ pub async fn fetch_and_stream_interactions(
         interactions_loaded.set(true);
         return;
     }
+
+    let local_counts = fetch_local_db_counts(&event_ids).await;
+    if !local_counts.is_empty() && *request_id.peek() == current_id {
+        interaction_counts.set(local_counts);
+    }
+
     let counts = if is_first_load {
         fetch_interaction_counts_batch(event_ids.clone(), Duration::from_secs(5)).await
     } else {

--- a/src/routes/home/feed_loaders.rs
+++ b/src/routes/home/feed_loaders.rs
@@ -10,7 +10,7 @@ use nostr_sdk::{Filter, Kind, PublicKey, Timestamp};
 use std::collections::HashSet;
 use std::time::Duration;
 
-fn feed_kinds() -> Vec<Kind> {
+pub fn feed_kinds() -> Vec<Kind> {
     vec![
         Kind::TextNote,
         Kind::Repost,
@@ -667,6 +667,76 @@ pub async fn load_people_list_feed(
             Err(NostrBlueError::Other(format!("Failed to load feed: {}", e)))
         }
     }
+}
+
+pub async fn load_relay_feed(
+    relay_urls: Vec<String>,
+    until: Option<u64>,
+) -> Result<Vec<FeedItem>, NostrBlueError> {
+    log::info!("Loading relay feed from {} relays (until: {:?})", relay_urls.len(), until);
+    let client = match crate::stores::nostr_client::get_client() {
+        Some(c) => c,
+        None => return Err(NostrBlueError::Other("Client not initialized".to_string())),
+    };
+    for url in &relay_urls {
+        let relay_url = match nostr_sdk::RelayUrl::parse(url) {
+            Ok(u) => u,
+            Err(_) => continue,
+        };
+        let relays = client.relays().await;
+        if !relays.contains_key(&relay_url) {
+            drop(relays);
+            if let Err(e) = client.add_read_relay(url).await {
+                log::warn!("Failed to add read relay {}: {}", url, e);
+                continue;
+            }
+        }
+        if let Err(e) = client.connect_relay(url).await {
+            log::warn!("Failed to connect relay {}: {}", url, e);
+        }
+    }
+    let mut filter = Filter::new().kinds(feed_kinds()).limit(100);
+    if let Some(until_ts) = until {
+        filter = filter.until(Timestamp::from(until_ts));
+    }
+    crate::stores::relay::connection::fetch_events_from_relays(
+        &client,
+        filter,
+        relay_urls.clone(),
+        Duration::from_secs(10),
+    )
+    .await
+    .map(|events| {
+        log::info!("Relay feed: received {} events", events.len());
+        let mut feed_items: Vec<FeedItem> = Vec::new();
+        for event in events.into_iter() {
+            if event.kind == Kind::Repost {
+                match extract_reposted_event(&event) {
+                    Ok(original) => {
+                        feed_items.push(FeedItem::Repost {
+                            original,
+                            reposted_by: event.pubkey,
+                            repost_timestamp: event.created_at,
+                        });
+                    }
+                    Err(e) => {
+                        log::warn!("Failed to parse repost event {}: {}", event.id, e);
+                    }
+                }
+            } else if event.kind == Kind::TextNote
+                || (event.kind == Kind::Comment
+                    && crate::stores::topic_store::is_topic_post(&event))
+            {
+                feed_items.push(FeedItem::OriginalPost(event));
+            }
+        }
+        feed_items.sort_by_key(|item| std::cmp::Reverse(item.sort_timestamp()));
+        feed_items
+    })
+    .map_err(|e| {
+        log::error!("Failed to fetch relay feed: {}", e);
+        NostrBlueError::Other(format!("Failed to load relay feed: {}", e))
+    })
 }
 
 #[cfg(test)]

--- a/src/routes/home/feed_loaders.rs
+++ b/src/routes/home/feed_loaders.rs
@@ -359,6 +359,24 @@ where
     let filter = build_following_feed_filter(authors, until, Timestamp::now());
     let mut all_items: Vec<FeedItem> = Vec::new();
     let mut seen_ids: HashSet<nostr_sdk::EventId> = HashSet::new();
+
+    #[cfg(feature = "native")]
+    {
+        if let Some(client) = nostr_client::get_client() {
+            if let Ok(db_events) = client.database().query(filter.clone()).await {
+                if !db_events.is_empty() {
+                    let db_items = process_events_to_feed_items(db_events.into_iter().collect());
+                    log::info!("nostrdb pre-step: {} items for feed", db_items.len());
+                    for item in &db_items {
+                        seen_ids.insert(item.event().id);
+                    }
+                    on_batch(db_items.clone());
+                    all_items = db_items;
+                }
+            }
+        }
+    }
+
     let stream_result =
         nostr_client::stream_events_immediate(filter, Duration::from_secs(10), |event| {
             let item = if event.kind == Kind::Repost {

--- a/src/routes/home/feed_loaders.rs
+++ b/src/routes/home/feed_loaders.rs
@@ -487,7 +487,17 @@ pub async fn load_following_with_replies(
         "Fetching all events (including replies and reposts) from {} followed accounts",
         filter.authors.as_ref().map(|a| a.len()).unwrap_or(0)
     );
-    match nostr_client::fetch_events_from_connected_relays(filter, Duration::from_secs(10)).await {
+    let fetch_result = {
+        #[cfg(feature = "native")]
+        {
+            nostr_client::fetch_events_ndb_first(filter, Duration::from_secs(10)).await
+        }
+        #[cfg(not(feature = "native"))]
+        {
+            nostr_client::fetch_events_from_connected_relays(filter, Duration::from_secs(10)).await
+        }
+    };
+    match fetch_result {
         Ok(events) => {
             log::info!(
                 "Loaded {} events (including replies and reposts) from following feed via outbox",
@@ -517,18 +527,36 @@ pub async fn load_following_with_replies(
             }
             feed_items.sort_by_key(|item| std::cmp::Reverse(item.sort_timestamp()));
             if feed_items.is_empty() {
-                log::info!("No events from followed users");
-                return Ok((Vec::new(), false));
+                log::info!(
+                    "No events from followed users (incl replies), trying favorite relays"
+                );
+                match try_feed_from_favorite_relays(&authors, until).await {
+                    Ok(extra_items) if !extra_items.is_empty() => {
+                        log::info!("Got {} items from favorite relays", extra_items.len());
+                        return Ok((extra_items, false));
+                    }
+                    _ => {
+                        return Ok((Vec::new(), false));
+                    }
+                }
             }
             Ok((feed_items, false))
         }
         Err(e) => {
             log::error!(
-                "Failed to fetch following feed with replies: {}, falling back to global",
+                "Failed to fetch following feed with replies: {}, trying favorite relays before global fallback",
                 e
             );
-            let global = load_global_feed(until).await?;
-            Ok((global, true))
+            match try_feed_from_favorite_relays(&authors, until).await {
+                Ok(extra_items) if !extra_items.is_empty() => {
+                    log::info!("Got {} items from favorite relays", extra_items.len());
+                    Ok((extra_items, false))
+                }
+                _ => {
+                    let global = load_global_feed(until).await?;
+                    Ok((global, true))
+                }
+            }
         }
     }
 }

--- a/src/routes/home/mod.rs
+++ b/src/routes/home/mod.rs
@@ -1131,6 +1131,7 @@ pub fn Home(list: String) -> Element {
     {
         let mut ndb_pending = pending_posts;
         let fstate = feed_state;
+        let ftype = feed_type;
         use_future(move || async move {
             loop {
                 crate::platform::timer::sleep_ms(500).await;
@@ -1162,8 +1163,13 @@ pub fn Home(list: String) -> Element {
                             Err(_) => None,
                         }
                     } else if event.kind == Kind::TextNote {
-                        let is_reply = event.tags.iter().any(|t| t.is_reply() || t.is_root());
-                        if !is_reply {
+                        let is_reply =
+                            event.tags.iter().any(|t| t.is_reply() || t.is_root());
+                        let include_replies = matches!(
+                            &*ftype.read(),
+                            FeedType::FollowingWithReplies
+                        );
+                        if !is_reply || include_replies {
                             Some(FeedItem::OriginalPost(event))
                         } else {
                             None

--- a/src/routes/home/mod.rs
+++ b/src/routes/home/mod.rs
@@ -11,15 +11,17 @@ use crate::error::NostrBlueError;
 use crate::hooks::{use_infinite_scroll, use_user_lists};
 use crate::services::aggregation::{InteractionCounts, InteractionStreamHandle};
 use crate::stores::feed_cache::{self, FeedCacheKey};
+use crate::stores::relay;
 use crate::stores::{auth_store, nostr_client, subscription_manager};
 use crate::stores::ui::scroll_restore;
+use crate::utils::list_kinds::NAMED_RELAYS;
 use crate::utils::{get_item_count, DataState, FeedItem};
 use dioxus::prelude::*;
 use engagement::{fetch_and_stream_interactions, fetch_paginated_interactions};
 use feed_loaders::{
-    exclusive_pagination_cursor, merge_paginated_feed_items, prefetch_author_metadata,
+    exclusive_pagination_cursor, feed_kinds, merge_paginated_feed_items, prefetch_author_metadata,
     load_following_feed, load_following_feed_streaming, load_following_with_replies,
-    load_global_feed, load_paginated_global_feed, load_people_list_feed,
+    load_global_feed, load_paginated_global_feed, load_people_list_feed, load_relay_feed,
 };
 use login::LoginSection;
 use nostr_sdk::{Filter, Kind, PublicKey, Timestamp};
@@ -49,12 +51,24 @@ pub fn Home(list: String) -> Element {
         use_signal(|| None);
     let mut request_id = use_signal(|| 0u32);
     let mut last_loaded_trigger = use_signal(|| (0u32, FeedType::Following, false));
+    let mut relay_feed_sub_id: Signal<Option<nostr_sdk::SubscriptionId>> =
+        use_signal(|| None);
+    let mut relay_feed_ephemeral_urls = use_signal(Vec::<String>::new);
+    let relay_url_input = use_signal(String::new);
     let (all_lists, _lists_loading, _lists_error, _) = use_user_lists();
     let people_lists = use_memo(move || {
         all_lists
             .read()
             .iter()
             .filter(|list| list.kind == crate::utils::list_kinds::NAMED_PEOPLE)
+            .cloned()
+            .collect::<Vec<_>>()
+    });
+    let relay_lists = use_memo(move || {
+        all_lists
+            .read()
+            .iter()
+            .filter(|list| list.kind == NAMED_RELAYS)
             .cloned()
             .collect::<Vec<_>>()
     });
@@ -647,6 +661,78 @@ pub fn Home(list: String) -> Element {
                         }
                     }
                 }
+                FeedType::RelayFeed { .. } | FeedType::RelaySetFeed { .. } => {
+                    let urls = current_feed_type.relay_urls();
+                    let cache_key = FeedCacheKey::RelayFeed {
+                        urls: urls.join(","),
+                    };
+                    let cached_items = feed_cache::load_cached_feed(&cache_key, 50)
+                        .await
+                        .unwrap_or_default();
+                    if is_stale() {
+                        return;
+                    }
+                    if !cached_items.is_empty() {
+                        feed_state.set(DataState::Loaded(cached_items.clone()));
+                    }
+                    let result = load_relay_feed(urls.clone(), None).await;
+                    if is_stale() {
+                        return;
+                    }
+                    match result {
+                        Ok(feed_items) => {
+                            if let Some(last_item) = feed_items.last() {
+                                oldest_timestamp.set(exclusive_pagination_cursor(Some(last_item)));
+                            }
+                            has_more.set(true);
+                            feed_state.set(DataState::Loaded(feed_items.clone()));
+                            if !is_stale() {
+                                let cache_key_for_store = cache_key;
+                                let items_for_cache = feed_items.clone();
+                                spawn(async move {
+                                    let _ = feed_cache::store_feed_items(
+                                        &cache_key_for_store,
+                                        &items_for_cache,
+                                    )
+                                    .await;
+                                    let _ = feed_cache::run_eviction_if_needed().await;
+                                });
+                            }
+                            if !is_stale() {
+                                let items_for_counts = feed_items.clone();
+                                let req_id = request_id;
+                                let curr_id = current_id;
+                                let ic = interaction_counts;
+                                let il = interactions_loaded;
+                                let ish = interaction_stream_handle;
+                                spawn(async move {
+                                    fetch_and_stream_interactions(
+                                        &items_for_counts,
+                                        is_first_load,
+                                        ic,
+                                        req_id,
+                                        curr_id,
+                                        il,
+                                        ish,
+                                    )
+                                    .await
+                                });
+                            }
+                            if !is_stale() {
+                                spawn(async move {
+                                    prefetch_author_metadata(&feed_items).await;
+                                });
+                            }
+                        }
+                        Err(e) => {
+                            if cached_items.is_empty() {
+                                feed_state.set(DataState::Error(e.to_string()));
+                            } else {
+                                log::warn!("Network error but showing cached data: {}", e);
+                            }
+                        }
+                    }
+                }
             }
         });
     });
@@ -683,6 +769,19 @@ pub fn Home(list: String) -> Element {
             });
         }
         interaction_stream_handle.set(None);
+        if let Some(sub_id) = relay_feed_sub_id.peek().clone() {
+            let ephemeral_urls = relay_feed_ephemeral_urls.peek().clone();
+            spawn(async move {
+                if let Some(client) = nostr_client::get_client() {
+                    let _ = client.unsubscribe(&sub_id).await;
+                    for url in &ephemeral_urls {
+                        let _ = client.force_remove_relay(url).await;
+                    }
+                }
+            });
+        }
+        relay_feed_sub_id.set(None);
+        relay_feed_ephemeral_urls.write().clear();
     });
 
     // Real-time subscriptions
@@ -720,6 +819,95 @@ pub fn Home(list: String) -> Element {
         };
         realtime_started.set(true);
         spawn(async move {
+            if current_feed_type.is_relay_feed() {
+                let urls = current_feed_type.relay_urls();
+                let client = match nostr_client::get_client() {
+                    Some(c) => c,
+                    None => return,
+                };
+                for url in &urls {
+                    let relay_url = match nostr_sdk::RelayUrl::parse(url) {
+                        Ok(u) => u,
+                        Err(_) => continue,
+                    };
+                    let relays = client.relays().await;
+                    if !relays.contains_key(&relay_url) {
+                        drop(relays);
+                        let _ = client.add_read_relay(url).await;
+                    }
+                    let _ = client.connect_relay(url).await;
+                }
+                let parsed_urls: Vec<nostr_sdk::RelayUrl> = urls
+                    .iter()
+                    .filter_map(|u| nostr_sdk::RelayUrl::parse(u).ok())
+                    .collect();
+                let filter = Filter::new().kinds(feed_kinds()).since(since_timestamp);
+                let sub_id = match client
+                    .subscribe_to(parsed_urls, filter, None)
+                    .await
+                {
+                    Ok(output) => {
+                        log::info!("Relay feed real-time subscription: {:?}", output.val);
+                        output.val
+                    }
+                    Err(e) => {
+                        log::error!("Failed to subscribe to relay feed: {}", e);
+                        return;
+                    }
+                };
+                relay_feed_sub_id.set(Some(sub_id.clone()));
+                relay_feed_ephemeral_urls.write().extend(urls.iter().cloned());
+                subscription_ids.write().push(sub_id.clone());
+                let mut pending = pending_posts;
+                let fstate = feed_state;
+                let mut notifications = client.notifications();
+                while let Ok(notification) = notifications.recv().await {
+                    if let nostr_sdk::RelayPoolNotification::Event {
+                        subscription_id: event_sub_id,
+                        event,
+                        ..
+                    } = notification
+                    {
+                        if event_sub_id != sub_id {
+                            continue;
+                        }
+                        let feed_item_opt = if event.kind == Kind::Repost {
+                            crate::utils::extract_reposted_event(&event).ok().map(|original| {
+                                FeedItem::Repost {
+                                    original,
+                                    reposted_by: event.pubkey,
+                                    repost_timestamp: event.created_at,
+                                }
+                            })
+                        } else if event.kind == Kind::TextNote
+                            || event.kind == Kind::Comment
+                            || event.kind.as_u16() == crate::utils::nip_bb::KIND_BLOBBI_STATE
+                        {
+                            Some(FeedItem::OriginalPost((*event).clone()))
+                        } else {
+                            None
+                        };
+                        if let Some(feed_item) = feed_item_opt {
+                            let event_id = feed_item.event().id;
+                            let already_buffered = pending
+                                .read()
+                                .iter()
+                                .any(|item| item.event().id == event_id);
+                            let already_in_feed = match &*fstate.peek() {
+                                DataState::Loaded(ref current_items) => current_items
+                                    .iter()
+                                    .any(|item| item.event().id == event_id),
+                                _ => false,
+                            };
+                            if !already_buffered && !already_in_feed {
+                                pending.write().push(feed_item);
+                            }
+                        }
+                    }
+                }
+                return;
+            }
+
             let pubkey_str = match auth_store::get_pubkey() {
                 Some(pk) => pk,
                 None => return,
@@ -800,7 +988,9 @@ pub fn Home(list: String) -> Element {
                                         .any(|tag| tag.is_reply() || tag.is_root()),
                                     FeedType::FollowingWithReplies
                                     | FeedType::Global
-                                    | FeedType::PeopleList(_) => true,
+                                    | FeedType::PeopleList(_)
+                                    | FeedType::RelayFeed { .. }
+                                    | FeedType::RelaySetFeed { .. } => true,
                                 };
                                 if should_add {
                                     Some(FeedItem::OriginalPost((*event).clone()))
@@ -1144,6 +1334,9 @@ pub fn Home(list: String) -> Element {
                 },
                 FeedType::Global => load_paginated_global_feed(until).await,
                 FeedType::PeopleList(list) => load_people_list_feed(&list, until).await,
+                FeedType::RelayFeed { .. } | FeedType::RelaySetFeed { .. } => {
+                    load_relay_feed(current_feed_type.relay_urls(), until).await
+                }
             };
             match fetch_result {
                 Ok(new_items) => {
@@ -1315,6 +1508,143 @@ pub fn Home(list: String) -> Element {
                                                         )
                                                         {
                                                             span { "✓" }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    {
+                                        let favorite_relays = {
+                                            use dioxus::prelude::ReadableExt;
+                                            let relays = relay::nip65::FAVORITE_RELAYS.peek().clone();
+                                            if relays.is_empty() {
+                                                relay::nip65::default_favorite_relays()
+                                            } else {
+                                                relays
+                                            }
+                                        };
+                                        let rlists = relay_lists.read().clone();
+                                        let has_relay_entries = !favorite_relays.is_empty() || !rlists.is_empty();
+                                        rsx! {
+                                            if has_relay_entries {
+                                                div { class: "border-t border-border" }
+                                                div { class: "px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wide",
+                                                    "Relay Feeds"
+                                                }
+                                            }
+                                            for url in &favorite_relays {
+                                                {
+                                                    let url_for_click = url.clone();
+                                                    let url_for_check = url.clone();
+                                                    let domain = url
+                                                        .trim_start_matches("wss://")
+                                                        .trim_start_matches("ws://")
+                                                        .trim_end_matches('/')
+                                                        .to_string();
+                                                    rsx! {
+                                                        button {
+                                                            key: "fav-{url}",
+                                                            class: "w-full px-4 py-3 text-left hover:bg-accent transition flex items-center justify-between",
+                                                            onclick: move |_| {
+                                                                feed_type.set(FeedType::RelayFeed {
+                                                                    url: url_for_click.clone(),
+                                                                    name: domain.clone(),
+                                                                });
+                                                                show_dropdown.set(false);
+                                                            },
+                                                            div {
+                                                                div { class: "font-medium", "📡 {domain}" }
+                                                                div { class: "text-xs text-muted-foreground truncate", "{url}" }
+                                                            }
+                                                            if matches!(
+                                                                feed_type.read().clone(),
+                                                                FeedType::RelayFeed { ref url, .. } if url == &url_for_check
+                                                            ) {
+                                                                span { "✓" }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            for list in rlists.iter() {
+                                                {
+                                                    let list_relay_urls: Vec<String> = list.tags.iter()
+                                                        .filter_map(|tag| {
+                                                            let s = tag.as_slice();
+                                                            if s.first().map(|v| v.as_str()) == Some("relay") {
+                                                                s.get(1).map(|v| v.to_string())
+                                                            } else {
+                                                                None
+                                                            }
+                                                        })
+                                                        .collect();
+                                                    let list_name_for_set = list.name.clone();
+                                                    let list_name_for_check = list.name.clone();
+                                                    let list_urls_for_set = list_relay_urls.clone();
+                                                    let list_urls_for_check = list_relay_urls.clone();
+                                                    let relay_count = list_relay_urls.len();
+                                                    rsx! {
+                                                        button {
+                                                            key: "rlist-{list.id}",
+                                                            class: "w-full px-4 py-3 text-left hover:bg-accent transition flex items-center justify-between",
+                                                            onclick: move |_| {
+                                                                if !list_urls_for_set.is_empty() {
+                                                                    feed_type.set(FeedType::RelaySetFeed {
+                                                                        name: list_name_for_set.clone(),
+                                                                        urls: list_urls_for_set.clone(),
+                                                                    });
+                                                                    show_dropdown.set(false);
+                                                                }
+                                                            },
+                                                            div {
+                                                                div { class: "font-medium", "📡 {list.name}" }
+                                                                div { class: "text-xs text-muted-foreground", "{relay_count} relays" }
+                                                            }
+                                                            if matches!(
+                                                                feed_type.read().clone(),
+                                                                FeedType::RelaySetFeed { ref name, ref urls, .. }
+                                                                if name == &list_name_for_check && urls == &list_urls_for_check
+                                                            ) {
+                                                                span { "✓" }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            {
+                                                let mut input_url = relay_url_input;
+                                                rsx! {
+                                                    div { class: "border-t border-border" }
+                                                    div { class: "px-4 py-2 flex gap-2",
+                                                        input {
+                                                            class: "flex-1 text-sm px-3 py-2 bg-muted border border-border rounded-lg focus:outline-none focus:ring-1 focus:ring-primary",
+                                                            r#type: "text",
+                                                            placeholder: "wss://relay.example.com",
+                                                            value: "{input_url}",
+                                                            oninput: move |e| {
+                                                                input_url.set(e.value());
+                                                            },
+                                                        }
+                                                        button {
+                                                            class: "px-3 py-2 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition",
+                                                            onclick: move |_| {
+                                                                let url = input_url.read().clone();
+                                                                if !url.is_empty() {
+                                                                    let domain = url
+                                                                        .trim_start_matches("wss://")
+                                                                        .trim_start_matches("ws://")
+                                                                        .trim_end_matches('/')
+                                                                        .to_string();
+                                                                    feed_type.set(FeedType::RelayFeed {
+                                                                        url: url.clone(),
+                                                                        name: domain,
+                                                                    });
+                                                                    show_dropdown.set(false);
+                                                                    input_url.set(String::new());
+                                                                }
+                                                            },
+                                                            "Go"
                                                         }
                                                     }
                                                 }

--- a/src/routes/home/mod.rs
+++ b/src/routes/home/mod.rs
@@ -354,10 +354,11 @@ pub fn Home(list: String) -> Element {
                                 oldest_timestamp.set(exclusive_pagination_cursor(Some(last_item)));
                             }
                             has_more.set(true);
-                            feed_state.set(DataState::Loaded(feed_items.clone()));
+                            accumulated_items = feed_cache::merge_feed_items(accumulated_items, feed_items.clone());
+                            feed_state.set(DataState::Loaded(accumulated_items.clone()));
                             if !is_stale() {
                                 let cache_key_for_store = effective_cache_key;
-                                let items_for_cache = feed_items.clone();
+                                let items_for_cache = accumulated_items.clone();
                                 spawn(async move {
                                     if let Err(e) = feed_cache::store_feed_items(
                                         &cache_key_for_store,
@@ -452,10 +453,11 @@ pub fn Home(list: String) -> Element {
                                 oldest_timestamp.set(exclusive_pagination_cursor(Some(last_item)));
                             }
                             has_more.set(true);
-                            feed_state.set(DataState::Loaded(feed_items.clone()));
+                            let merged = feed_cache::merge_feed_items(cached_items, feed_items.clone());
+                            feed_state.set(DataState::Loaded(merged.clone()));
                             if !is_stale() {
                                 let cache_key_for_store = effective_cache_key;
-                                let items_for_cache = feed_items.clone();
+                                let items_for_cache = merged;
                                 spawn(async move {
                                     let _ = feed_cache::store_feed_items(
                                         &cache_key_for_store,
@@ -1216,6 +1218,45 @@ pub fn Home(list: String) -> Element {
             anchor.feed_type_label = feed_type.read().label();
             log::debug!("Saved scroll position (sync): y={}", scroll_y);
         }
+
+        let ids = subscription_ids.peek().clone();
+        if !ids.is_empty() {
+            spawn(async move {
+                if let Some(client) = nostr_client::get_client() {
+                    log::info!(
+                        "Cleaning up {} real-time subscriptions on unmount",
+                        ids.len()
+                    );
+                    subscription_manager::unsubscribe_all(&client, &ids).await;
+                }
+            });
+        }
+        #[cfg(feature = "native")]
+        {
+            spawn(async move {
+                let _ = crate::stores::ndb::subscriptions::unsubscribe(
+                    crate::stores::ndb::subscriptions::SubKey::FollowingFeed,
+                )
+                .await;
+            });
+        }
+        if let Some(handle) = interaction_stream_handle.peek().clone() {
+            spawn(async move {
+                log::info!("Cleaning up interaction stream on unmount");
+                handle.unsubscribe().await;
+            });
+        }
+        if let Some(sub_id) = relay_feed_sub_id.peek().clone() {
+            let ephemeral_urls = relay_feed_ephemeral_urls.peek().clone();
+            spawn(async move {
+                if let Some(client) = nostr_client::get_client() {
+                    let _ = client.unsubscribe(&sub_id).await;
+                    for url in &ephemeral_urls {
+                        let _ = client.force_remove_relay(url).await;
+                    }
+                }
+            });
+        }
     });
 
     // Restore scroll position after feed content loads (only for popstate/back navigation)
@@ -1386,12 +1427,9 @@ pub fn Home(list: String) -> Element {
     let mut refresh_and_scroll_to_top = move || {
         let current = *refresh_trigger.read();
         refresh_trigger.set(current + 1);
-        #[cfg(feature = "web")]
-        {
-            if let Some(window) = web_sys::window() {
-                window.scroll_to_with_x_and_y(0.0, 0.0);
-            }
-        }
+        spawn(async move {
+            crate::stores::ui::scroll_restore::set_scroll_y(0.0).await;
+        });
     };
 
     let auth = auth_store::AUTH_STATE.read();

--- a/src/routes/home/types.rs
+++ b/src/routes/home/types.rs
@@ -7,6 +7,14 @@ pub enum FeedType {
     FollowingWithReplies,
     Global,
     PeopleList(Box<UserList>),
+    RelayFeed {
+        url: String,
+        name: String,
+    },
+    RelaySetFeed {
+        name: String,
+        urls: Vec<String>,
+    },
 }
 
 impl FeedType {
@@ -16,6 +24,20 @@ impl FeedType {
             FeedType::FollowingWithReplies => "Following + Replies".to_string(),
             FeedType::Global => "Global".to_string(),
             FeedType::PeopleList(list) => list.name.clone(),
+            FeedType::RelayFeed { name, .. } => name.clone(),
+            FeedType::RelaySetFeed { name, .. } => name.clone(),
+        }
+    }
+
+    pub fn is_relay_feed(&self) -> bool {
+        matches!(self, FeedType::RelayFeed { .. } | FeedType::RelaySetFeed { .. })
+    }
+
+    pub fn relay_urls(&self) -> Vec<String> {
+        match self {
+            FeedType::RelayFeed { url, .. } => vec![url.clone()],
+            FeedType::RelaySetFeed { urls, .. } => urls.clone(),
+            _ => Vec::new(),
         }
     }
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -804,10 +804,7 @@ fn Layout() -> Element {
             let _ = route.clone();
             spawn(async move {
                 if !crate::stores::ui::scroll_restore::was_popstate_nav().await {
-                    #[cfg(feature = "web")]
-                    if let Some(window) = web_sys::window() {
-                        window.scroll_to_with_x_and_y(0.0, 0.0);
-                    }
+                    crate::stores::ui::scroll_restore::set_scroll_y(0.0).await;
                 }
                 crate::platform::timer::sleep_ms(100).await;
                 crate::stores::ui::scroll_restore::clear_popstate_flag().await;
@@ -1113,10 +1110,9 @@ fn Layout() -> Element {
                                         class: "flex items-center gap-2 hover:opacity-80 transition mb-6 cursor-pointer",
                                         onclick: move |_| {
                                             if is_home_page {
-                                                #[cfg(feature = "web")]
-                                                if let Some(window) = web_sys::window() {
-                                                    window.scroll_to_with_x_and_y(0.0, 0.0);
-                                                }
+                                                spawn(async move {
+                                                    crate::stores::ui::scroll_restore::set_scroll_y(0.0).await;
+                                                });
                                             } else {
                                                 navigator.push(Route::Home { list: String::new() });
                                             }
@@ -1149,10 +1145,9 @@ fn Layout() -> Element {
                                                         onclick: move |_| {
                                                             *sidebar_page.write() = 0;
                                                             if is_home_page {
-                                                                #[cfg(feature = "web")]
-                                                                if let Some(window) = web_sys::window() {
-                                                                    window.scroll_to_with_x_and_y(0.0, 0.0);
-                                                                }
+                                                                spawn(async move {
+                                                                    crate::stores::ui::scroll_restore::set_scroll_y(0.0).await;
+                                                                });
                                                             } else {
                                                                 navigator.push(Route::Home { list: String::new() });
                                                             }
@@ -1319,10 +1314,9 @@ fn Layout() -> Element {
                                                     *sidebar_open.write() = false;
                                                     *sidebar_page.write() = 0;
                                                     if is_home_page {
-                                                        #[cfg(feature = "web")]
-                                                        if let Some(window) = web_sys::window() {
-                                                            window.scroll_to_with_x_and_y(0.0, 0.0);
-                                                        }
+                                                        spawn(async move {
+                                                            crate::stores::ui::scroll_restore::set_scroll_y(0.0).await;
+                                                        });
                                                     } else {
                                                         navigator.push(Route::Home { list: String::new() });
                                                     }
@@ -1358,10 +1352,9 @@ fn Layout() -> Element {
                                                                     *sidebar_open.write() = false;
                                                                     *sidebar_page.write() = 0;
                                                                     if is_home_page {
-                                                                        #[cfg(feature = "web")]
-                                                                        if let Some(window) = web_sys::window() {
-                                                                            window.scroll_to_with_x_and_y(0.0, 0.0);
-                                                                        }
+                                                                        spawn(async move {
+                                                                            crate::stores::ui::scroll_restore::set_scroll_y(0.0).await;
+                                                                        });
                                                                     } else {
                                                                         navigator.push(Route::Home { list: String::new() });
                                                                     }

--- a/src/routes/music/leaderboard.rs
+++ b/src/routes/music/leaderboard.rs
@@ -328,7 +328,7 @@ async fn fetch_leaderboard_data() -> Result<Vec<LeaderboardEntry>, String> {
                     let pubkey = parts[1].to_string();
                     let d_tag = parts[2..].join(":");
                     match crate::stores::nostr_music::fetch_nostr_track_by_coordinate(
-                        &pubkey, &d_tag,
+                        &pubkey, &d_tag, vec![],
                     )
                     .await
                     {

--- a/src/routes/music/music_home.rs
+++ b/src/routes/music/music_home.rs
@@ -181,7 +181,7 @@ pub fn MusicHome() -> Element {
                                             }
                                         });
                                         let track =
-                                            MusicTrack::from_rss_music_track(&episode, &feed);
+                                            MusicTrack::from_rss_music_track(&episode, &feed, item.image.as_deref());
                                         Some((item.rank, item.boosts, track))
                                     }
                                     Err(e) => {

--- a/src/routes/music/music_search.rs
+++ b/src/routes/music/music_search.rs
@@ -188,7 +188,7 @@ pub fn MusicSearch(q: String) -> Element {
                             podcast_index::get_episodes_by_feed_id(album.id, Some(3), None).await
                         {
                             for ep in &episodes {
-                                tracks.push(MusicTrack::from_rss_music_track(ep, album));
+                                tracks.push(MusicTrack::from_rss_music_track(ep, album, None));
                             }
                         }
                     }

--- a/src/routes/music/playlist_detail.rs
+++ b/src/routes/music/playlist_detail.rs
@@ -14,7 +14,7 @@ pub fn MusicPlaylistDetail(naddr: String) -> Element {
         loading.set(true);
         error_msg.set(None);
         spawn(async move {
-            let (pubkey, d_tag) = match crate::utils::nip19::parse_naddr(&naddr_clone) {
+            let parsed = match crate::utils::nip19::parse_naddr(&naddr_clone) {
                 Ok(result) => result,
                 Err(e) => {
                     error_msg.set(Some(e));
@@ -22,7 +22,7 @@ pub fn MusicPlaylistDetail(naddr: String) -> Element {
                     return;
                 }
             };
-            match nostr_music::fetch_playlist_by_coordinate(&pubkey, &d_tag).await {
+            match nostr_music::fetch_playlist_by_coordinate(&parsed.pubkey, &parsed.identifier, parsed.relay_hints).await {
                 Ok(Some(pl)) => {
                     playlist.set(Some(pl.clone()));
                     if let Ok(profile) = profiles::fetch_profile(pl.pubkey.clone()).await {

--- a/src/routes/music/rss_album.rs
+++ b/src/routes/music/rss_album.rs
@@ -120,6 +120,7 @@ pub fn MusicRssAlbum(feed_id: u64) -> Element {
                                                     src: "{art_url}",
                                                     alt: "{feed.title}",
                                                     class: "w-full h-full object-cover",
+                                                    referrerpolicy: "no-referrer",
                                                 }
                                             } else {
                                                 MusicIcon { class: "w-24 h-24 text-muted-foreground" }

--- a/src/routes/music/rss_album.rs
+++ b/src/routes/music/rss_album.rs
@@ -58,7 +58,7 @@ pub fn MusicRssAlbum(feed_id: u64) -> Element {
             episodes_state
                 .read()
                 .iter()
-                .map(|ep| MusicTrack::from_rss_music_track(ep, feed))
+                .map(|ep| MusicTrack::from_rss_music_track(ep, feed, None))
                 .collect::<Vec<MusicTrack>>()
         } else {
             Vec::new()

--- a/src/routes/music/track_detail.rs
+++ b/src/routes/music/track_detail.rs
@@ -414,8 +414,8 @@ fn TrackDetailSkeleton() -> Element {
 pub(crate) async fn fetch_track(id: &str) -> Result<music_player::MusicTrack, String> {
     if id.starts_with("naddr1") {
         // Nostr track (kind 36787)
-        let (pubkey, d_tag) = crate::utils::nip19::parse_naddr(id)?;
-        let nostr_track = nostr_music::fetch_nostr_track_by_coordinate(&pubkey, &d_tag)
+        let parsed = crate::utils::nip19::parse_naddr(id)?;
+        let nostr_track = nostr_music::fetch_nostr_track_by_coordinate(&parsed.pubkey, &parsed.identifier, parsed.relay_hints)
             .await?
             .ok_or("Track not found")?;
 

--- a/src/routes/music/track_detail.rs
+++ b/src/routes/music/track_detail.rs
@@ -447,7 +447,7 @@ pub(crate) async fn fetch_track(id: &str) -> Result<music_player::MusicTrack, St
             .ok_or("Track not found")?;
 
         Ok(music_player::MusicTrack::from_rss_music_track(
-            episode, &feed,
+            episode, &feed, None,
         ))
     } else {
         // Wavlake track (UUID)

--- a/src/routes/note.rs
+++ b/src/routes/note.rs
@@ -8,7 +8,8 @@ use crate::components::{ClientInitializing, EditProposalCard, NoteCard, Threaded
 use crate::hooks::{use_mute_block_cache, use_relay_subscription};
 use crate::routes::Route;
 use crate::services::aggregation::{
-    fetch_interaction_counts_batch, InteractionCounts,
+    fetch_interaction_counts_batch, fetch_local_db_counts, stream_interaction_counts,
+    InteractionCounts, InteractionStreamHandle,
 };
 use crate::stores::back_navigation;
 use crate::stores::nostr_client;
@@ -580,6 +581,8 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
     let mut error = use_signal(|| None::<String>);
     let mut interaction_counts: Signal<HashMap<String, InteractionCounts>> =
         use_signal(HashMap::new);
+    let mut interaction_stream_handle: Signal<Option<InteractionStreamHandle>> =
+        use_signal(|| None);
     let (cached_muted_posts, cached_blocked_users) = use_mute_block_cache();
     let mut load_generation = use_signal(|| 0u32);
     let mut reply_ids: Signal<HashSet<EventId>> = use_signal(HashSet::new);
@@ -731,13 +734,22 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
             all_events.extend(parent_events.peek().iter().cloned());
             all_events.extend(replies.peek().iter().cloned());
             let mut ic = interaction_counts;
+            let mut ic_stream = interaction_stream_handle;
             let ids_for_counts: Vec<EventId> = all_events.iter().map(|e| e.id).collect();
             let ids_clone = ids_for_counts.clone();
+            let ids_for_stream = ids_for_counts.clone();
+            let lg_stream = this_generation;
             spawn(async move {
                 profile_prefetch::prefetch_event_authors(&all_events).await;
             });
             if !ids_clone.is_empty() {
                 spawn(async move {
+                    let local_counts = fetch_local_db_counts(&ids_clone).await;
+                    if !local_counts.is_empty()
+                        && *load_generation.peek() == this_generation
+                    {
+                        ic.set(local_counts);
+                    }
                     if let Ok(counts) =
                         fetch_interaction_counts_batch(ids_clone, Duration::from_secs(5))
                             .await
@@ -746,6 +758,15 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
                             return;
                         }
                         ic.set(counts);
+                        if let Ok(handle) =
+                            stream_interaction_counts(ids_for_stream, ic, Some(600)).await
+                        {
+                            if *load_generation.peek() != lg_stream {
+                                handle.unsubscribe().await;
+                                return;
+                            }
+                            ic_stream.set(Some(handle));
+                        }
                     }
                 });
             }
@@ -778,6 +799,11 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
 
     use_drop(move || {
         back_navigation::clear_active_note_back_context(&note_id);
+        if let Some(handle) = interaction_stream_handle.write().take() {
+            spawn(async move {
+                handle.unsubscribe().await;
+            });
+        }
     });
 
     rsx! {

--- a/src/routes/note.rs
+++ b/src/routes/note.rs
@@ -355,10 +355,71 @@ async fn fetch_author_relays_replies(
     result
 }
 
-async fn fetch_replies_fast(
+fn merge_new_replies(
+    new_events: Vec<NostrEvent>,
+    mut replies: Signal<Vec<NostrEvent>>,
+    mut reply_ids: Signal<HashSet<EventId>>,
+) {
+    let mut added = false;
+    for event in new_events {
+        if reply_ids.write().insert(event.id) {
+            replies.write().push(event);
+            added = true;
+        }
+    }
+    if added {
+        replies.write().sort_by_key(|a| a.created_at);
+    }
+}
+
+async fn fetch_replies_db(
+    event_id: EventId,
+) -> std::result::Result<Vec<NostrEvent>, String> {
+    let Some(client) = nostr_client::get_client() else {
+        return Err("Client not initialized".to_string());
+    };
+    let event_id_hex = event_id.to_hex();
+
+    let filter_lower = Filter::new()
+        .kinds(vec![
+            Kind::TextNote,
+            Kind::VoiceMessage,
+            Kind::VoiceMessageReply,
+            Kind::Custom(crate::stores::nostr_client::edits::KIND_NOTE_EDIT),
+        ])
+        .event(event_id)
+        .limit(100);
+
+    let upper_e_tag = nostr_sdk::SingleLetterTag::uppercase(nostr_sdk::Alphabet::E);
+    let filter_upper = Filter::new()
+        .kinds(vec![
+            Kind::VoiceMessage,
+            Kind::VoiceMessageReply,
+            Kind::Comment,
+        ])
+        .custom_tag(upper_e_tag, event_id_hex)
+        .limit(100);
+
+    let (lower_db, upper_db) = tokio::join!(
+        client.database().query(filter_lower),
+        client.database().query(filter_upper),
+    );
+
+    let mut db_replies = Vec::new();
+    if let Ok(events) = lower_db {
+        db_replies.extend(events);
+    }
+    if let Ok(events) = upper_db {
+        db_replies.extend(events);
+    }
+
+    Ok(dedup_replies(db_replies))
+}
+
+async fn fetch_replies_from_relays(
     event_id: EventId,
     root_author_pubkey: Option<PublicKey>,
-) -> std::result::Result<(Vec<NostrEvent>, HashSet<PublicKey>), String> {
+) -> std::result::Result<Vec<NostrEvent>, String> {
     let event_id_hex = event_id.to_hex();
 
     let filter_lower = Filter::new()
@@ -382,8 +443,8 @@ async fn fetch_replies_fast(
         .limit(100);
 
     let (lower_result, upper_result, author_result) = tokio::join!(
-        nostr_client::fetch_events_aggregated_outbox(filter_lower, Duration::from_secs(5)),
-        nostr_client::fetch_events_aggregated_outbox(filter_upper, Duration::from_secs(5)),
+        nostr_client::fetch_events_from_connected_relays(filter_lower, Duration::from_secs(5)),
+        nostr_client::fetch_events_from_connected_relays(filter_upper, Duration::from_secs(5)),
         async {
             match root_author_pubkey {
                 Some(pk) => fetch_author_relays_replies(event_id, &pk).await,
@@ -401,9 +462,7 @@ async fn fetch_replies_fast(
     }
     all_replies.extend(author_result);
 
-    let reply_authors: HashSet<PublicKey> = all_replies.iter().map(|e| e.pubkey).collect();
-    let unique_replies = dedup_replies(all_replies);
-    Ok((unique_replies, reply_authors))
+    Ok(dedup_replies(all_replies))
 }
 
 const MAX_EPHEMERAL_RELAYS: usize = 5;
@@ -411,7 +470,8 @@ const MAX_EPHEMERAL_RELAYS: usize = 5;
 async fn fetch_replies_phase2(
     event_id: EventId,
     reply_authors: HashSet<PublicKey>,
-    mut replies_signal: Signal<Vec<NostrEvent>>,
+    replies_signal: Signal<Vec<NostrEvent>>,
+    reply_ids_signal: Signal<HashSet<EventId>>,
     load_generation: Signal<u32>,
     this_generation: u32,
 ) {
@@ -477,12 +537,8 @@ async fn fetch_replies_phase2(
                     relay::coverage::cleanup_ephemeral_relays(&client, &ephemeral.newly_added).await;
                     return;
                 }
-                let mut existing = replies_signal.read().clone();
-                existing.extend(events);
-                let mut merged = dedup_replies(existing);
-                merged.sort_by_key(|a| a.created_at);
-                log::info!("Phase 2: added {} additional replies", merged.len());
-                replies_signal.set(merged);
+                log::info!("Phase 2: merging {} additional replies", events.len());
+                merge_new_replies(events, replies_signal, reply_ids_signal);
             }
             relay::coverage::cleanup_ephemeral_relays(&client, &ephemeral.newly_added).await;
         }
@@ -526,6 +582,7 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
         use_signal(HashMap::new);
     let (cached_muted_posts, cached_blocked_users) = use_mute_block_cache();
     let mut load_generation = use_signal(|| 0u32);
+    let mut reply_ids: Signal<HashSet<EventId>> = use_signal(HashSet::new);
 
     use_effect(use_reactive!(|note_id| {
         let note_id_str = note_id.clone();
@@ -537,6 +594,7 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
         replies.set(Vec::new());
         parent_events.set(Vec::new());
         interaction_counts.set(HashMap::new());
+        reply_ids.set(HashSet::new());
         loading.set(true);
         loading_parents.set(true);
         error.set(None);
@@ -555,24 +613,43 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
             return;
         }
 
+        let event_id = match parse_event_id(&note_id_str) {
+            Some(p) => p.event_id,
+            None => match EventId::from_hex(&note_id_str) {
+                Ok(id) => id,
+                Err(e) => {
+                    error.set(Some(format!("Invalid note ID: {}", e)));
+                    loading.set(false);
+                    loading_parents.set(false);
+                    return;
+                }
+            },
+        };
+
+        let mut replies_early = replies;
+        let mut reply_ids_early = reply_ids;
+        let lg = load_generation;
+        let gen = this_generation;
+
         spawn(async move {
+            // Phase 0: DB query for replies (instant, ~1ms)
+            if let Ok(db_replies) = fetch_replies_db(event_id).await {
+                if *lg.peek() != gen { return; }
+                let db_ids: HashSet<EventId> = db_replies.iter().map(|e| e.id).collect();
+                let db_count = db_replies.len();
+                reply_ids_early.set(db_ids);
+                replies_early.set(db_replies);
+                loading_parents.set(false);
+                log::info!("Phase 0: loaded {} replies from DB cache", db_count);
+            }
+        });
+
+        spawn(async move {
+            // Phase 1: Fetch main note (DB-first, then relays)
             let note_result = fetch_main_note(&note_id_str).await;
             if *load_generation.peek() != this_generation {
                 return;
             }
-
-            let event_id = match parse_event_id(&note_id_str) {
-                Some(p) => p.event_id,
-                None => match EventId::from_hex(&note_id_str) {
-                    Ok(id) => id,
-                    Err(e) => {
-                        error.set(Some(format!("Invalid note ID: {}", e)));
-                        loading.set(false);
-                        loading_parents.set(false);
-                        return;
-                    }
-                },
-            };
 
             let parent_ids = match &note_result {
                 Ok(event) => {
@@ -596,9 +673,10 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
             let clicked_note = note_result.as_ref().unwrap().clone();
             let root_author = clicked_note.pubkey;
 
-            let (parents_result, replies_result) = tokio::join!(
+            // Phase 2: Fetch parents + relay replies concurrently
+            let (parents_result, relay_replies_result) = tokio::join!(
                 fetch_parents_with_hints(parent_ids, &clicked_note, 5),
-                fetch_replies_fast(event_id, Some(root_author))
+                fetch_replies_from_relays(event_id, Some(root_author))
             );
 
             if *load_generation.peek() != this_generation {
@@ -614,22 +692,31 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
                 );
                 parent_events.set(parents);
             }
-            if let Ok((mut reply_vec, phase2_authors)) = replies_result {
-                reply_vec.sort_by_key(|a| a.created_at);
-                log::info!("Phase 1: loaded {} replies", reply_vec.len());
-                replies.set(reply_vec);
 
-                if !phase2_authors.is_empty() {
+            if let Ok(relay_replies) = relay_replies_result {
+                let relay_count = relay_replies.len();
+                let reply_authors: HashSet<PublicKey> =
+                    relay_replies.iter().map(|e| e.pubkey).collect();
+
+                merge_new_replies(relay_replies, replies, reply_ids);
+                log::info!(
+                    "Phase 1: merged {} relay replies (total now {})",
+                    relay_count,
+                    replies.peek().len()
+                );
+
+                if !reply_authors.is_empty() {
                     let replies_bg = replies;
-                    let gen = this_generation;
-                    let lg = load_generation;
+                    let lg = this_generation;
+                    let load_gen = load_generation;
                     spawn(async move {
                         fetch_replies_phase2(
                             event_id,
-                            phase2_authors,
+                            reply_authors,
                             replies_bg,
+                            reply_ids,
+                            load_gen,
                             lg,
-                            gen,
                         )
                         .await;
                     });
@@ -643,15 +730,16 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
             }
             all_events.extend(parent_events.peek().iter().cloned());
             all_events.extend(replies.peek().iter().cloned());
-            if !all_events.is_empty() {
-                let mut ic = interaction_counts;
-                let ids_for_counts: Vec<EventId> = all_events.iter().map(|e| e.id).collect();
+            let mut ic = interaction_counts;
+            let ids_for_counts: Vec<EventId> = all_events.iter().map(|e| e.id).collect();
+            let ids_clone = ids_for_counts.clone();
+            spawn(async move {
+                profile_prefetch::prefetch_event_authors(&all_events).await;
+            });
+            if !ids_clone.is_empty() {
                 spawn(async move {
-                    profile_prefetch::prefetch_event_authors(&all_events).await;
-                });
-                if !ids_for_counts.is_empty() {
                     if let Ok(counts) =
-                        fetch_interaction_counts_batch(ids_for_counts, Duration::from_secs(5))
+                        fetch_interaction_counts_batch(ids_clone, Duration::from_secs(5))
                             .await
                     {
                         if *load_generation.peek() != this_generation {
@@ -659,11 +747,8 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
                         }
                         ic.set(counts);
                     }
-                }
+                });
             }
-
-            loading.set(false);
-            loading_parents.set(false);
         });
     }));
 
@@ -681,8 +766,7 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
                 .limit(0)
         });
         use_relay_subscription(reply_filter, move |event: &nostr::Event| {
-            let already_exists = replies.read().iter().any(|e| e.id == event.id);
-            if !already_exists {
+            if reply_ids.write().insert(event.id) {
                 log::info!(
                     "New reply received via streaming: {}",
                     event.id.to_hex()
@@ -798,8 +882,7 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
                                 cached_muted_posts: cached_muted_posts.read().clone(),
                                 cached_blocked_users: cached_blocked_users.read().clone(),
                                 on_reply: move |reply_event: NostrEvent| {
-                                    let already_exists = replies.read().iter().any(|e| e.id == reply_event.id);
-                                    if !already_exists {
+                                    if reply_ids.write().insert(reply_event.id) {
                                         log::info!("Adding reply optimistically from main note: {}", reply_event.id.to_hex());
                                         replies.write().push(reply_event);
                                         crate::utils::thread_tree::invalidate_thread_tree_cache(&root_event_id);
@@ -854,8 +937,7 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
                                         cached_muted_posts: cached_muted_posts.read().clone(),
                                         cached_blocked_users: cached_blocked_users.read().clone(),
                                         on_reply: move |reply_event: NostrEvent| {
-                                            let already_exists = replies.read().iter().any(|e| e.id == reply_event.id);
-                                            if !already_exists {
+                                            if reply_ids.write().insert(reply_event.id) {
                                                 log::info!("Adding reply optimistically: {}", reply_event.id.to_hex());
                                                 replies.write().push(reply_event);
                                                 crate::utils::thread_tree::invalidate_thread_tree_cache(&root_event_id);

--- a/src/routes/note.rs
+++ b/src/routes/note.rs
@@ -424,7 +424,7 @@ async fn fetch_replies_db(
             Kind::Custom(crate::stores::nostr_client::edits::KIND_NOTE_EDIT),
         ];
         let bridge_replies = crate::stores::ndb::get_cached_replies(&event_id, &reply_kinds);
-        log::info!("fetch_replies_db: bridge cache found {} replies for {:?}", bridge_replies.len(), event_id.to_hex());
+        log::debug!("fetch_replies_db: bridge cache found {} replies for {:?}", bridge_replies.len(), event_id.to_hex());
         db_replies.extend(bridge_replies);
     }
 

--- a/src/routes/note.rs
+++ b/src/routes/note.rs
@@ -593,6 +593,12 @@ pub fn Note(note_id: String, from_voice: Option<String>) -> Element {
         let this_generation = load_generation.peek().wrapping_add(1);
         load_generation.set(this_generation);
 
+        if let Some(handle) = interaction_stream_handle.write().take() {
+            spawn(async move {
+                handle.unsubscribe().await;
+            });
+        }
+
         note_data.set(None);
         replies.set(Vec::new());
         parent_events.set(Vec::new());

--- a/src/routes/note.rs
+++ b/src/routes/note.rs
@@ -414,6 +414,20 @@ async fn fetch_replies_db(
         db_replies.extend(events);
     }
 
+    #[cfg(feature = "native")]
+    {
+        let reply_kinds = vec![
+            Kind::TextNote,
+            Kind::VoiceMessage,
+            Kind::VoiceMessageReply,
+            Kind::Comment,
+            Kind::Custom(crate::stores::nostr_client::edits::KIND_NOTE_EDIT),
+        ];
+        let bridge_replies = crate::stores::ndb::get_cached_replies(&event_id, &reply_kinds);
+        log::info!("fetch_replies_db: bridge cache found {} replies for {:?}", bridge_replies.len(), event_id.to_hex());
+        db_replies.extend(bridge_replies);
+    }
+
     Ok(dedup_replies(db_replies))
 }
 

--- a/src/routes/podcast/home.rs
+++ b/src/routes/podcast/home.rs
@@ -498,6 +498,7 @@ fn BrowsePodcastRow(props: BrowsePodcastRowProps) -> Element {
                 src: "{image}",
                 alt: "{props.title}",
                 class: "w-14 h-14 rounded-lg object-cover shrink-0",
+                referrerpolicy: "no-referrer",
             }
             div { class: "flex-1 min-w-0",
                 div { class: "font-medium truncate", "{props.title}" }
@@ -569,6 +570,7 @@ fn TrendingPodcastCard(props: TrendingPodcastCardProps) -> Element {
                         alt: "{feed.title}",
                         class: "w-full h-full object-cover",
                         loading: "lazy",
+                        referrerpolicy: "no-referrer",
                     }
                 } else {
                     div {
@@ -1201,6 +1203,7 @@ fn SubscribedPodcastRow(props: SubscribedPodcastRowProps) -> Element {
                         src: "{image}",
                         alt: "{title}",
                         class: "w-12 h-12 rounded object-cover",
+                        referrerpolicy: "no-referrer",
                     }
                     div { class: "flex-1 min-w-0",
                         div { class: "font-medium truncate", "{title}" }
@@ -1442,6 +1445,7 @@ fn SearchResultRow(props: SearchResultRowProps) -> Element {
                 src: "{image}",
                 alt: "{props.title}",
                 class: "w-12 h-12 rounded object-cover shrink-0",
+                referrerpolicy: "no-referrer",
             }
             div { class: "flex-1 min-w-0",
                 div { class: "font-medium truncate", "{props.title}" }
@@ -1929,6 +1933,7 @@ fn SubscribedFeedCard(props: SubscribedFeedCardProps) -> Element {
                         src: "{img}",
                         alt: "{title}",
                         class: "w-full h-full object-cover",
+                        referrerpolicy: "no-referrer",
                     }
                 } else {
                     div {

--- a/src/routes/podcast/home.rs
+++ b/src/routes/podcast/home.rs
@@ -463,9 +463,7 @@ fn BrowsePodcastsByCategory(props: BrowsePodcastsByCategoryProps) -> Element {
                                 image: show.image.clone(),
                                 is_nostr: true,
                                 has_v4v: true,
-                                route: Route::PodcastNostrDetail {
-                                    naddr: show.id.clone(),
-                                },
+                                route: get_show_route(show),
                             }
                         }
                     }

--- a/src/routes/podcast/podcast_episode_detail.rs
+++ b/src/routes/podcast/podcast_episode_detail.rs
@@ -21,7 +21,7 @@ use crate::utils::podcast::{self, PodcastMetadata};
 use dioxus::prelude::*;
 use nostr_sdk::nips::nip01::Coordinate;
 use nostr_sdk::nips::nip19::ToBech32;
-use nostr_sdk::prelude::{Filter, Kind, PublicKey, SingleLetterTag};
+use nostr_sdk::prelude::{Filter, Kind, PublicKey};
 use std::time::Duration;
 
 enum RssEpisodeDetailState {
@@ -532,21 +532,19 @@ fn EpisodeDetailSkeleton() -> Element {
 }
 /// Fetch Nostr podcast episode by naddr/coordinate
 async fn fetch_nostr_episode(naddr: &str) -> Result<(DisplayEpisode, PodcastMetadata), String> {
-    let (pubkey, d_tag) = crate::utils::nip19::parse_naddr(naddr)?;
-    let episode_filter = Filter::new()
-        .kind(Kind::from(podcast::KIND_PODCAST_EPISODE))
-        .author(PublicKey::from_hex(&pubkey).map_err(|e| e.to_string())?)
-        .custom_tag(SingleLetterTag::from_char('d').unwrap(), d_tag.clone())
-        .limit(1);
-    let episode_events =
-        nostr_client::fetch_events_aggregated(episode_filter, Duration::from_secs(10)).await?;
-    let episode_event = episode_events
-        .first()
-        .ok_or_else(|| "Episode not found".to_string())?;
-    let episode = podcast::parse_podcast_episode(episode_event)?;
+    let parsed = crate::utils::nip19::parse_naddr(naddr)?;
+    let episode_event = nostr_client::fetch_event_by_coordinate_with_relays(
+        parsed.kind,
+        parsed.pubkey.clone(),
+        parsed.identifier,
+        parsed.relay_hints,
+    )
+    .await?
+    .ok_or_else(|| "Episode not found".to_string())?;
+    let episode = podcast::parse_podcast_episode(&episode_event)?;
     let metadata_filter = Filter::new()
         .kind(Kind::from(podcast::KIND_APP_DATA))
-        .author(PublicKey::from_hex(&pubkey).map_err(|e| e.to_string())?)
+        .author(PublicKey::from_hex(&parsed.pubkey).map_err(|e| e.to_string())?)
         .limit(1);
     let metadata_events =
         nostr_client::fetch_events_aggregated(metadata_filter, Duration::from_secs(5)).await?;
@@ -566,7 +564,7 @@ async fn fetch_nostr_episode(naddr: &str) -> Result<(DisplayEpisode, PodcastMeta
         website: None,
         funding: Vec::new(),
         value: None,
-        pubkey: pubkey.clone(),
+        pubkey: parsed.pubkey.clone(),
         d_tag: "".to_string(),
         created_at: 0,
     });

--- a/src/routes/podcast/podcast_episode_detail.rs
+++ b/src/routes/podcast/podcast_episode_detail.rs
@@ -214,6 +214,7 @@ fn EpisodeDetailContent(props: EpisodeDetailContentProps) -> Element {
                                 src: "{image_url}",
                                 alt: "{episode.title}",
                                 class: "w-full aspect-square rounded-lg object-cover shadow-lg",
+                                referrerpolicy: "no-referrer",
                             }
                         }
                         div { class: "flex-1 min-w-0",

--- a/src/routes/podcast/podcast_nostr_detail.rs
+++ b/src/routes/podcast/podcast_nostr_detail.rs
@@ -188,6 +188,7 @@ fn PodcastDetailContent(props: PodcastDetailContentProps) -> Element {
                             src: "{image_url}",
                             alt: "{metadata.title}",
                             class: "w-32 h-32 md:w-40 md:h-40 rounded-lg object-cover shadow-lg",
+                            referrerpolicy: "no-referrer",
                         }
                         div { class: "flex-1 min-w-0",
                             h1 { class: "text-2xl font-bold truncate", "{metadata.title}" }

--- a/src/routes/podcast/podcast_nostr_detail.rs
+++ b/src/routes/podcast/podcast_nostr_detail.rs
@@ -13,7 +13,7 @@ use crate::routes::Route;
 use crate::stores::{auth_store, nostr_client, podcast_subscription};
 use crate::utils::podcast::{self, PodcastMetadata};
 use dioxus::prelude::*;
-use nostr_sdk::prelude::{Filter, Kind, PublicKey, SingleLetterTag, Timestamp};
+use nostr_sdk::prelude::{Filter, Kind, PublicKey, Timestamp};
 use std::collections::HashSet;
 use std::time::Duration;
 #[derive(Props, Clone, PartialEq)]
@@ -384,19 +384,19 @@ fn PodcastDetailSkeleton() -> Element {
 async fn fetch_nostr_podcast_metadata(
     naddr: &str,
 ) -> std::result::Result<(PodcastMetadata, String), String> {
-    let (pubkey, d_tag) = crate::utils::nip19::parse_naddr(naddr)?;
-    let metadata_filter = Filter::new()
-        .kind(Kind::from(podcast::KIND_APP_DATA))
-        .author(PublicKey::from_hex(&pubkey).map_err(|e| e.to_string())?)
-        .custom_tag(SingleLetterTag::from_char('d').unwrap(), d_tag.clone())
-        .limit(1);
+    let parsed = crate::utils::nip19::parse_naddr(naddr)?;
     let metadata_events =
-        nostr_client::fetch_events_aggregated(metadata_filter, Duration::from_secs(10)).await?;
+        nostr_client::fetch_event_by_coordinate_with_relays(
+            parsed.kind,
+            parsed.pubkey.clone(),
+            parsed.identifier,
+            parsed.relay_hints,
+        )
+        .await?;
     let metadata_event = metadata_events
-        .first()
         .ok_or_else(|| "Podcast not found".to_string())?;
-    let metadata = podcast::parse_podcast_metadata(metadata_event)?;
-    Ok((metadata, pubkey))
+    let metadata = podcast::parse_podcast_metadata(&metadata_event)?;
+    Ok((metadata, parsed.pubkey))
 }
 
 /// Fetch Nostr podcast episodes with pagination

--- a/src/routes/podcast/podcast_rss_detail.rs
+++ b/src/routes/podcast/podcast_rss_detail.rs
@@ -229,6 +229,7 @@ fn RssPodcastDetailContent(props: RssPodcastDetailContentProps) -> Element {
                             src: "{image_url}",
                             alt: "{feed.title}",
                             class: "w-32 h-32 md:w-40 md:h-40 rounded-lg object-cover shadow-lg",
+                            referrerpolicy: "no-referrer",
                         }
                         div { class: "flex-1 min-w-0",
                             h1 { class: "text-2xl font-bold truncate", "{feed.title}" }

--- a/src/routes/podcast/podcast_trending.rs
+++ b/src/routes/podcast/podcast_trending.rs
@@ -136,6 +136,7 @@ fn TrendingCard(props: TrendingCardProps) -> Element {
                         alt: "{feed.title}",
                         class: "w-full h-full object-cover",
                         loading: "lazy",
+                        referrerpolicy: "no-referrer",
                     }
                 } else {
                     div {

--- a/src/routes/profile.rs
+++ b/src/routes/profile.rs
@@ -1341,6 +1341,13 @@ fn VertsVideoCard(event: NostrEvent) -> Element {
         });
     }));
     let video_id = event.id.to_hex();
+    let video_src = video_meta.url.as_ref().map(|u| {
+        if video_meta.thumbnail.is_none() {
+            format!("{}#t=0.1", u)
+        } else {
+            u.clone()
+        }
+    });
     rsx! {
         div {
             class: "group cursor-pointer",
@@ -1357,7 +1364,7 @@ fn VertsVideoCard(event: NostrEvent) -> Element {
                             alt: "{video_meta.title.as_deref().unwrap_or(\"Vert\")}",
                             class: "w-full h-full object-cover group-hover:scale-105 transition-transform duration-200",
                         }
-                    } else if let Some(url) = &video_meta.url {
+                    } else if let Some(url) = &video_src {
                         video {
                             id: "{video_element_id}",
                             class: "w-full h-full object-cover",

--- a/src/routes/profile.rs
+++ b/src/routes/profile.rs
@@ -120,7 +120,6 @@ pub fn Profile(pubkey: String) -> Element {
     let mut pinned_events = use_signal(Vec::<NostrEvent>::new);
     let mut pinned_loading = use_signal(|| true);
     let mut user_write_relays = use_signal(Vec::<String>::new);
-    let mut interaction_counts: Signal<HashMap<String, crate::services::aggregation::InteractionCounts>> = use_signal(HashMap::new);
     let (cached_muted_posts, cached_blocked_users) = use_mute_block_cache();
     let pubkey_for_button = pubkey.clone();
     let pubkey_for_display = pubkey.clone();
@@ -157,7 +156,6 @@ pub fn Profile(pubkey: String) -> Element {
         pinned_events.set(Vec::new());
         pinned_loading.set(true);
         user_write_relays.set(Vec::new());
-        interaction_counts.set(HashMap::new());
     }));
     use_effect(use_reactive(
         (
@@ -544,46 +542,6 @@ pub fn Profile(pubkey: String) -> Element {
         });
     };
     let sentinel_id = use_infinite_scroll(load_more, current_tab_has_more, loading_events);
-
-    // Viewport-aware engagement (#7)
-    {
-        let ic = interaction_counts;
-        use_future(move || async move {
-            loop {
-                crate::platform::timer::sleep_ms(300).await;
-                let engaged = crate::hooks::use_viewport_engagement::ENGAGED_IDS.read().clone();
-                let ic = ic;
-                let script = r#"
-                    const els = document.querySelectorAll('[data-event-id]');
-                    const vh = window.innerHeight;
-                    const results = [];
-                    for (const el of els) {
-                        const rect = el.getBoundingClientRect();
-                        if (rect.bottom >= -200 && rect.top <= vh + 200) {
-                            results.push(el.getAttribute('data-event-id'));
-                        }
-                        if (results.length >= 30) break;
-                    }
-                    return JSON.stringify(results);
-                "#;
-                let result = match document::eval(script).await {
-                    Ok(v) => v.as_str().unwrap_or_default().to_string(),
-                    Err(_) => continue,
-                };
-                let visible_ids: Vec<String> = match serde_json::from_str(&result) {
-                    Ok(v) => v,
-                    Err(_) => continue,
-                };
-                let unengaged: Vec<String> = visible_ids
-                    .into_iter()
-                    .filter(|id| !engaged.contains(id))
-                    .collect();
-                if !unengaged.is_empty() {
-                    crate::hooks::use_viewport_engagement::fetch_counts_for_visible(unengaged, ic).await;
-                }
-            }
-        });
-    }
 
     // Trigger NIP-05 verification when profile metadata arrives
     {
@@ -2107,6 +2065,7 @@ async fn load_tab_events(
             })
         }
         ProfileTab::Zaps => {
+            let hex_pk = public_key.to_hex();
             let mut filter = Filter::new()
                 .kind(Kind::ZapReceipt)
                 .pubkey(public_key)
@@ -2114,7 +2073,9 @@ async fn load_tab_events(
             if let Some(until_ts) = until {
                 filter = filter.until(Timestamp::from(until_ts));
             }
-            let events = nostr_client::fetch_events_from_relays(filter, Duration::from_secs(10))
+            let events = nostr_client::fetch_profile_events_targeted(
+                &hex_pk, filter, Duration::from_secs(10),
+            )
                 .await
                 .map_err(|e| format!("Failed to fetch zaps: {}", e))?;
             let relay_count = events.len();
@@ -2234,8 +2195,14 @@ fn ZapEntryCard(event: NostrEvent) -> Element {
         use_effect(use_reactive((&sender_name,), move |(pk_hex,)| {
             if let Some(hex) = pk_hex {
                 spawn(async move {
-                    let metadata = profiles::get_profile(&hex);
-                    sp.set(metadata);
+                    if let Some(metadata) = profiles::get_profile(&hex) {
+                        sp.set(Some(metadata));
+                    } else {
+                        let _ = profiles::fetch_profile(hex.clone()).await;
+                        if let Some(metadata) = profiles::get_profile(&hex) {
+                            sp.set(Some(metadata));
+                        }
+                    }
                 });
             }
         }));

--- a/src/routes/profile.rs
+++ b/src/routes/profile.rs
@@ -1,12 +1,13 @@
 use crate::components::dialog::{DialogDescription, DialogRoot, DialogTitle};
 use crate::components::icons::{InfoIcon, ListIcon, MailIcon};
 use crate::components::{
-    AddToPeopleListModal, ArticleCard, ArticleCardSkeleton, ClientInitializing, ExternalIdentitiesSection, NoteCard,
+    AddToPeopleListModal, ArticleCard, ArticleCardSkeleton, ClientInitializing, ExternalIdentitiesSection, Nip05Badge, NoteCard,
     PhotoCard, PinnedNotesCarousel, ProfileBadgesSection, ProfileEditorModal, VideoCard,
 };
 use crate::hooks::{use_infinite_scroll, use_mute_block_cache};
+use crate::services::nip05;
 use crate::services::profile_stats;
-use crate::stores::{auth_store, dms, edit_cache, nostr_client, pinned_notes};
+use crate::stores::{auth_store, dms, edit_cache, nostr_client, pinned_notes, profiles};
 use crate::utils::article_meta::{get_identifier, get_published_at};
 use crate::utils::repost::{expand_events_for_prefetch, extract_reposted_event};
 use crate::utils::video_kinds::{horizontal_kinds, vertical_kinds};
@@ -29,6 +30,7 @@ enum ProfileTab {
     Articles,
     Media(MediaSubTab),
     Likes,
+    Zaps,
 }
 #[derive(Clone, Debug)]
 struct TabData {
@@ -63,6 +65,7 @@ fn default_tab_data_map() -> HashMap<ProfileTab, TabData> {
     map.insert(ProfileTab::Media(MediaSubTab::Videos), TabData::default());
     map.insert(ProfileTab::Media(MediaSubTab::Verts), TabData::default());
     map.insert(ProfileTab::Likes, TabData::default());
+    map.insert(ProfileTab::Zaps, TabData::default());
     map
 }
 /// Deduplicate articles by NIP-23 address (kind:pubkey:identifier)
@@ -95,6 +98,8 @@ pub fn Profile(pubkey: String) -> Element {
     let mut profile_data = use_signal(|| None::<nostr_sdk::Metadata>);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
+    let mut metadata_error = use_signal(|| None::<String>);
+    let mut retry_count = use_signal(|| 0u32);
     let mut active_tab = use_signal(|| ProfileTab::Posts);
     let mut tab_data = use_signal(default_tab_data_map);
     let mut loading_events = use_signal(|| false);
@@ -114,6 +119,8 @@ pub fn Profile(pubkey: String) -> Element {
     let mut show_add_to_list_modal = use_signal(|| false);
     let mut pinned_events = use_signal(Vec::<NostrEvent>::new);
     let mut pinned_loading = use_signal(|| true);
+    let mut user_write_relays = use_signal(Vec::<String>::new);
+    let mut interaction_counts: Signal<HashMap<String, crate::services::aggregation::InteractionCounts>> = use_signal(HashMap::new);
     let (cached_muted_posts, cached_blocked_users) = use_mute_block_cache();
     let pubkey_for_button = pubkey.clone();
     let pubkey_for_display = pubkey.clone();
@@ -136,6 +143,8 @@ pub fn Profile(pubkey: String) -> Element {
         profile_data.set(None);
         loading.set(true);
         error.set(None);
+        metadata_error.set(None);
+        retry_count.set(0);
         active_tab.set(ProfileTab::Posts);
         tab_data.set(default_tab_data_map());
         loading_events.set(false);
@@ -147,6 +156,8 @@ pub fn Profile(pubkey: String) -> Element {
         post_count.set(0);
         pinned_events.set(Vec::new());
         pinned_loading.set(true);
+        user_write_relays.set(Vec::new());
+        interaction_counts.set(HashMap::new());
     }));
     use_effect(use_reactive(
         (
@@ -179,14 +190,18 @@ pub fn Profile(pubkey: String) -> Element {
         },
     ));
     use_effect(use_reactive(
-        (&pubkey, &*nostr_client::CLIENT_INITIALIZED.read()),
-        move |(pubkey_str, client_initialized)| {
+        (
+            &pubkey,
+            &*nostr_client::CLIENT_INITIALIZED.read(),
+            &*retry_count.read(),
+        ),
+        move |(pubkey_str, client_initialized, _retry)| {
             if !client_initialized {
                 return;
             }
             spawn(async move {
                 loading.set(true);
-                error.set(None);
+                metadata_error.set(None);
                 let public_key = match PublicKey::from_bech32(&pubkey_str)
                     .or_else(|_| PublicKey::from_hex(&pubkey_str))
                 {
@@ -205,13 +220,35 @@ pub fn Profile(pubkey: String) -> Element {
                         return;
                     }
                 };
+                let hex_pubkey = public_key.to_hex();
+
+                // Pre-resolve relay list (needed for targeted tab fetches)
+                let write_relays = crate::stores::relay::coverage::resolve_user_relays(
+                    &hex_pubkey,
+                    crate::stores::relay::coverage::RelayPurpose::Write,
+                )
+                .await;
+                if !write_relays.is_empty() {
+                    user_write_relays.set(write_relays);
+                }
+
+                // Tier 0: LRU profile cache (instant, session-only)
+                if let Some(metadata) = profiles::get_profile(&hex_pubkey) {
+                    log::debug!("Loaded profile metadata from LRU cache");
+                    profile_data.set(Some(metadata));
+                    loading.set(false);
+                    return;
+                }
+
+                // Tier 1: SDK database (SQLite/indexedDB, near-instant)
                 if let Ok(Some(metadata)) = client.database().metadata(public_key).await {
                     log::debug!("Loaded profile metadata from database cache");
                     profile_data.set(Some(metadata));
                     loading.set(false);
                     return;
                 }
-                let hex_pubkey = public_key.to_hex();
+
+                // Tier 2: Targeted relay fetch (NIP-65 write relays -> SDK fallback)
                 match nostr_client::fetch_metadata_targeted(&hex_pubkey, Duration::from_secs(5))
                     .await
                 {
@@ -221,10 +258,12 @@ pub fn Profile(pubkey: String) -> Element {
                     }
                     Ok(None) => {
                         log::debug!("No metadata found, using empty profile");
+                        metadata_error.set(Some("No profile data found".to_string()));
                         profile_data.set(Some(nostr_sdk::Metadata::new()));
                     }
                     Err(e) => {
                         log::error!("Failed to fetch profile metadata: {}", e);
+                        metadata_error.set(Some(format!("Failed to load: {}", e)));
                         profile_data.set(Some(nostr_sdk::Metadata::new()));
                     }
                 }
@@ -392,29 +431,6 @@ pub fn Profile(pubkey: String) -> Element {
     ));
     use_effect(use_reactive(&pubkey, move |pubkey_str| {
         let client_initialized = *nostr_client::CLIENT_INITIALIZED.read();
-        if !client_initialized || !auth_store::is_authenticated() {
-            return;
-        }
-        spawn(async move {
-            let hex_pubkey = if let Ok(pk) = PublicKey::from_bech32(&pubkey_str) {
-                pk.to_hex()
-            } else if let Ok(pk) = PublicKey::from_hex(&pubkey_str) {
-                pk.to_hex()
-            } else {
-                return;
-            };
-            match nostr_client::is_following(hex_pubkey).await {
-                Ok(following) => {
-                    is_following.set(following);
-                }
-                Err(e) => {
-                    log::error!("Failed to check following status: {}", e);
-                }
-            }
-        });
-    }));
-    use_effect(use_reactive(&pubkey, move |pubkey_str| {
-        let client_initialized = *nostr_client::CLIENT_INITIALIZED.read();
         if !client_initialized {
             return;
         }
@@ -428,9 +444,22 @@ pub fn Profile(pubkey: String) -> Element {
             } else {
                 return;
             };
+
             let contacts_future = nostr_client::fetch_contacts(hex_pubkey.clone());
             let stats_future = profile_stats::fetch_profile_stats(&hex_pubkey);
-            let (contacts_result, stats_result) = futures::join!(contacts_future, stats_future);
+            let following_future = async {
+                if is_authenticated {
+                    nostr_client::is_following(hex_pubkey.clone()).await
+                } else {
+                    Err("not authenticated".to_string())
+                }
+            };
+            let (contacts_result, stats_result, following_result) =
+                futures::join!(contacts_future, stats_future, following_future);
+
+            if let Ok(following) = following_result {
+                is_following.set(following);
+            }
             if let Ok(contacts) = contacts_result {
                 following_count.set(contacts.len());
                 if is_authenticated {
@@ -515,6 +544,64 @@ pub fn Profile(pubkey: String) -> Element {
         });
     };
     let sentinel_id = use_infinite_scroll(load_more, current_tab_has_more, loading_events);
+
+    // Viewport-aware engagement (#7)
+    {
+        let ic = interaction_counts;
+        use_future(move || async move {
+            loop {
+                crate::platform::timer::sleep_ms(300).await;
+                let engaged = crate::hooks::use_viewport_engagement::ENGAGED_IDS.read().clone();
+                let ic = ic;
+                let script = r#"
+                    const els = document.querySelectorAll('[data-event-id]');
+                    const vh = window.innerHeight;
+                    const results = [];
+                    for (const el of els) {
+                        const rect = el.getBoundingClientRect();
+                        if (rect.bottom >= -200 && rect.top <= vh + 200) {
+                            results.push(el.getAttribute('data-event-id'));
+                        }
+                        if (results.length >= 30) break;
+                    }
+                    return JSON.stringify(results);
+                "#;
+                let result = match document::eval(script).await {
+                    Ok(v) => v.as_str().unwrap_or_default().to_string(),
+                    Err(_) => continue,
+                };
+                let visible_ids: Vec<String> = match serde_json::from_str(&result) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                let unengaged: Vec<String> = visible_ids
+                    .into_iter()
+                    .filter(|id| !engaged.contains(id))
+                    .collect();
+                if !unengaged.is_empty() {
+                    crate::hooks::use_viewport_engagement::fetch_counts_for_visible(unengaged, ic).await;
+                }
+            }
+        });
+    }
+
+    // Trigger NIP-05 verification when profile metadata arrives
+    {
+        let pubkey_for_nip05 = pubkey.clone();
+        use_effect(move || {
+            if let Some(metadata) = profile_data.read().as_ref() {
+                if let Some(nip05_str) = &metadata.nip05 {
+                    if !nip05_str.is_empty() {
+                        let pk_hex = PublicKey::from_bech32(&pubkey_for_nip05)
+                            .or_else(|_| PublicKey::from_hex(&pubkey_for_nip05))
+                            .map(|p| p.to_hex())
+                            .unwrap_or_else(|_| pubkey_for_nip05.clone());
+                        nip05::verify_nip05(&pk_hex, nip05_str);
+                    }
+                }
+            }
+        });
+    }
     rsx! {
         div { class: "min-h-screen",
             div { class: "sticky top-0 z-20 bg-background/80 backdrop-blur-sm border-b border-border",
@@ -570,7 +657,7 @@ pub fn Profile(pubkey: String) -> Element {
                         div { class: "w-full h-48 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500" }
                     }
                 } else {
-                    div { class: "w-full h-48 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500" }
+                    div { class: "w-full h-48 bg-gradient-to-r from-blue-500/20 via-purple-500/20 to-pink-500/20 animate-pulse" }
                 }
                 div { class: "absolute bottom-0 left-4 transform translate-y-1/2",
                     if let Some(metadata) = profile_data.read().as_ref() {
@@ -586,14 +673,39 @@ pub fn Profile(pubkey: String) -> Element {
                             }
                         }
                     } else {
-                        div { class: "w-32 h-32 rounded-full border-4 border-background bg-gray-600 flex items-center justify-center text-white text-4xl font-bold",
-                            "?"
-                        }
+                        div { class: "w-32 h-32 rounded-full border-4 border-background bg-muted animate-pulse" }
                     }
                 }
             }
             div { class: "px-4 pb-4",
                 div { class: "flex justify-end gap-2 pt-4 mb-16",
+                    if metadata_error.read().is_some() {
+                        {
+                            let mut retry_count_sig = retry_count;
+                            rsx! {
+                                button {
+                                    class: "p-2 border border-orange-300 rounded-full hover:bg-accent transition text-orange-500",
+                                    onclick: move |_| {
+                                        retry_count_sig += 1;
+                                    },
+                                    "aria-label": "Retry",
+                                    title: "Retry loading profile",
+                                    svg {
+                                        class: "w-5 h-5",
+                                        xmlns: "http://www.w3.org/2000/svg",
+                                        view_box: "0 0 24 24",
+                                        fill: "none",
+                                        stroke: "currentColor",
+                                        stroke_width: "2",
+                                        stroke_linecap: "round",
+                                        stroke_linejoin: "round",
+                                        polyline { points: "23 4 23 10 17 10" }
+                                        path { d: "20.49 15a9 9 0 1 1-2.12-9.36L23 10" }
+                                    }
+                                }
+                            }
+                        }
+                    }
                     button {
                         class: "p-2 border border-border rounded-full hover:bg-accent transition",
                         onclick: move |_| show_info_dialog.set(true),
@@ -717,8 +829,18 @@ pub fn Profile(pubkey: String) -> Element {
                             }
                         }
                     }
-                    p { class: "text-muted-foreground",
+                    p { class: "text-muted-foreground flex items-center gap-1",
                         "@{get_username(metadata, &pubkey_for_display)}"
+                        if let Some(nip05_str) = &metadata.nip05 {
+                            if !nip05_str.is_empty() {
+                                Nip05Badge {
+                                    pubkey: if let Ok(pk) = PublicKey::from_bech32(&pubkey_for_display)
+                                        .or_else(|_| PublicKey::from_hex(&pubkey_for_display))
+                                    { pk.to_hex() } else { pubkey_for_display.clone() },
+                                    nip05: nip05_str.clone(),
+                                }
+                            }
+                        }
                     }
                     if let Some(about) = &metadata.about {
                         if !about.is_empty() {
@@ -872,6 +994,11 @@ pub fn Profile(pubkey: String) -> Element {
                         active: matches!(*active_tab.read(), ProfileTab::Likes),
                         onclick: move |_| active_tab.set(ProfileTab::Likes),
                     }
+                    ProfileTabButton {
+                        label: "Zaps",
+                        active: matches!(*active_tab.read(), ProfileTab::Zaps),
+                        onclick: move |_| active_tab.set(ProfileTab::Zaps),
+                    }
                 }
                 if matches!(*active_tab.read(), ProfileTab::Media(_)) {
                     div { class: "flex gap-2 px-4 py-2 bg-accent/10",
@@ -981,6 +1108,9 @@ pub fn Profile(pubkey: String) -> Element {
                                                 },
                                             }
                                         }
+                                        ProfileTab::Zaps => rsx! {
+                                            ZapEntryCard { key: "{event.id}", event: event.clone() }
+                                        },
                                         _ => {
                                             if event.kind == Kind::Repost {
                                                 match extract_reposted_event(event) {
@@ -1415,6 +1545,10 @@ fn build_tab_filter(
             .author(public_key)
             .kind(Kind::Reaction)
             .limit(limit),
+        ProfileTab::Zaps => Filter::new()
+            .kind(Kind::ZapReceipt)
+            .pubkey(public_key)
+            .limit(limit),
     };
     if let Some(until_ts) = until {
         filter = filter.until(Timestamp::from(until_ts));
@@ -1443,6 +1577,7 @@ fn process_tab_events(events: Vec<NostrEvent>, tab: &ProfileTab) -> Vec<NostrEve
             .filter(|e| e.kind != Kind::Repost && e.tags.event_ids().next().is_some())
             .collect(),
         ProfileTab::Articles => dedupe_articles_by_address(events),
+        ProfileTab::Zaps => events,
         _ => events,
     }
 }
@@ -1456,6 +1591,13 @@ async fn load_tab_events_db(
         .map_err(|e| format!("Invalid public key: {}", e))?;
     if matches!(tab, ProfileTab::Likes) {
         return load_likes_db(public_key, until).await;
+    }
+    if matches!(tab, ProfileTab::Zaps) {
+        return Ok(LoadOutcome {
+            events: Vec::new(),
+            oldest_cursor: None,
+            relay_count: 0,
+        });
     }
     let filter = build_tab_filter(public_key, tab, until, 100);
     let events = nostr_client::fetch_profile_events_db(filter).await?;
@@ -1489,6 +1631,9 @@ async fn load_tab_events_relays(
         .map_err(|e| format!("Invalid public key: {}", e))?;
     if matches!(tab, ProfileTab::Likes) {
         return load_likes_relays(public_key, until).await;
+    }
+    if matches!(tab, ProfileTab::Zaps) {
+        return load_tab_events(pubkey, tab, until).await;
     }
     let filter = build_tab_filter(public_key, tab, until, 100);
     let events =
@@ -1961,6 +2106,28 @@ async fn load_tab_events(
                 relay_count,
             })
         }
+        ProfileTab::Zaps => {
+            let mut filter = Filter::new()
+                .kind(Kind::ZapReceipt)
+                .pubkey(public_key)
+                .limit(TARGET_COUNT);
+            if let Some(until_ts) = until {
+                filter = filter.until(Timestamp::from(until_ts));
+            }
+            let events = nostr_client::fetch_events_from_relays(filter, Duration::from_secs(10))
+                .await
+                .map_err(|e| format!("Failed to fetch zaps: {}", e))?;
+            let relay_count = events.len();
+            let mut event_vec: Vec<NostrEvent> = events.into_iter().collect();
+            event_vec.sort_by_key(|b| std::cmp::Reverse(b.created_at));
+            log::info!("Loaded {} zaps", event_vec.len());
+            let oldest_cursor = event_vec.last().map(|e| e.created_at.as_secs());
+            Ok(LoadOutcome {
+                events: event_vec,
+                oldest_cursor,
+                relay_count,
+            })
+        }
     }
 }
 fn get_display_name(metadata: &nostr_sdk::Metadata, pubkey: &str) -> String {
@@ -2016,6 +2183,7 @@ fn get_empty_state_message(tab: &ProfileTab) -> &'static str {
         ProfileTab::Media(MediaSubTab::Videos) => "No videos yet",
         ProfileTab::Media(MediaSubTab::Verts) => "No verts yet",
         ProfileTab::Likes => "No likes yet",
+        ProfileTab::Zaps => "No zaps received yet",
     }
 }
 fn get_empty_state_icon(tab: &ProfileTab) -> &'static str {
@@ -2027,10 +2195,126 @@ fn get_empty_state_icon(tab: &ProfileTab) -> &'static str {
         ProfileTab::Media(MediaSubTab::Videos) => "🎬",
         ProfileTab::Media(MediaSubTab::Verts) => "📱",
         ProfileTab::Likes => "❤️",
+        ProfileTab::Zaps => "⚡",
     }
 }
 /// Batch prefetch author metadata for all events
 async fn prefetch_author_metadata(events: &[NostrEvent]) {
     use crate::utils::profile_prefetch;
     profile_prefetch::prefetch_event_authors(events).await;
+}
+
+#[component]
+fn ZapEntryCard(event: NostrEvent) -> Element {
+    let sender_pubkey = event.tags.iter().find_map(|tag| {
+        let slice = tag.as_slice();
+        if slice.first().map(|s| s.as_str()) == Some("P") && slice.len() > 1 {
+            PublicKey::from_hex(slice[1].as_str()).ok()
+        } else {
+            None
+        }
+    });
+    let zap_amount = crate::services::aggregation::extract_zap_amount(&event);
+    let zap_message: Option<String> = event.tags.iter().find_map(|tag| {
+        let slice = tag.as_slice();
+        if slice.first().map(|s| s.as_str()) == Some("description") && slice.len() > 1 {
+            Some(slice[1].clone())
+        } else {
+            None
+        }
+    }).or_else(|| {
+        let content = event.content.trim();
+        if content.is_empty() { None } else { Some(content.to_string()) }
+    });
+    let sender_profile = use_signal(|| None::<nostr_sdk::Metadata>);
+    let sender_name = sender_pubkey.as_ref().map(|pk| pk.to_hex());
+    {
+        let mut sp = sender_profile;
+        let _pk_hex = sender_name.clone();
+        use_effect(use_reactive((&sender_name,), move |(pk_hex,)| {
+            if let Some(hex) = pk_hex {
+                spawn(async move {
+                    let metadata = profiles::get_profile(&hex);
+                    sp.set(metadata);
+                });
+            }
+        }));
+    }
+    let display_name = sender_profile.read().as_ref()
+        .map(|m| get_display_name(m, sender_name.as_deref().unwrap_or("")))
+        .unwrap_or_else(|| {
+            sender_name.as_deref().map(|h| {
+                if h.len() > 12 {
+                    format!("{}...{}", &h[..8], &h[h.len()-4..])
+                } else { h.to_string() }
+            }).unwrap_or_else(|| "Anonymous".to_string())
+        });
+    let sender_picture = sender_profile.read().as_ref()
+        .and_then(|m| m.picture.clone());
+    let amount_str = zap_amount.map(|a| format!("{} sats", a)).unwrap_or_default();
+    rsx! {
+        div { class: "flex items-start gap-3 p-4 border-b border-border",
+            if let Some(pic) = sender_picture {
+                img {
+                    class: "w-10 h-10 rounded-full",
+                    src: "{pic}",
+                    alt: "Zap sender",
+                }
+            } else {
+                div { class: "w-10 h-10 rounded-full bg-muted flex items-center justify-center text-sm font-bold text-muted-foreground",
+                    "{display_name.chars().next().unwrap_or('?').to_uppercase()}"
+                }
+            }
+            div { class: "flex-1 min-w-0",
+                div { class: "flex items-center gap-2",
+                    span { class: "font-semibold text-sm truncate", "{display_name}" }
+                    if !amount_str.is_empty() {
+                        span { class: "text-orange-500 font-bold text-sm", "⚡ {amount_str}" }
+                    }
+                }
+                if let Some(msg) = zap_message {
+                    if !msg.is_empty() {
+                        p { class: "text-sm text-muted-foreground mt-1 line-clamp-2", "{msg}" }
+                    }
+                }
+                p { class: "text-xs text-muted-foreground mt-1",
+                    "{format_timestamp(event.created_at.as_secs())}"
+                }
+            }
+        }
+    }
+}
+
+fn format_timestamp(secs: u64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let diff = now.saturating_sub(secs);
+    if diff < 60 {
+        "just now".to_string()
+    } else if diff < 3600 {
+        format!("{}m ago", diff / 60)
+    } else if diff < 86400 {
+        format!("{}h ago", diff / 3600)
+    } else if diff < 604800 {
+        format!("{}d ago", diff / 86400)
+    } else {
+        let months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+        let days_in_month = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+        let mut remaining = secs;
+        let year = 1970 + (remaining / (365 * 86400 + 21600));
+        remaining %= 365 * 86400 + 21600;
+        let mut month = 0usize;
+        for (i, &d) in days_in_month.iter().enumerate() {
+            let d_secs = d as u64 * 86400;
+            if remaining < d_secs {
+                month = i;
+                break;
+            }
+            remaining -= d_secs;
+        }
+        let day = 1 + remaining / 86400;
+        format!("{} {} {}", months.get(month).unwrap_or(&"?"), day, year)
+    }
 }

--- a/src/routes/profile.rs
+++ b/src/routes/profile.rs
@@ -16,8 +16,6 @@ use nostr_sdk::prelude::*;
 use nostr_sdk::Event as NostrEvent;
 use std::collections::HashMap;
 use std::time::Duration;
-#[cfg(feature = "web")]
-use wasm_bindgen::JsCast;
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 enum MediaSubTab {
     Photos,
@@ -1321,23 +1319,11 @@ fn VertsVideoCard(event: NostrEvent) -> Element {
     use_effect(use_reactive(&*is_hovering.read(), move |hovering| {
         let id = video_element_id_for_effect.clone();
         spawn(async move {
-            #[cfg(feature = "web")]
-            if let Some(window) = web_sys::window() {
-                if let Some(document) = window.document() {
-                    if let Some(element) = document.get_element_by_id(&id) {
-                        if let Ok(video) = element.dyn_into::<web_sys::HtmlVideoElement>() {
-                            if hovering {
-                                let _ = video.play();
-                            } else {
-                                let _ = video.pause();
-                                video.set_current_time(0.0);
-                            }
-                        }
-                    }
-                }
-            }
-            #[cfg(not(feature = "web"))]
-            let _ = (&id, hovering);
+            let action = if hovering { "play" } else { "pause" };
+            let js = format!(
+                r#"(function() {{ var v = document.getElementById("{id}"); if (v) {{ if ("{action}" === "play") {{ v.play().catch(function(){{}}); }} else {{ v.pause(); v.currentTime = 0; }} }} }})()"#
+            );
+            let _ = document::eval(&js).await;
         });
     }));
     let video_id = event.id.to_hex();

--- a/src/routes/video/home.rs
+++ b/src/routes/video/home.rs
@@ -12,8 +12,6 @@ use crate::utils::FeedItem;
 use dioxus::prelude::*;
 use nostr_sdk::{Event, Filter, Kind, PublicKey, Timestamp};
 use std::time::Duration;
-#[cfg(feature = "web")]
-use wasm_bindgen::JsCast;
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum FeedType {
     Following,
@@ -541,23 +539,11 @@ fn LandscapeVideoCard(event: Event, feed_type: FeedType) -> Element {
         let hovering = *is_hovering.read();
         let id = video_element_id_for_effect.clone();
         spawn(async move {
-            #[cfg(feature = "web")]
-            if let Some(window) = web_sys::window() {
-                if let Some(document) = window.document() {
-                    if let Some(element) = document.get_element_by_id(&id) {
-                        if let Ok(video) = element.dyn_into::<web_sys::HtmlVideoElement>() {
-                            if hovering {
-                                let _ = video.play();
-                            } else {
-                                let _ = video.pause();
-                                video.set_current_time(0.0);
-                            }
-                        }
-                    }
-                }
-            }
-            #[cfg(not(feature = "web"))]
-            let _ = (&id, hovering);
+            let action = if hovering { "play" } else { "pause" };
+            let js = format!(
+                r#"(function() {{ var v = document.getElementById("{id}"); if (v) {{ if ("{action}" === "play") {{ v.play().catch(function(){{}}); }} else {{ v.pause(); v.currentTime = 0; }} }} }})()"#
+            );
+            let _ = document::eval(&js).await;
         });
     });
     let display_name = author_metadata
@@ -650,23 +636,11 @@ fn VertsVideoCard(event: Event, feed_type: FeedType) -> Element {
         let hovering = *is_hovering.read();
         let id = video_element_id_for_effect.clone();
         spawn(async move {
-            #[cfg(feature = "web")]
-            if let Some(window) = web_sys::window() {
-                if let Some(document) = window.document() {
-                    if let Some(element) = document.get_element_by_id(&id) {
-                        if let Ok(video) = element.dyn_into::<web_sys::HtmlVideoElement>() {
-                            if hovering {
-                                let _ = video.play();
-                            } else {
-                                let _ = video.pause();
-                                video.set_current_time(0.0);
-                            }
-                        }
-                    }
-                }
-            }
-            #[cfg(not(feature = "web"))]
-            let _ = (&id, hovering);
+            let action = if hovering { "play" } else { "pause" };
+            let js = format!(
+                r#"(function() {{ var v = document.getElementById("{id}"); if (v) {{ if ("{action}" === "play") {{ v.play().catch(function(){{}}); }} else {{ v.pause(); v.currentTime = 0; }} }} }})()"#
+            );
+            let _ = document::eval(&js).await;
         });
     });
     let video_id = event.id.to_hex();

--- a/src/routes/video/home.rs
+++ b/src/routes/video/home.rs
@@ -569,6 +569,11 @@ fn LandscapeVideoCard(event: Event, feed_type: FeedType) -> Element {
             truncate_pubkey(&pk)
         });
     let video_id = event.id.to_hex();
+    let video_src = if video_meta.thumbnail.is_none() {
+        video_meta.url.as_ref().map(|u| format!("{}#t=0.1", u))
+    } else {
+        video_meta.url.clone()
+    };
     let feed_param = match feed_type {
         FeedType::Following => "following",
         FeedType::Global => "global",
@@ -594,7 +599,7 @@ fn LandscapeVideoCard(event: Event, feed_type: FeedType) -> Element {
                             },
                         }
                     }
-                    if let Some(url) = &video_meta.url {
+                    if let Some(url) = &video_src {
                         video {
                             id: "{video_element_id}",
                             class: if video_meta.thumbnail.is_some() && !*is_hovering.read() {
@@ -665,6 +670,11 @@ fn VertsVideoCard(event: Event, feed_type: FeedType) -> Element {
         });
     });
     let video_id = event.id.to_hex();
+    let video_src = if video_meta.thumbnail.is_none() {
+        video_meta.url.as_ref().map(|u| format!("{}#t=0.1", u))
+    } else {
+        video_meta.url.clone()
+    };
     let feed_param = match feed_type {
         FeedType::Following => "following",
         FeedType::Global => "global",
@@ -690,7 +700,7 @@ fn VertsVideoCard(event: Event, feed_type: FeedType) -> Element {
                             },
                         }
                     }
-                    if let Some(url) = &video_meta.url {
+                    if let Some(url) = &video_src {
                         video {
                             id: "{video_element_id}",
                             class: if video_meta.thumbnail.is_some() && !*is_hovering.read() {

--- a/src/routes/video/live_stream_detail.rs
+++ b/src/routes/video/live_stream_detail.rs
@@ -2,16 +2,15 @@ use crate::components::icons::{ArrowLeftIcon, ShareIcon, ZapIcon};
 use crate::components::live::stream_card::{parse_live_stream_event, LiveStreamMeta};
 use crate::components::{LiveChat, LiveStreamPlayer, ShareModal, StreamStatus, ZapModal};
 use crate::routes::Route;
-use crate::stores::nostr_client::{fetch_events_aggregated, CLIENT_INITIALIZED, HAS_SIGNER};
+use crate::stores::nostr_client::{fetch_event_by_coordinate_with_relays, CLIENT_INITIALIZED, HAS_SIGNER};
 use crate::stores::profiles;
+use crate::utils::nip19::ParsedNaddr;
 use crate::utils::truncate_pubkey;
 use dioxus::prelude::*;
-use nostr_sdk::{Filter, Kind, PublicKey};
-use std::time::Duration;
 #[component]
 pub fn LiveStreamDetail(note_id: String) -> Element {
     let parsed_naddr = use_memo(move || {
-        crate::utils::nip19::parse_naddr(&note_id).unwrap_or((String::new(), String::new()))
+        crate::utils::nip19::parse_naddr(&note_id).ok()
     });
     let mut stream_event = use_signal(|| None::<nostr_sdk::Event>);
     let mut stream_meta = use_signal(|| None::<LiveStreamMeta>);
@@ -26,55 +25,51 @@ pub fn LiveStreamDetail(note_id: String) -> Element {
                 return profiles::get_profile(host_pk);
             }
         }
-        let (pubkey_str, _) = parsed_naddr.read().clone();
-        profiles::get_profile(&pubkey_str)
+        let p = parsed_naddr.read();
+        if let Some(ref parsed) = *p {
+            profiles::get_profile(&parsed.pubkey)
+        } else {
+            None
+        }
     });
     use_effect(use_reactive(
         (&*CLIENT_INITIALIZED.read(), &parsed_naddr),
-        move |(client_ready, _naddr)| {
+        move |(client_ready, _)| {
             if !client_ready {
                 return;
             }
-            let (author_pk, dtag) = parsed_naddr.read().clone();
+            let parsed = (*parsed_naddr.read()).clone();
+            let Some(parsed) = parsed else { return };
+            let ParsedNaddr { pubkey: author_pk, identifier: dtag, kind, relay_hints, .. } = parsed;
             spawn(async move {
                 loading.set(true);
                 error.set(None);
-                let pubkey = match PublicKey::parse(&author_pk) {
-                    Ok(pk) => pk,
-                    Err(e) => {
-                        error.set(Some(format!("Invalid public key: {}", e)));
-                        loading.set(false);
-                        return;
-                    }
-                };
-                let filter = Filter::new()
-                    .kind(Kind::from(30311))
-                    .author(pubkey)
-                    .custom_tag(
-                        nostr_sdk::SingleLetterTag::lowercase(nostr_sdk::Alphabet::D),
-                        &dtag,
-                    )
-                    .limit(1);
-                match fetch_events_aggregated(filter, Duration::from_secs(10)).await {
-                    Ok(events) => {
-                        if let Some(event) = events.first() {
-                            if let Some(meta) = parse_live_stream_event(event) {
-                                let profile_to_fetch = meta
-                                    .host_pubkey
-                                    .clone()
-                                    .unwrap_or_else(|| author_pk.clone());
-                                stream_meta.set(Some(meta));
-                                stream_event.set(Some(event.clone()));
-                                loading.set(false);
-                                let _ = profiles::fetch_profile(profile_to_fetch).await;
-                            } else {
-                                error.set(Some("Failed to parse stream metadata".to_string()));
-                                loading.set(false);
-                            }
+                match fetch_event_by_coordinate_with_relays(
+                    kind,
+                    author_pk.clone(),
+                    dtag,
+                    relay_hints,
+                )
+                .await
+                {
+                    Ok(Some(event)) => {
+                        if let Some(meta) = parse_live_stream_event(&event) {
+                            let profile_to_fetch = meta
+                                .host_pubkey
+                                .clone()
+                                .unwrap_or_else(|| author_pk.clone());
+                            stream_meta.set(Some(meta));
+                            stream_event.set(Some(event));
+                            loading.set(false);
+                            let _ = profiles::fetch_profile(profile_to_fetch).await;
                         } else {
-                            error.set(Some("Stream not found".to_string()));
+                            error.set(Some("Failed to parse stream metadata".to_string()));
                             loading.set(false);
                         }
+                    }
+                    Ok(None) => {
+                        error.set(Some("Stream not found".to_string()));
+                        loading.set(false);
                     }
                     Err(e) => {
                         error.set(Some(format!("Failed to load stream: {}", e)));
@@ -87,31 +82,32 @@ pub fn LiveStreamDetail(note_id: String) -> Element {
     let handle_refresh = move |_| {
         loading.set(true);
         error.set(None);
-        let (author_pk, dtag) = parsed_naddr.peek().clone();
+        let parsed = (*parsed_naddr.read()).clone();
         spawn(async move {
-            if let Ok(pubkey) = PublicKey::parse(&author_pk) {
-                let filter = Filter::new()
-                    .kind(Kind::from(30311))
-                    .author(pubkey)
-                    .custom_tag(
-                        nostr_sdk::SingleLetterTag::lowercase(nostr_sdk::Alphabet::D),
-                        &dtag,
-                    )
-                    .limit(1);
-                match fetch_events_aggregated(filter, Duration::from_secs(10)).await {
-                    Ok(events) => {
-                        if let Some(event) = events.first() {
-                            if let Some(meta) = parse_live_stream_event(event) {
-                                stream_meta.set(Some(meta));
-                                stream_event.set(Some(event.clone()));
-                                loading.set(false);
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        error.set(Some(format!("Failed to refresh: {}", e)));
+            let Some(parsed) = parsed else { return };
+            let ParsedNaddr { pubkey: author_pk, identifier: dtag, kind, relay_hints, .. } = parsed;
+            match fetch_event_by_coordinate_with_relays(
+                kind,
+                author_pk.clone(),
+                dtag,
+                relay_hints,
+            )
+            .await
+            {
+                Ok(Some(event)) => {
+                    if let Some(meta) = parse_live_stream_event(&event) {
+                        stream_meta.set(Some(meta));
+                        stream_event.set(Some(event));
                         loading.set(false);
                     }
+                }
+                Ok(None) => {
+                    error.set(Some("Stream not found".to_string()));
+                    loading.set(false);
+                }
+                Err(e) => {
+                    error.set(Some(format!("Failed to refresh: {}", e)));
+                    loading.set(false);
                 }
             }
         });
@@ -311,7 +307,9 @@ pub fn LiveStreamDetail(note_id: String) -> Element {
                         div { class: "lg:w-96 border-t lg:border-t-0 lg:border-l border-border flex-1 lg:flex-none min-h-0 flex flex-col overflow-hidden",
                             if let Some(_event) = stream_event.read().as_ref() {
                                 {
-                                    let (author_pk, dtag) = parsed_naddr.peek().clone();
+                                    let p = (*parsed_naddr.read()).clone();
+                                    let author_pk = p.as_ref().map(|p| p.pubkey.clone()).unwrap_or_default();
+                                    let dtag = p.as_ref().map(|p| p.identifier.clone()).unwrap_or_default();
                                     rsx! {
                                         LiveChat { stream_author_pubkey: author_pk, stream_d_tag: dtag }
                                     }

--- a/src/routes/video/video_detail.rs
+++ b/src/routes/video/video_detail.rs
@@ -13,10 +13,6 @@ use dioxus::prelude::*;
 use nostr_sdk::prelude::*;
 use nostr_sdk::{Event, EventId, PublicKey};
 use std::time::Duration;
-#[cfg(feature = "web")]
-use wasm_bindgen::JsCast;
-#[cfg(feature = "web")]
-use web_sys::HtmlVideoElement;
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub(crate) enum FeedType {
     Following,
@@ -639,18 +635,10 @@ fn VerticalVideoPlayer(
     use_effect(use_reactive(&is_muted, move |muted| {
         let id = video_id_for_effect.clone();
         spawn(async move {
-            #[cfg(feature = "web")]
-            if let Some(window) = web_sys::window() {
-                if let Some(document) = window.document() {
-                    if let Some(element) = document.get_element_by_id(&id) {
-                        if let Ok(video) = element.dyn_into::<HtmlVideoElement>() {
-                            video.set_muted(muted);
-                        }
-                    }
-                }
-            }
-            #[cfg(not(feature = "web"))]
-            let _ = (&id, muted);
+            let js = format!(
+                r#"(function() {{ var v = document.getElementById("{id}"); if (v) {{ v.muted = {muted}; }} }})()"#
+            );
+            let _ = document::eval(&js).await;
         });
     }));
     rsx! {

--- a/src/routes/video/video_detail.rs
+++ b/src/routes/video/video_detail.rs
@@ -170,6 +170,13 @@ fn LandscapePlayer(event: Event) -> Element {
     }
 
     let video_meta = parse_video_meta(&event);
+    let video_src = video_meta.url.as_ref().map(|u| {
+        if video_meta.thumbnail.is_none() {
+            format!("{}#t=0.1", u)
+        } else {
+            u.clone()
+        }
+    });
     rsx! {
         div { class: "min-h-screen bg-background",
             div { class: "sticky top-0 z-20 bg-black/80 backdrop-blur-sm border-b border-gray-800",
@@ -186,15 +193,16 @@ fn LandscapePlayer(event: Event) -> Element {
                 div {
                     class: "relative w-full bg-black rounded-lg overflow-hidden mb-4",
                     style: "max-height: 80vh;",
-                    if let Some(url) = &video_meta.url {
+                    if let Some(url) = &video_src {
                         video {
                             class: "w-full h-full object-contain",
                             src: "{url}",
-                            poster: "{video_meta.thumbnail.clone().unwrap_or_default()}",
+                            poster: video_meta.thumbnail.as_deref(),
                             controls: true,
                             muted: *is_muted.read(),
                             autoplay: true,
                             playsinline: true,
+                            preload: "metadata",
                         }
                     } else {
                         div { class: "flex items-center justify-center h-96 text-white",
@@ -621,6 +629,13 @@ fn VerticalVideoPlayer(
     let video_id = format!("video-{}", &event.id.to_hex()[..8]);
     let video_id_for_effect = video_id.clone();
     let video_meta = parse_video_meta(&event);
+    let video_src = video_meta.url.as_ref().map(|u| {
+        if video_meta.thumbnail.is_none() {
+            format!("{}#t=0.1", u)
+        } else {
+            u.clone()
+        }
+    });
     use_effect(use_reactive(&is_muted, move |muted| {
         let id = video_id_for_effect.clone();
         spawn(async move {
@@ -640,17 +655,18 @@ fn VerticalVideoPlayer(
     }));
     rsx! {
         div { class: "relative w-full h-full flex items-center justify-center bg-black",
-            if let Some(url) = video_meta.url.clone() {
+            if let Some(url) = video_src.clone() {
                 video {
                     id: "{video_id}",
                     class: "max-w-full max-h-full object-contain",
                     src: "{url}",
-                    poster: "{video_meta.thumbnail.clone().unwrap_or_default()}",
+                    poster: video_meta.thumbnail.as_deref(),
                     r#loop: true,
                     muted: is_muted,
                     autoplay: is_active,
                     playsinline: true,
                     controls: true,
+                    preload: "metadata",
                 }
             } else {
                 div { class: "flex flex-col items-center justify-center text-white",

--- a/src/routes/video/video_detail.rs
+++ b/src/routes/video/video_detail.rs
@@ -40,7 +40,6 @@ pub fn VideoDetail(video_id: String) -> Element {
         }
         loading.set(true);
         error.set(None);
-        crate::stores::profiles::PROFILE_CACHE.write().clear();
         spawn(async move {
             match load_video_by_id(&id).await {
                 Ok(event) => {

--- a/src/services/aggregation/counting.rs
+++ b/src/services/aggregation/counting.rs
@@ -14,7 +14,7 @@ use std::sync::{Mutex, OnceLock};
 
 const MAX_RELAY_LIMIT: usize = 5_000;
 const INTERACTION_PAGE_LIMIT: usize = 1_000;
-const INTERACTION_EVENT_BATCH_SIZE: usize = 25;
+const INTERACTION_EVENT_BATCH_SIZE: usize = 100;
 
 #[derive(Clone, Eq, Hash, PartialEq)]
 struct Nip45CacheKey {
@@ -843,6 +843,49 @@ pub(super) fn parse_amount_from_description(description: &str) -> Option<u64> {
 
 /// Fetch interaction counts for a time range (useful for trending/popular feeds)
 ///
+/// Get interaction counts from the local database only (zero relay round-trips).
+///
+/// This provides instant counts by querying the nostr-sdk's local database.
+/// Useful as a first-pass fast path before the full relay fetch resolves user-state.
+///
+/// The counts may be incomplete if the local DB hasn't seen all interactions.
+/// Callers should overwrite with full relay-fetched counts when they arrive.
+pub async fn fetch_local_db_counts(
+    event_ids: &[EventId],
+) -> HashMap<String, InteractionCounts> {
+    let client = match get_client() {
+        Some(c) => c,
+        None => return HashMap::new(),
+    };
+    let db = client.database();
+    let mut result = HashMap::new();
+    for event_id in event_ids {
+        let hex = event_id.to_hex();
+        let mut counts = InteractionCounts::default();
+        let filter_base = Filter::new().event(*event_id);
+        let reply_filter = filter_base
+            .clone()
+            .kinds(vec![Kind::TextNote, Kind::Comment]);
+        if let Ok(count) = db.count(reply_filter).await {
+            counts.replies = count;
+        }
+        let reaction_filter = filter_base.clone().kind(Kind::Reaction);
+        if let Ok(count) = db.count(reaction_filter).await {
+            counts.likes = count;
+        }
+        let repost_filter = filter_base.clone().kind(Kind::Repost);
+        if let Ok(count) = db.count(repost_filter).await {
+            counts.reposts = count;
+        }
+        let zap_filter = filter_base.kind(Kind::ZapReceipt);
+        if let Ok(count) = db.count(zap_filter).await {
+            counts.zaps = count;
+        }
+        result.insert(hex, counts);
+    }
+    result
+}
+
 /// This fetches all interactions in a given time period and groups by event.
 /// Useful for "trending" or "popular" feeds that want to rank by recent engagement.
 #[allow(dead_code)]

--- a/src/services/aggregation/counting.rs
+++ b/src/services/aggregation/counting.rs
@@ -222,14 +222,20 @@ async fn fetch_events_for_filter(
     filter: Filter,
     timeout: Duration,
 ) -> Result<FetchEventsPage, String> {
-    let db_events: Vec<Event> = match client.database().query(filter.clone()).await {
+    let (db_events, relay_events) = tokio::join!(
+        client.database().query(filter.clone()),
+        client.fetch_events(filter, timeout)
+    );
+
+    let db_events: Vec<Event> = match db_events {
         Ok(events) => events.into_iter().collect(),
         Err(e) => {
             log::debug!("Database query for interactions failed: {}", e);
             Vec::new()
         }
     };
-    let relay_events: Vec<Event> = match client.fetch_events(filter, timeout).await {
+
+    let relay_events: Vec<Event> = match relay_events {
         Ok(events) => events.into_iter().collect(),
         Err(e) => {
             if !db_events.is_empty() {
@@ -393,26 +399,27 @@ pub async fn fetch_interaction_counts_batch(
     }
     let client = get_client().ok_or("Client not initialized")?;
     let mut event_map: HashMap<EventId, Event> = HashMap::new();
-    for batch in uncached_ids.chunks(INTERACTION_EVENT_BATCH_SIZE) {
-        let batch_events = fetch_paginated_interaction_events(
-            &client,
-            batch,
-            &[
-                Kind::TextNote,
-                Kind::Comment,
-                Kind::Reaction,
-                Kind::Repost,
-                Kind::ZapReceipt,
-                Kind::Custom(1010),
-            ],
-            timeout,
-        )
-        .await?;
-        log::info!(
-            "Fetched {} interaction events for batch of {} requested IDs",
-            batch_events.len(),
-            batch.len()
-        );
+    let batch_futures: Vec<_> = uncached_ids
+        .chunks(INTERACTION_EVENT_BATCH_SIZE)
+        .map(|batch| {
+            fetch_paginated_interaction_events(
+                &client,
+                batch,
+                &[
+                    Kind::TextNote,
+                    Kind::Comment,
+                    Kind::Reaction,
+                    Kind::Repost,
+                    Kind::ZapReceipt,
+                    Kind::Custom(1010),
+                ],
+                timeout,
+            )
+        })
+        .collect();
+    let batch_results = futures::future::join_all(batch_futures).await;
+    for batch_events in batch_results {
+        let batch_events = batch_events?;
         for event in batch_events {
             event_map.insert(event.id, event);
         }

--- a/src/services/aggregation/counting.rs
+++ b/src/services/aggregation/counting.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::stores::nostr_client::get_client;
+use crate::stores::nostr_client::{fetch_events_from_connected_relays_with_client, get_client};
 use crate::stores::signer::SIGNER_INFO;
 use crate::utils::bolt11::parse_bolt11_amount;
 use dioxus::prelude::ReadableExt;
@@ -218,16 +218,16 @@ struct FetchEventsPage {
 }
 
 async fn fetch_events_for_filter(
-    client: &Client,
+    client: &std::sync::Arc<Client>,
     filter: Filter,
     timeout: Duration,
 ) -> Result<FetchEventsPage, String> {
-    let (db_events, relay_events) = tokio::join!(
+    let (db_result, relay_result) = tokio::join!(
         client.database().query(filter.clone()),
-        client.fetch_events(filter, timeout)
+        fetch_events_from_connected_relays_with_client(client, filter, timeout)
     );
 
-    let db_events: Vec<Event> = match db_events {
+    let db_events: Vec<Event> = match db_result {
         Ok(events) => events.into_iter().collect(),
         Err(e) => {
             log::debug!("Database query for interactions failed: {}", e);
@@ -235,8 +235,8 @@ async fn fetch_events_for_filter(
         }
     };
 
-    let relay_events: Vec<Event> = match relay_events {
-        Ok(events) => events.into_iter().collect(),
+    let relay_events: Vec<Event> = match relay_result {
+        Ok(events) => events,
         Err(e) => {
             if !db_events.is_empty() {
                 log::warn!(
@@ -246,7 +246,7 @@ async fn fetch_events_for_filter(
                 );
                 Vec::new()
             } else {
-                return Err(format!("Failed to fetch interactions: {}", e));
+                return Err(e);
             }
         }
     };
@@ -271,7 +271,7 @@ async fn fetch_events_for_filter(
 }
 
 async fn fetch_paginated_interaction_events(
-    client: &Client,
+    client: &std::sync::Arc<Client>,
     event_ids: &[EventId],
     kinds: &[Kind],
     timeout: Duration,

--- a/src/services/aggregation/counting.rs
+++ b/src/services/aggregation/counting.rs
@@ -786,7 +786,7 @@ pub(super) fn extract_zap_sender(event: &Event) -> Option<String> {
 }
 
 /// Extract zap amount in satoshis from a zap event (kind 9735)
-pub(super) fn extract_zap_amount(event: &Event) -> Option<u64> {
+pub fn extract_zap_amount(event: &Event) -> Option<u64> {
     if let Some(bolt11_tag) = event.tags.iter().find(|tag| {
         tag.as_slice()
             .first()

--- a/src/services/aggregation/counting.rs
+++ b/src/services/aggregation/counting.rs
@@ -296,6 +296,12 @@ async fn fetch_paginated_interaction_events(
 
         let previous_len = all_events.len();
         for event in page.events {
+            #[cfg(feature = "native")]
+            {
+                if matches!(event.kind, Kind::TextNote | Kind::Comment | Kind::VoiceMessage | Kind::VoiceMessageReply) {
+                    crate::stores::ndb::cache_event(&event);
+                }
+            }
             all_events.insert(event.id, event);
         }
 

--- a/src/services/aggregation/mod.rs
+++ b/src/services/aggregation/mod.rs
@@ -11,7 +11,7 @@
 //!
 //! # L2 Caching (Phase 3.5)
 //! Implements in-memory LRU cache for computed interaction counts:
-//! - Cache size: 1000 events
+//! - Cache size: 10000 events
 //! - TTL: 5 minutes per entry
 //! - Automatic eviction of stale/excess entries
 //! - Reduces redundant database queries for recently-viewed events
@@ -214,16 +214,14 @@ impl CountsCache {
     }
 }
 
-/// Global L2 cache for interaction counts
-///
 /// Cache configuration:
-/// - Capacity: 1000 events (enough for ~10 full feeds)
+/// - Capacity: 10000 events
 /// - TTL: 5 minutes (balance freshness vs performance)
 static COUNTS_CACHE: OnceLock<Mutex<CountsCache>> = OnceLock::new();
 
 /// Get or initialize the counts cache
 pub(crate) fn get_counts_cache() -> &'static Mutex<CountsCache> {
-    COUNTS_CACHE.get_or_init(|| Mutex::new(CountsCache::new(1000, Duration::from_secs(300))))
+    COUNTS_CACHE.get_or_init(|| Mutex::new(CountsCache::new(10000, Duration::from_secs(300))))
 }
 
 pub(crate) fn is_reply_kind(kind: Kind) -> bool {

--- a/src/services/git_hosting/repository.rs
+++ b/src/services/git_hosting/repository.rs
@@ -4,7 +4,7 @@
 #![allow(dead_code)]
 use crate::stores::code_store::{cache_repo_events, get_cached_repo};
 use crate::stores::nostr_client::{fetch_events_aggregated, get_client, HAS_SIGNER};
-use crate::utils::nip34::{decode_repo_naddr, Repository};
+use crate::utils::nip34::Repository;
 use dioxus::signals::ReadableExt;
 use nostr_sdk::prelude::*;
 use std::time::Duration;
@@ -15,20 +15,19 @@ pub async fn fetch_repository(naddr: &str) -> Result<Repository, String> {
     if let Some(repo) = get_cached_repo(naddr) {
         return Ok(repo);
     }
-    let (coordinate, _relay_hints) =
-        decode_repo_naddr(naddr).map_err(|e| format!("Invalid naddr: {}", e))?;
-    let filter = Filter::new()
-        .kind(Kind::GitRepoAnnouncement)
-        .author(coordinate.public_key)
-        .identifier(&coordinate.identifier);
-    let events = fetch_events_aggregated(filter, FETCH_TIMEOUT)
-        .await
-        .map_err(|e| format!("Failed to fetch repository: {}", e))?;
-    cache_repo_events(&events);
-    events
-        .into_iter()
-        .max_by_key(|e| e.created_at)
-        .and_then(|e| Repository::from_event(&e))
+    let parsed = crate::utils::nip19::parse_naddr(naddr)
+        .map_err(|e| format!("Invalid naddr: {}", e))?;
+    let event = crate::stores::nostr_client::fetch_event_by_coordinate_with_relays(
+        parsed.kind,
+        parsed.pubkey,
+        parsed.identifier,
+        parsed.relay_hints,
+    )
+    .await
+    .map_err(|e| format!("Failed to fetch repository: {}", e))?;
+    let event = event.ok_or_else(|| "Repository not found".to_string())?;
+    cache_repo_events(std::slice::from_ref(&event));
+    Repository::from_event(&event)
         .ok_or_else(|| "Repository not found".to_string())
 }
 /// Fetch repositories by author pubkey

--- a/src/services/github_nips.rs
+++ b/src/services/github_nips.rs
@@ -84,10 +84,22 @@ fn validate_hex_number(number: &str, label: &str) -> Result<String, String> {
 }
 
 #[cfg(feature = "web")]
+fn resolve_url(path: &str) -> String {
+    if path.starts_with("http://") || path.starts_with("https://") || path.starts_with("blob:") {
+        return path.to_string();
+    }
+    let origin = web_sys::window()
+        .and_then(|w| w.location().origin().ok())
+        .unwrap_or_default();
+    format!("{}{}", origin, path)
+}
+
+#[cfg(feature = "web")]
 async fn fetch_text(url: &str, context: &str) -> Result<String, String> {
+    let absolute = resolve_url(url);
     let response = http_client()
         .map_err(|e| format!("HTTP client init failed: {}", e))?
-        .get(url)
+        .get(&absolute)
         .send()
         .await
         .map_err(|e| format!("Failed to fetch {}: {}", context, e))?;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -47,6 +47,7 @@ pub mod git_worker;
 pub mod github_nips;
 pub mod openlibrary;
 pub mod pages;
+pub mod nip05;
 pub mod profile_stats;
 pub mod scheduler;
 pub mod sync;

--- a/src/services/nip05.rs
+++ b/src/services/nip05.rs
@@ -1,0 +1,165 @@
+use dioxus::prelude::*;
+use instant::Instant;
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Nip05Status {
+    Unknown,
+    Verifying,
+    Verified,
+    Impersonator,
+    Error,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CacheEntry {
+    status: Nip05Status,
+    checked_at: Instant,
+}
+
+const CACHE_TTL_SECS: u64 = 8 * 60 * 60;
+
+pub(super) static NIP05_CACHE: GlobalSignal<HashMap<String, CacheEntry>> =
+    Signal::global(HashMap::new);
+
+fn cache_key(pubkey: &str, nip05: &str) -> String {
+    format!("{}:{}", pubkey, nip05.to_lowercase())
+}
+
+pub fn get_nip05_status(pubkey: &str, nip05: &str) -> Nip05Status {
+    let key = cache_key(pubkey, nip05);
+    let cache = NIP05_CACHE.peek();
+    if let Some(entry) = cache.get(&key) {
+        match &entry.status {
+            Nip05Status::Verified | Nip05Status::Impersonator => return entry.status.clone(),
+            Nip05Status::Error => {
+                if entry.checked_at.elapsed().as_secs() < CACHE_TTL_SECS {
+                    return entry.status.clone();
+                }
+            }
+            Nip05Status::Verifying => return entry.status.clone(),
+            Nip05Status::Unknown => {}
+        }
+    }
+    Nip05Status::Unknown
+}
+
+pub fn verify_nip05(pubkey: &str, nip05: &str) {
+    let key = cache_key(pubkey, nip05);
+    {
+        let cache = NIP05_CACHE.peek();
+        if let Some(entry) = cache.get(&key) {
+            match &entry.status {
+                Nip05Status::Verified | Nip05Status::Impersonator => return,
+                Nip05Status::Verifying => return,
+                Nip05Status::Error => {
+                    if entry.checked_at.elapsed().as_secs() < CACHE_TTL_SECS {
+                        return;
+                    }
+                }
+                Nip05Status::Unknown => {}
+            }
+        }
+    }
+
+    NIP05_CACHE.write().insert(
+        key.clone(),
+        CacheEntry {
+            status: Nip05Status::Verifying,
+            checked_at: Instant::now(),
+        },
+    );
+
+    let pubkey_hex = pubkey.to_string();
+    let nip05_str = nip05.to_string();
+    let key_clone = key.clone();
+    spawn(async move {
+        let result = do_verify(&pubkey_hex, &nip05_str).await;
+        NIP05_CACHE.write().insert(
+            key_clone,
+            CacheEntry {
+                status: result,
+                checked_at: Instant::now(),
+            },
+        );
+    });
+}
+
+async fn do_verify(pubkey_hex: &str, nip05: &str) -> Nip05Status {
+    let (name, domain) = match nip05.split_once('@') {
+        Some((n, d)) => (n, d),
+        None => return Nip05Status::Error,
+    };
+
+    if name.is_empty() || domain.is_empty() {
+        return Nip05Status::Error;
+    }
+
+    let url = format!(
+        "https://{}/.well-known/nostr.json?name={}",
+        domain,
+        urlencoding::encode(name)
+    );
+
+    let client = match crate::platform::http::http_client() {
+        Ok(c) => c,
+        Err(_) => return Nip05Status::Error,
+    };
+
+    let resp = match client
+        .get(&url)
+        .header("Accept", "application/json")
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            log::debug!("NIP-05 fetch failed for {}: {}", nip05, e);
+            return Nip05Status::Error;
+        }
+    };
+
+    if !resp.status().is_success() {
+        log::debug!("NIP-05 returned {} for {}", resp.status(), nip05);
+        return Nip05Status::Error;
+    }
+
+    let body: serde_json::Value = match resp.json().await {
+        Ok(b) => b,
+        Err(e) => {
+            log::debug!("NIP-05 parse failed for {}: {}", nip05, e);
+            return Nip05Status::Error;
+        }
+    };
+
+    let names = match body.get("names").and_then(|n| n.as_object()) {
+        Some(m) => m,
+        None => return Nip05Status::Error,
+    };
+
+    let name_lower = name.to_lowercase();
+    let returned_pubkey = match names.get(&name_lower).and_then(|v| v.as_str()) {
+        Some(pk) => pk,
+        None => return Nip05Status::Impersonator,
+    };
+
+    if returned_pubkey.to_lowercase() == pubkey_hex.to_lowercase() {
+        log::debug!("NIP-05 verified: {} matches {}", nip05, pubkey_hex);
+        Nip05Status::Verified
+    } else {
+        log::debug!(
+            "NIP-05 impersonator: {} returned {} expected {}",
+            nip05,
+            returned_pubkey,
+            pubkey_hex
+        );
+        Nip05Status::Impersonator
+    }
+}
+
+pub fn retry_nip05(pubkey: &str, nip05: &str) {
+    let key = cache_key(pubkey, nip05);
+    NIP05_CACHE.write().remove(&key);
+    verify_nip05(pubkey, nip05);
+}

--- a/src/services/podcasts/podcast_rss.rs
+++ b/src/services/podcasts/podcast_rss.rs
@@ -172,6 +172,7 @@ pub fn parse_podcast_feed(xml: &str, feed_url: &str) -> Result<RssPodcast, Strin
     use quick_xml::Reader;
     let mut reader = Reader::from_str(xml);
     reader.config_mut().trim_text(true);
+    reader.config_mut().expand_empty_elements = true;
     let mut podcast = RssPodcast {
         guid: String::new(),
         title: String::new(),
@@ -196,6 +197,7 @@ pub fn parse_podcast_feed(xml: &str, feed_url: &str) -> Result<RssPodcast, Strin
     let mut current_element = String::new();
     let mut in_channel = false;
     let mut in_item = false;
+    let mut in_image = false;
     let mut current_episode: Option<RssEpisode> = None;
     let mut buf = Vec::new();
     loop {
@@ -205,6 +207,7 @@ pub fn parse_podcast_feed(xml: &str, feed_url: &str) -> Result<RssPodcast, Strin
                 current_element = name.clone();
                 match name.as_str() {
                     "channel" => in_channel = true,
+                    "image" if !in_item => in_image = true,
                     "item" => {
                         in_item = true;
                         current_episode = Some(RssEpisode {
@@ -300,7 +303,8 @@ pub fn parse_podcast_feed(xml: &str, feed_url: &str) -> Result<RssPodcast, Strin
                         for attr in e.attributes().flatten() {
                             let key = String::from_utf8_lossy(attr.key.as_ref());
                             if key == "href" || key == "url" {
-                                let url = String::from_utf8_lossy(&attr.value).to_string();
+                                let url =
+                                    upgrade_to_https(String::from_utf8_lossy(&attr.value).to_string());
                                 if in_item {
                                     if let Some(ref mut ep) = current_episode {
                                         ep.image = Some(url);
@@ -318,6 +322,7 @@ pub fn parse_podcast_feed(xml: &str, feed_url: &str) -> Result<RssPodcast, Strin
                 let name = String::from_utf8_lossy(e.name().as_ref()).to_string();
                 match name.as_str() {
                     "channel" => in_channel = false,
+                    "image" => in_image = false,
                     "item" => {
                         in_item = false;
                         if let Some(ep) = current_episode.take() {
@@ -333,6 +338,12 @@ pub fn parse_podcast_feed(xml: &str, feed_url: &str) -> Result<RssPodcast, Strin
             Ok(Event::Text(ref e)) => {
                 let text = e.decode().unwrap_or_default().to_string();
                 if text.trim().is_empty() {
+                    continue;
+                }
+                if in_image {
+                    if current_element == "url" && podcast.image.is_none() {
+                        podcast.image = Some(upgrade_to_https(text));
+                    }
                     continue;
                 }
                 if in_item {
@@ -445,6 +456,13 @@ pub async fn fetch_transcript(transcript: &TranscriptRef) -> Result<String, Stri
         .text()
         .await
         .map_err(|e| format!("Failed to read transcript: {}", e))
+}
+fn upgrade_to_https(url: String) -> String {
+    if url.starts_with("http://") {
+        url.replacen("http://", "https://", 1)
+    } else {
+        url
+    }
 }
 /// Parse duration string to seconds
 /// Supports formats: "HH:MM:SS", "MM:SS", "SS", or numeric seconds
@@ -632,5 +650,95 @@ mod tests {
         let guid1 = generate_guid("Episode 1", "https://example.com/ep1.mp3");
         let guid2 = generate_guid("Episode 2", "https://example.com/ep2.mp3");
         assert_ne!(guid1, guid2);
+    }
+    #[test]
+    fn test_parse_podcast_feed_self_closing_tags() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+  xmlns:podcast="https://podcastindex.org/namespace/1.0">
+<channel>
+    <title>Test Show</title>
+    <image>
+        <url>http://example.com/rss-image.jpg</url>
+        <title>Test Show</title>
+        <link>https://example.com</link>
+    </image>
+    <itunes:image href="http://example.com/itunes-art.jpg"/>
+    <podcast:image href="http://example.com/podcast-art.jpg"/>
+    <item>
+        <title>Episode 1</title>
+        <guid>ep1</guid>
+        <enclosure url="https://example.com/ep1.mp3" type="audio/mpeg" length="12345"/>
+        <itunes:image href="http://example.com/ep1-art.jpg"/>
+        <podcast:chapters url="https://example.com/chapters.json" type="application/json"/>
+    </item>
+    <item>
+        <title>Episode 2</title>
+        <guid>ep2</guid>
+        <enclosure url="https://example.com/ep2.mp3" type="audio/mpeg"/>
+    </item>
+</channel>
+</rss>"#;
+        let result = parse_podcast_feed(xml, "https://example.com/feed.xml").unwrap();
+        assert_eq!(result.title, "Test Show");
+        assert_eq!(
+            result.image,
+            Some("https://example.com/podcast-art.jpg".to_string())
+        );
+        assert_eq!(result.episodes.len(), 2);
+        let ep1 = &result.episodes[0];
+        assert_eq!(ep1.title, "Episode 1");
+        assert_eq!(ep1.enclosure_url, "https://example.com/ep1.mp3");
+        assert_eq!(ep1.enclosure_type, "audio/mpeg");
+        assert_eq!(
+            ep1.image,
+            Some("https://example.com/ep1-art.jpg".to_string())
+        );
+        assert_eq!(
+            ep1.chapters_url,
+            Some("https://example.com/chapters.json".to_string())
+        );
+        let ep2 = &result.episodes[1];
+        assert_eq!(ep2.title, "Episode 2");
+    }
+    #[test]
+    fn test_parse_podcast_feed_image_fallback() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+    <title>Fallback Show</title>
+    <image>
+        <url>http://example.com/fallback.jpg</url>
+        <title>Fallback Show</title>
+        <link>https://example.com</link>
+    </image>
+    <item>
+        <title>Episode A</title>
+        <guid>epA</guid>
+        <enclosure url="https://example.com/epA.mp3" type="audio/mpeg"/>
+    </item>
+</channel>
+</rss>"#;
+        let result = parse_podcast_feed(xml, "https://example.com/feed.xml").unwrap();
+        assert_eq!(
+            result.image,
+            Some("https://example.com/fallback.jpg".to_string())
+        );
+    }
+    #[test]
+    fn test_upgrade_to_https() {
+        assert_eq!(
+            upgrade_to_https("http://example.com/img.jpg".to_string()),
+            "https://example.com/img.jpg"
+        );
+        assert_eq!(
+            upgrade_to_https("https://example.com/img.jpg".to_string()),
+            "https://example.com/img.jpg"
+        );
+        assert_eq!(
+            upgrade_to_https("//example.com/img.jpg".to_string()),
+            "//example.com/img.jpg"
+        );
     }
 }

--- a/src/services/profile_stats.rs
+++ b/src/services/profile_stats.rs
@@ -5,14 +5,15 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 #[cfg(feature = "web")]
 use web_sys::{Request, RequestInit, RequestMode, Response};
-#[cfg(feature = "web")]
+
 const NOSTR_ARCHIVES_API: &str = "https://api.nostrarchives.com";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProfileStats {
     pub pubkey: String,
     pub followers_pubkey_count: Option<u64>,
 }
-#[cfg(feature = "web")]
+
 #[derive(Debug, Clone, Deserialize)]
 struct SocialListResponse {
     count: i64,
@@ -20,11 +21,12 @@ struct SocialListResponse {
     #[allow(dead_code)]
     pubkeys: Vec<String>,
 }
-#[cfg(feature = "web")]
+
 #[derive(Debug, Clone, Deserialize)]
 struct SocialGraphResponse {
     followers: SocialListResponse,
 }
+
 #[cfg(feature = "web")]
 pub async fn fetch_profile_stats(pubkey: &str) -> Result<ProfileStats, String> {
     let url = format!(
@@ -66,8 +68,27 @@ pub async fn fetch_profile_stats(pubkey: &str) -> Result<ProfileStats, String> {
 
 #[cfg(not(feature = "web"))]
 pub async fn fetch_profile_stats(pubkey: &str) -> Result<ProfileStats, String> {
-    Err(format!(
-        "Profile stats not yet supported on native for pubkey: {}",
-        pubkey
-    ))
+    let url = format!(
+        "{}/v1/social/{}?followers_limit=0&follows_limit=0",
+        NOSTR_ARCHIVES_API, pubkey
+    );
+    let client = crate::platform::http::http_client()
+        .map_err(|e| format!("HTTP client error: {}", e))?;
+    let resp = client
+        .get(&url)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(|e| format!("Fetch failed: {}", e))?;
+    if !resp.status().is_success() {
+        return Err(format!("API returned status: {}", resp.status()));
+    }
+    let response: SocialGraphResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to deserialize: {}", e))?;
+    Ok(ProfileStats {
+        pubkey: pubkey.to_string(),
+        followers_pubkey_count: Some(response.followers.count as u64),
+    })
 }

--- a/src/stores/audio/music_player.rs
+++ b/src/stores/audio/music_player.rs
@@ -299,8 +299,26 @@ impl MusicTrack {
         use nostr_sdk::nips::nip19::ToBech32;
         coord.to_bech32().ok()
     }
+    fn resolve_image_url<'a>(
+        episode: &'a PodcastIndexEpisode,
+        feed: &'a PodcastFeed,
+        chart_image: Option<&'a str>,
+    ) -> Option<&'a str> {
+        episode
+            .image
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .or(chart_image.filter(|s| !s.is_empty()))
+            .or(episode.feed_image.as_deref().filter(|s| !s.is_empty()))
+            .or(feed.get_image())
+    }
+
     /// Create MusicTrack from RSS music album track (Podcast Index medium="music")
-    pub fn from_rss_music_track(episode: &PodcastIndexEpisode, feed: &PodcastFeed) -> Self {
+    pub fn from_rss_music_track(
+        episode: &PodcastIndexEpisode,
+        feed: &PodcastFeed,
+        chart_image: Option<&str>,
+    ) -> Self {
         let value_block = episode.value.as_ref().or(feed.value.as_ref()).map(|v| {
             let model = v.model.as_ref();
             crate::utils::podcast::ValueBlock {
@@ -334,8 +352,8 @@ impl MusicTrack {
             artist: feed.author.clone().unwrap_or_else(|| feed.title.clone()),
             album: Some(feed.title.clone()),
             media_url: episode.enclosure_url.clone().unwrap_or_default(),
-            album_art_url: episode.get_image().or(feed.get_image()).map(String::from),
-            artist_art_url: feed.get_image().map(String::from),
+            album_art_url: Self::resolve_image_url(episode, feed, chart_image).map(String::from),
+            artist_art_url: feed.get_image().filter(|s| !s.is_empty()).map(String::from),
             duration: episode.duration.map(|d| d as u32),
             artist_id: None,
             album_id: None,

--- a/src/stores/audio/music_player.rs
+++ b/src/stores/audio/music_player.rs
@@ -857,7 +857,8 @@ pub fn restore_from_floating() {
 /// Show zap dialog for a specific track (or current track if None)
 pub fn show_zap_dialog_for_track(track: Option<MusicTrack>) {
     let store = MUSIC_PLAYER.resolve();
-    *store.zap_track().write() = track.or_else(|| store.current_track().peek().clone());
+    let current = store.current_track().peek().clone();
+    *store.zap_track().write() = track.or(current);
     *store.show_zap_dialog().write() = true;
 }
 /// Show zap dialog for current track
@@ -1135,8 +1136,8 @@ pub fn sync_native_playback_snapshot(snapshot: AndroidPlaybackSnapshot) {
     if !store.playlist().peek().is_empty() && snapshot.current_index < store.playlist().peek().len()
         && prev_index != snapshot.current_index {
         *store.current_index().write() = snapshot.current_index;
-        *store.current_track().write() =
-            store.playlist().peek().get(snapshot.current_index).cloned();
+        let track = store.playlist().peek().get(snapshot.current_index).cloned();
+        *store.current_track().write() = track;
     }
     *store.is_playing().write() = snapshot.is_playing;
     *store.is_buffering().write() = snapshot.is_buffering;

--- a/src/stores/audio/nostr_music.rs
+++ b/src/stores/audio/nostr_music.rs
@@ -344,6 +344,7 @@ pub async fn fetch_nostr_tracks(
 pub async fn fetch_nostr_track_by_coordinate(
     pubkey: &str,
     d_tag: &str,
+    relay_hints: Vec<String>,
 ) -> Result<Option<NostrTrack>, String> {
     let cache_key = format!("{}:{}:{}", KIND_MUSIC_TRACK, pubkey, d_tag);
     if let Some(cached) = NOSTR_TRACK_CACHE.read().peek(&cache_key) {
@@ -352,16 +353,15 @@ pub async fn fetch_nostr_track_by_coordinate(
             return Ok(Some(cached.track.clone()));
         }
     }
-    let public_key = PublicKey::from_hex(pubkey).map_err(|e| format!("Invalid pubkey: {}", e))?;
-    let filter = Filter::new()
-        .kind(Kind::from(KIND_MUSIC_TRACK))
-        .author(public_key)
-        .identifier(d_tag)
-        .limit(1);
-    let events = nostr_client::fetch_events_aggregated(filter, Duration::from_secs(5))
-        .await
-        .map_err(|e| format!("Failed to fetch track: {}", e))?;
-    if let Some(event) = events.into_iter().next() {
+    let event = nostr_client::fetch_event_by_coordinate_with_relays(
+        KIND_MUSIC_TRACK,
+        pubkey.to_string(),
+        d_tag.to_string(),
+        relay_hints,
+    )
+    .await
+    .map_err(|e| format!("Failed to fetch track: {}", e))?;
+    if let Some(event) = event {
         let track = parse_track_event(&event)?;
         NOSTR_TRACK_CACHE.write().put(
             track.coordinate.clone(),
@@ -601,19 +601,17 @@ pub async fn fetch_playlists(
 pub async fn fetch_playlist_by_coordinate(
     author: &str,
     d_tag: &str,
+    relay_hints: Vec<String>,
 ) -> Result<Option<NostrPlaylist>, String> {
-    let public_key = PublicKey::from_hex(author)
-        .or_else(|_| PublicKey::from_bech32(author))
-        .map_err(|e| format!("Invalid pubkey: {}", e))?;
-    let filter = Filter::new()
-        .kind(Kind::from(KIND_PLAYLIST))
-        .author(public_key)
-        .identifier(d_tag)
-        .limit(1);
-    let events = nostr_client::fetch_events_aggregated(filter, Duration::from_secs(5))
-        .await
-        .map_err(|e| format!("Failed to fetch playlist: {}", e))?;
-    if let Some(event) = events.into_iter().next() {
+    let event = nostr_client::fetch_event_by_coordinate_with_relays(
+        KIND_PLAYLIST,
+        author.to_string(),
+        d_tag.to_string(),
+        relay_hints,
+    )
+    .await
+    .map_err(|e| format!("Failed to fetch playlist: {}", e))?;
+    if let Some(event) = event {
         let playlist = parse_playlist_event(&event)?;
         NOSTR_PLAYLIST_CACHE
             .write()
@@ -647,7 +645,7 @@ pub async fn resolve_playlist_tracks(playlist: &NostrPlaylist) -> Result<Vec<Nos
             if parts.len() >= 3 {
                 let pubkey = parts[1];
                 let d_tag = parts[2];
-                if let Ok(Some(track)) = fetch_nostr_track_by_coordinate(pubkey, d_tag).await {
+                if let Ok(Some(track)) = fetch_nostr_track_by_coordinate(pubkey, d_tag, vec![]).await {
                     for (ref_key, track_opt) in &mut tracks {
                         if ref_key == track_ref {
                             *track_opt = Some(track.clone());

--- a/src/stores/auth_store.rs
+++ b/src/stores/auth_store.rs
@@ -409,21 +409,31 @@ async fn restore_nostr_connect(
 async fn run_post_login_init() {
     log::info!("Running post-login initialization...");
     crate::stores::notifications::load_checked_at();
-    crate::stores::notifications::fetch_and_merge_from_nip78().await;
-    if let Err(e) = crate::stores::blossom_store::fetch_user_servers().await {
-        log::warn!("Failed to fetch Blossom servers: {}", e);
-    }
-    // Wait for user relay lists before starting subscriptions
-    // Critical for NIP-46 where signer restoration is slow and
-    // relay application happens concurrently in set_signer()'s spawn_forever
+    // Wait for user relay lists BEFORE any NIP-78 fetches.
+    // Without this, fetches hit bootstrap relays only and silently return
+    // empty results, which get baked in as LoadedDefaults (never retried).
     crate::stores::relay::wait_for_user_relays(
         std::time::Duration::from_secs(10),
         "run_post_login_init",
     )
     .await;
-    crate::stores::sidebar_store::load_sidebar_preferences().await;
-    crate::stores::reactions_store::load_preferred_reactions().await;
-    crate::stores::ai_provider_store::sync_provider_state_from_relays().await;
+    // Run all NIP-78 loads in parallel now that the relay pool is correct
+    futures::join!(
+        crate::stores::notifications::fetch_and_merge_from_nip78(),
+        async {
+            if let Err(e) = crate::stores::blossom_store::fetch_user_servers().await {
+                log::warn!("Failed to fetch Blossom servers: {}", e);
+            }
+        },
+        crate::stores::sidebar_store::load_sidebar_preferences(),
+        crate::stores::reactions_store::load_preferred_reactions(),
+        crate::stores::ai_provider_store::sync_provider_state_from_relays(),
+        async {
+            if let Err(e) = crate::stores::settings_store::load_settings().await {
+                log::warn!("Failed to load settings: {}", e);
+            }
+        },
+    );
     crate::stores::notifications::start_realtime_subscription().await;
     crate::stores::relay::start_relay_list_subscription().await;
     crate::stores::emoji_store::init_emoji_fetch();

--- a/src/stores/auth_store.rs
+++ b/src/stores/auth_store.rs
@@ -413,7 +413,7 @@ async fn run_post_login_init() {
     // Without this, fetches hit bootstrap relays only and silently return
     // empty results, which get baked in as LoadedDefaults (never retried).
     crate::stores::relay::wait_for_user_relays(
-        std::time::Duration::from_secs(10),
+        std::time::Duration::from_secs(5),
         "run_post_login_init",
     )
     .await;

--- a/src/stores/calendar_store/fetch.rs
+++ b/src/stores/calendar_store/fetch.rs
@@ -582,25 +582,28 @@ pub async fn fetch_unified_event_by_naddr(naddr: &str) -> StdResult<Option<Unifi
         format!("Invalid naddr: {}", e)
     })?;
     let coord = nip19.coordinate;
-    let pk = coord.public_key;
     let kind = coord.kind.as_u16();
+    let pk = coord.public_key;
     let identifier = coord.identifier.clone();
+    let relay_hints: Vec<String> = nip19.relays.iter().map(|r| r.to_string()).collect();
     log::info!(
-        "[calendar_store] Parsed naddr - kind: {}, pubkey: {}, identifier: {}",
-        kind,
-        pk,
-        identifier
+        "[calendar_store] Parsed naddr - kind: {}, pubkey: {}, identifier: {}, hints: {}",
+        kind, pk, identifier, relay_hints.len()
     );
-    let filter = event_by_coordinate_filter(pk, kind, &identifier);
-    log::info!("[calendar_store] Fetching from relays with 10s timeout...");
-    let events =
-        crate::stores::nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10))
-            .await?;
+    log::info!("[calendar_store] Fetching from relays...");
+    let event =
+        crate::stores::nostr_client::fetch_event_by_coordinate_with_relays(
+            kind,
+            pk.to_hex(),
+            identifier,
+            relay_hints,
+        )
+        .await?;
     log::info!(
-        "[calendar_store] Received {} events from relays",
-        events.len()
+        "[calendar_store] Fetch result: {}",
+        if event.is_some() { "found" } else { "not found" }
     );
-    if let Some(event) = events.first() {
+    if let Some(event) = event {
         let event_kind = event.kind.as_u16();
         log::info!(
             "[calendar_store] Attempting to parse event kind {}",
@@ -608,7 +611,7 @@ pub async fn fetch_unified_event_by_naddr(naddr: &str) -> StdResult<Option<Unifi
         );
         match event_kind {
             KIND_DATE_CALENDAR_EVENT | KIND_TIME_CALENDAR_EVENT => {
-                if let Ok(cal_event) = parse_calendar_event(event) {
+                if let Ok(cal_event) = parse_calendar_event(&event) {
                     log::info!(
                         "[calendar_store] Successfully parsed calendar event: {}",
                         cal_event.title
@@ -618,7 +621,7 @@ pub async fn fetch_unified_event_by_naddr(naddr: &str) -> StdResult<Option<Unifi
                 }
             }
             KIND_MEETING_SPACE => {
-                if let Ok(space) = parse_meeting_space(event) {
+                if let Ok(space) = parse_meeting_space(&event) {
                     log::info!(
                         "[calendar_store] Successfully parsed meeting space: {}",
                         space.room_name
@@ -631,7 +634,7 @@ pub async fn fetch_unified_event_by_naddr(naddr: &str) -> StdResult<Option<Unifi
                 }
             }
             KIND_MEETING_ROOM => {
-                if let Ok(meeting) = parse_meeting_room_event(event) {
+                if let Ok(meeting) = parse_meeting_room_event(&event) {
                     log::info!(
                         "[calendar_store] Successfully parsed meeting room: {}",
                         meeting.title

--- a/src/stores/content/publication_store.rs
+++ b/src/stores/content/publication_store.rs
@@ -706,24 +706,28 @@ pub async fn fetch_publication_by_naddr(
     if let Some(pub_) = get_cached_publication_by_naddr(naddr) {
         return Ok(Some(pub_));
     }
-    let coord = Coordinate::from_bech32(naddr).map_err(|e| format!("Invalid naddr: {}", e))?;
-    let identifier = coord.identifier;
+    let parsed = crate::utils::nip19::parse_naddr(naddr)?;
+    let identifier = parsed.identifier;
     if identifier.is_empty() {
         return Err("No identifier in naddr".to_string());
     }
-    let filter = publication_by_coord_filter(coord.public_key, &identifier);
     let result =
-        crate::stores::nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10)).await;
+        crate::stores::nostr_client::fetch_event_by_coordinate_with_relays(
+            parsed.kind,
+            parsed.pubkey,
+            identifier,
+            parsed.relay_hints,
+        )
+        .await;
     match result {
-        Ok(events) => {
-            if let Some(event) = events.first() {
-                if let Some(pub_) = parse_publication_index(event) {
-                    cache_publication(pub_.clone());
-                    return Ok(Some(pub_));
-                }
+        Ok(Some(event)) => {
+            if let Some(pub_) = parse_publication_index(&event) {
+                cache_publication(pub_.clone());
+                return Ok(Some(pub_));
             }
             Ok(None)
         }
+        Ok(None) => Ok(None),
         Err(e) => {
             log::error!("Failed to fetch publication: {}", e);
             Err(e)

--- a/src/stores/content/recipe_store.rs
+++ b/src/stores/content/recipe_store.rs
@@ -338,13 +338,16 @@ pub async fn fetch_recipe_by_naddr(naddr: &str) -> StdResult<Option<CachedRecipe
     if let Some(cached) = get_cached_recipe_by_naddr(naddr) {
         return Ok(Some(cached));
     }
-    let coord = Coordinate::from_bech32(naddr).map_err(|e| format!("Invalid naddr: {}", e))?;
-    let filter = recipe_by_coord_filter(coord.public_key, &coord.identifier);
-    let events =
-        crate::stores::nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10))
-            .await?;
-    if let Some(event) = events.first() {
-        if let Some(recipe) = parse_recipe_event(event) {
+    let parsed = crate::utils::nip19::parse_naddr(naddr)?;
+    let event = crate::stores::nostr_client::fetch_event_by_coordinate_with_relays(
+        parsed.kind,
+        parsed.pubkey,
+        parsed.identifier,
+        parsed.relay_hints,
+    )
+    .await?;
+    if let Some(event) = event {
+        if let Some(recipe) = parse_recipe_event(&event) {
             cache_recipe(recipe.clone());
             return Ok(Some(recipe));
         }

--- a/src/stores/feed_cache.rs
+++ b/src/stores/feed_cache.rs
@@ -64,6 +64,8 @@ pub enum FeedCacheKey {
     ArticlesGlobal,
     /// People list feed
     PeopleList { pubkey: String, list_id: String },
+    /// Relay feed (single relay or relay set)
+    RelayFeed { urls: String },
 }
 impl FeedCacheKey {
     /// Convert to string key for IndexedDB storage
@@ -84,6 +86,7 @@ impl FeedCacheKey {
             FeedCacheKey::PeopleList { pubkey, list_id } => {
                 format!("list:{}:{}", pubkey, list_id)
             }
+            FeedCacheKey::RelayFeed { urls } => format!("relay_feed:{}", urls),
         }
     }
 }

--- a/src/stores/ndb/mod.rs
+++ b/src/stores/ndb/mod.rs
@@ -22,6 +22,15 @@ use nostr_ndb::NdbDatabase;
 use std::sync::OnceLock;
 
 #[cfg(feature = "native")]
+use lru::LruCache;
+
+#[cfg(feature = "native")]
+use nostr::{EventId, Kind};
+
+#[cfg(feature = "native")]
+use std::num::NonZeroUsize;
+
+#[cfg(feature = "native")]
 use dioxus::core::spawn_forever;
 
 #[cfg(feature = "native")]
@@ -97,4 +106,45 @@ pub fn start_ndb_event_processor() {
 pub fn drain_ndb_live_events() -> Vec<nostr::Event> {
     let mut live = NDB_LIVE_EVENTS.write();
     std::mem::take(&mut *live)
+}
+
+#[cfg(feature = "native")]
+static EVENT_BRIDGE_CACHE: std::sync::LazyLock<std::sync::Mutex<LruCache<[u8; 32], nostr::Event>>> =
+    std::sync::LazyLock::new(|| {
+        std::sync::Mutex::new(LruCache::new(NonZeroUsize::new(10000).unwrap()))
+    });
+
+#[cfg(feature = "native")]
+pub fn cache_event(event: &nostr::Event) {
+    if let Ok(mut cache) = EVENT_BRIDGE_CACHE.lock() {
+        cache.put(event.id.to_bytes(), event.clone());
+    }
+}
+
+#[cfg(feature = "native")]
+pub fn get_cached_event(id: &[u8; 32]) -> Option<nostr::Event> {
+    EVENT_BRIDGE_CACHE
+        .lock()
+        .ok()
+        .and_then(|mut cache| cache.get(id).cloned())
+}
+
+#[cfg(feature = "native")]
+pub fn get_cached_replies(event_id: &EventId, kinds: &[Kind]) -> Vec<nostr::Event> {
+    let Ok(cache) = EVENT_BRIDGE_CACHE.lock() else {
+        return Vec::new();
+    };
+    let event_id_hex = event_id.to_hex();
+    cache
+        .iter()
+        .filter(|(_, event)| {
+            if !kinds.is_empty() && !kinds.contains(&event.kind) {
+                return false;
+            }
+            event.tags.iter().any(|tag| {
+                tag.content().map(|c| c == event_id_hex).unwrap_or(false)
+            })
+        })
+        .map(|(_, event)| event.clone())
+        .collect()
 }

--- a/src/stores/ndb/mod.rs
+++ b/src/stores/ndb/mod.rs
@@ -109,15 +109,60 @@ pub fn drain_ndb_live_events() -> Vec<nostr::Event> {
 }
 
 #[cfg(feature = "native")]
-static EVENT_BRIDGE_CACHE: std::sync::LazyLock<std::sync::Mutex<LruCache<[u8; 32], nostr::Event>>> =
+struct BridgeCache {
+    lru: LruCache<[u8; 32], nostr::Event>,
+    reply_index: std::collections::HashMap<[u8; 32], Vec<[u8; 32]>>,
+}
+
+#[cfg(feature = "native")]
+static EVENT_BRIDGE_CACHE: std::sync::LazyLock<std::sync::Mutex<BridgeCache>> =
     std::sync::LazyLock::new(|| {
-        std::sync::Mutex::new(LruCache::new(NonZeroUsize::new(10000).unwrap()))
+        std::sync::Mutex::new(BridgeCache {
+            lru: LruCache::new(NonZeroUsize::new(10000).unwrap()),
+            reply_index: std::collections::HashMap::new(),
+        })
     });
 
 #[cfg(feature = "native")]
+fn index_etag_targets(event: &nostr::Event) -> Vec<[u8; 32]> {
+    use nostr::TagKind;
+    event
+        .tags
+        .iter()
+        .filter(|tag| tag.kind() == TagKind::e())
+        .filter_map(|tag| {
+            let hex = tag.content()?;
+            let id = EventId::from_hex(hex).ok()?;
+            Some(id.to_bytes())
+        })
+        .collect()
+}
+
+#[cfg(feature = "native")]
 pub fn cache_event(event: &nostr::Event) {
-    if let Ok(mut cache) = EVENT_BRIDGE_CACHE.lock() {
-        cache.put(event.id.to_bytes(), event.clone());
+    if let Ok(mut guard) = EVENT_BRIDGE_CACHE.lock() {
+        let targets = index_etag_targets(event);
+        let event_id = event.id.to_bytes();
+        if let Some((evicted_id, evicted_event)) =
+            guard.lru.push(event_id, event.clone())
+        {
+            let evicted_targets = index_etag_targets(&evicted_event);
+            for target in &evicted_targets {
+                if let Some(list) = guard.reply_index.get_mut(target) {
+                    list.retain(|id| id != &evicted_id);
+                    if list.is_empty() {
+                        guard.reply_index.remove(target);
+                    }
+                }
+            }
+        }
+        for target in targets {
+            guard
+                .reply_index
+                .entry(target)
+                .or_default()
+                .push(event_id);
+        }
     }
 }
 
@@ -126,25 +171,26 @@ pub fn get_cached_event(id: &[u8; 32]) -> Option<nostr::Event> {
     EVENT_BRIDGE_CACHE
         .lock()
         .ok()
-        .and_then(|mut cache| cache.get(id).cloned())
+        .and_then(|mut guard| guard.lru.get(id).cloned())
 }
 
 #[cfg(feature = "native")]
 pub fn get_cached_replies(event_id: &EventId, kinds: &[Kind]) -> Vec<nostr::Event> {
-    let Ok(cache) = EVENT_BRIDGE_CACHE.lock() else {
+    let Ok(mut guard) = EVENT_BRIDGE_CACHE.lock() else {
         return Vec::new();
     };
-    let event_id_hex = event_id.to_hex();
-    cache
-        .iter()
-        .filter(|(_, event)| {
+    let parent_id = event_id.to_bytes();
+    let Some(child_ids) = guard.reply_index.get(&parent_id).cloned() else {
+        return Vec::new();
+    };
+    child_ids
+        .into_iter()
+        .filter_map(|id| {
+            let event = guard.lru.get(&id).cloned()?;
             if !kinds.is_empty() && !kinds.contains(&event.kind) {
-                return false;
+                return None;
             }
-            event.tags.iter().any(|tag| {
-                tag.content().map(|c| c == event_id_hex).unwrap_or(false)
-            })
+            Some(event)
         })
-        .map(|(_, event)| event.clone())
         .collect()
 }

--- a/src/stores/nostr_client/fetching.rs
+++ b/src/stores/nostr_client/fetching.rs
@@ -371,7 +371,7 @@ pub async fn fetch_event_targeted(
     #[cfg(feature = "native")]
     {
         let bridge_hit = crate::stores::ndb::get_cached_event(&event_id.to_bytes());
-        log::info!("fetch_event_targeted: Phase 0 bridge cache check for {:?} -> {}", event_id.to_hex(), if bridge_hit.is_some() { "HIT" } else { "MISS" });
+        log::debug!("fetch_event_targeted: Phase 0 bridge cache check for {:?} -> {}", event_id.to_hex(), if bridge_hit.is_some() { "HIT" } else { "MISS" });
         if let Some(event) = bridge_hit {
             return Ok(Some(event));
         }
@@ -380,14 +380,14 @@ pub async fn fetch_event_targeted(
     // Phase 1: DB check (instant) — direct primary key lookup
     match client.database().event_by_id(&event_id).await {
         Ok(Some(event)) => {
-            log::info!("fetch_event_targeted: Phase 1 DB hit for {:?}", event_id.to_hex());
+            log::debug!("fetch_event_targeted: Phase 1 DB hit for {:?}", event_id.to_hex());
             return Ok(Some(event));
         }
         Ok(None) => {
-            log::info!("fetch_event_targeted: Phase 1 DB miss for {:?}", event_id.to_hex());
+            log::debug!("fetch_event_targeted: Phase 1 DB miss for {:?}", event_id.to_hex());
         }
         Err(e) => {
-            log::info!("fetch_event_targeted: Phase 1 DB error for {:?}: {}", event_id.to_hex(), e);
+            log::debug!("fetch_event_targeted: Phase 1 DB error for {:?}: {}", event_id.to_hex(), e);
         }
     }
 
@@ -402,7 +402,7 @@ pub async fn fetch_event_targeted(
     .await
     {
         Ok(events) if !events.is_empty() => {
-            log::info!("fetch_event_targeted: Phase 2 broadcast hit for {:?}", event_id.to_hex());
+            log::debug!("fetch_event_targeted: Phase 2 broadcast hit for {:?}", event_id.to_hex());
             let event = events.into_iter().next();
             #[cfg(feature = "native")]
             if let Some(ref e) = event {
@@ -411,10 +411,10 @@ pub async fn fetch_event_targeted(
             return Ok(event);
         }
         Ok(events) => {
-            log::info!("fetch_event_targeted: Phase 2 broadcast miss for {:?} ({} events)", event_id.to_hex(), events.len());
+            log::debug!("fetch_event_targeted: Phase 2 broadcast miss for {:?} ({} events)", event_id.to_hex(), events.len());
         }
         Err(e) => {
-            log::info!("fetch_event_targeted: Phase 2 broadcast error for {:?}: {}", event_id.to_hex(), e);
+            log::debug!("fetch_event_targeted: Phase 2 broadcast error for {:?}: {}", event_id.to_hex(), e);
         }
     }
 
@@ -437,7 +437,7 @@ pub async fn fetch_event_targeted(
             relay::coverage::cleanup_ephemeral_relays(&client, &ephemeral.newly_added).await;
             if let Ok(events) = result {
                 if let Some(event) = events.into_iter().next() {
-                    log::info!("fetch_event_targeted: Phase 3 author relays hit for {:?}", event_id.to_hex());
+                    log::debug!("fetch_event_targeted: Phase 3 author relays hit for {:?}", event_id.to_hex());
                     #[cfg(feature = "native")]
                     crate::stores::ndb::cache_event(&event);
                     return Ok(Some(event));
@@ -461,7 +461,7 @@ pub async fn fetch_event_targeted(
             relay::coverage::cleanup_ephemeral_relays(&client, &ephemeral.newly_added).await;
             if let Ok(events) = result {
                 if let Some(event) = events.into_iter().next() {
-                    log::info!("fetch_event_targeted: Phase 4 relay hints hit for {:?}", event_id.to_hex());
+                    log::debug!("fetch_event_targeted: Phase 4 relay hints hit for {:?}", event_id.to_hex());
                     #[cfg(feature = "native")]
                     crate::stores::ndb::cache_event(&event);
                     return Ok(Some(event));

--- a/src/stores/nostr_client/fetching.rs
+++ b/src/stores/nostr_client/fetching.rs
@@ -354,25 +354,44 @@ pub fn parse_event_id(id: &str) -> Option<ParsedEventId> {
 
 /// Targeted event fetch with hybrid broadcast+targeted strategy.
 ///
-/// 1. DB check (instant)
-/// 2. Broadcast to connected relays (fast, uses existing connections)
-/// 3. Targeted author relays via NIP-65 resolution (if author known)
-/// 4. Relay hints from nevent (if available)
-/// 5. Fallback — gossip/outbox model
+/// 1. Bridge cache check (instant, native only — bridges nostrdb async ingestion gap)
+/// 2. DB check (instant, direct primary key lookup)
+/// 3. Broadcast to connected relays (fast, uses existing connections)
+/// 4. Targeted author relays via NIP-65 resolution (if author known)
+/// 5. Relay hints from nevent (if available)
+/// 6. Fallback — gossip/outbox model
 pub async fn fetch_event_targeted(
     parsed: ParsedEventId,
     timeout: Duration,
 ) -> std::result::Result<Option<nostr::Event>, String> {
     let client = get_client().ok_or("Client not initialized")?;
-    let filter = Filter::new().id(parsed.event_id).limit(1);
+    let event_id = parsed.event_id;
 
-    // Phase 1: DB check (instant)
-    if let Ok(events) = client.database().query(filter.clone()).await {
-        if let Some(event) = events.into_iter().next() {
-            log::debug!("fetch_event_targeted: found in DB cache");
+    // Phase 0: Bridge cache check (instant, native only)
+    #[cfg(feature = "native")]
+    {
+        let bridge_hit = crate::stores::ndb::get_cached_event(&event_id.to_bytes());
+        log::info!("fetch_event_targeted: Phase 0 bridge cache check for {:?} -> {}", event_id.to_hex(), if bridge_hit.is_some() { "HIT" } else { "MISS" });
+        if let Some(event) = bridge_hit {
             return Ok(Some(event));
         }
     }
+
+    // Phase 1: DB check (instant) — direct primary key lookup
+    match client.database().event_by_id(&event_id).await {
+        Ok(Some(event)) => {
+            log::info!("fetch_event_targeted: Phase 1 DB hit for {:?}", event_id.to_hex());
+            return Ok(Some(event));
+        }
+        Ok(None) => {
+            log::info!("fetch_event_targeted: Phase 1 DB miss for {:?}", event_id.to_hex());
+        }
+        Err(e) => {
+            log::info!("fetch_event_targeted: Phase 1 DB error for {:?}: {}", event_id.to_hex(), e);
+        }
+    }
+
+    let filter = Filter::new().id(event_id).limit(1);
 
     // Phase 2: Broadcast to connected relays (fast)
     match fetch_events_from_connected_relays_with_client(
@@ -383,10 +402,20 @@ pub async fn fetch_event_targeted(
     .await
     {
         Ok(events) if !events.is_empty() => {
-            log::debug!("fetch_event_targeted: found via broadcast");
-            return Ok(events.into_iter().next());
+            log::info!("fetch_event_targeted: Phase 2 broadcast hit for {:?}", event_id.to_hex());
+            let event = events.into_iter().next();
+            #[cfg(feature = "native")]
+            if let Some(ref e) = event {
+                crate::stores::ndb::cache_event(e);
+            }
+            return Ok(event);
         }
-        _ => {}
+        Ok(events) => {
+            log::info!("fetch_event_targeted: Phase 2 broadcast miss for {:?} ({} events)", event_id.to_hex(), events.len());
+        }
+        Err(e) => {
+            log::info!("fetch_event_targeted: Phase 2 broadcast error for {:?}: {}", event_id.to_hex(), e);
+        }
     }
 
     // Phase 3: Targeted author relays (if known)
@@ -408,7 +437,9 @@ pub async fn fetch_event_targeted(
             relay::coverage::cleanup_ephemeral_relays(&client, &ephemeral.newly_added).await;
             if let Ok(events) = result {
                 if let Some(event) = events.into_iter().next() {
-                    log::debug!("fetch_event_targeted: found via author relays");
+                    log::info!("fetch_event_targeted: Phase 3 author relays hit for {:?}", event_id.to_hex());
+                    #[cfg(feature = "native")]
+                    crate::stores::ndb::cache_event(&event);
                     return Ok(Some(event));
                 }
             }
@@ -430,7 +461,9 @@ pub async fn fetch_event_targeted(
             relay::coverage::cleanup_ephemeral_relays(&client, &ephemeral.newly_added).await;
             if let Ok(events) = result {
                 if let Some(event) = events.into_iter().next() {
-                    log::debug!("fetch_event_targeted: found via relay hints");
+                    log::info!("fetch_event_targeted: Phase 4 relay hints hit for {:?}", event_id.to_hex());
+                    #[cfg(feature = "native")]
+                    crate::stores::ndb::cache_event(&event);
                     return Ok(Some(event));
                 }
             }
@@ -439,7 +472,12 @@ pub async fn fetch_event_targeted(
 
     // Phase 5: Fallback — outbox (gossip model)
     let events = fetch_events_aggregated_outbox(filter, timeout).await?;
-    Ok(events.into_iter().next())
+    let event = events.into_iter().next();
+    #[cfg(feature = "native")]
+    if let Some(ref e) = event {
+        crate::stores::ndb::cache_event(e);
+    }
+    Ok(event)
 }
 
 /// Fetch video events from connected relays (bypasses gossip)

--- a/src/stores/nostr_client/fetching.rs
+++ b/src/stores/nostr_client/fetching.rs
@@ -135,7 +135,7 @@ pub async fn fetch_events_aggregated_outbox(
 /// Internal: Fetch events using gossip with provided client (avoids re-reading NOSTR_CLIENT)
 ///
 /// Dioxus pattern: Get client once, pass same instance through all async operations.
-async fn fetch_events_aggregated_outbox_with_client(
+pub(crate) async fn fetch_events_aggregated_outbox_with_client(
     client: &std::sync::Arc<Client>,
     filter: Filter,
     timeout: Duration,

--- a/src/stores/nostr_client/mod.rs
+++ b/src/stores/nostr_client/mod.rs
@@ -416,6 +416,7 @@ pub async fn set_read_only() -> std::result::Result<(), String> {
     *HAS_SIGNER.write() = false;
     *CURRENT_SIGNER.write() = None;
     *relay::USER_RELAYS_APPLIED.write() = false;
+    relay::pool::reset_pool_to_defaults(&client).await;
     if let Err(e) = crate::stores::publish_queue::processor::process_once_guarded().await {
         log::warn!("Flush before read-only failed: {}", e);
     }

--- a/src/stores/nostr_client/mod.rs
+++ b/src/stores/nostr_client/mod.rs
@@ -181,7 +181,7 @@ pub async fn initialize_client() -> std::result::Result<Arc<Client>, String> {
                 timeout: Duration::from_secs(30),
             })
             .gossip(GossipOptions::default().limits(gossip_limits))
-            .pool(RelayPoolOptions::new().max_relays(Some(50)));
+            .pool(RelayPoolOptions::new());
         Client::builder()
             .database(database)
             .gossip(gossip)
@@ -232,7 +232,7 @@ pub async fn initialize_client() -> std::result::Result<Arc<Client>, String> {
                 timeout: Duration::from_secs(30),
             })
             .gossip(GossipOptions::default().limits(gossip_limits))
-            .pool(RelayPoolOptions::new().max_relays(Some(50)));
+            .pool(RelayPoolOptions::new());
         Client::builder()
             .database(database)
             .gossip(gossip)

--- a/src/stores/nostr_client/mod.rs
+++ b/src/stores/nostr_client/mod.rs
@@ -379,8 +379,12 @@ pub async fn set_signer(signer: SignerType) -> std::result::Result<(), String> {
         if let Err(e) = relay::init_user_relay_lists(client_clone.clone()).await {
             log::warn!("Failed to load user relay lists: {}", e);
         }
+        client_clone.connect().await;
+        client_clone
+            .wait_for_connection(std::time::Duration::from_secs(3))
+            .await;
         *relay::USER_RELAYS_APPLIED.write() = true;
-        log::info!("User relays applied, feed fetching unblocked");
+        log::info!("User relays applied and connected, feed fetching unblocked");
         if let Err(e) = relay::init_nip51_relay_lists(client_clone.clone()).await {
             log::warn!("Failed to load NIP-51 relay lists: {}", e);
         }
@@ -411,6 +415,7 @@ pub async fn set_read_only() -> std::result::Result<(), String> {
     client.unset_signer().await;
     *HAS_SIGNER.write() = false;
     *CURRENT_SIGNER.write() = None;
+    *relay::USER_RELAYS_APPLIED.write() = false;
     if let Err(e) = crate::stores::publish_queue::processor::process_once_guarded().await {
         log::warn!("Flush before read-only failed: {}", e);
     }

--- a/src/stores/notification_dispatcher.rs
+++ b/src/stores/notification_dispatcher.rs
@@ -81,6 +81,8 @@ impl NotificationDispatcher {
                             #[cfg(feature = "native")]
                             {
                                 crate::stores::ndb::unknown_ids::queue_event((*event).clone());
+                                crate::stores::ndb::cache_event(&event);
+                                log::info!("notification_dispatcher: cached event {:?} in bridge cache", event.id.to_hex());
                             }
                             let inner = inner.lock().unwrap();
                             if let Some(senders) = inner.subscribers.get(&subscription_id) {

--- a/src/stores/relay/connection.rs
+++ b/src/stores/relay/connection.rs
@@ -272,10 +272,15 @@ pub async fn fetch_events_from_relays(
 pub async fn ensure_video_relay_connected(client: &Client) {
     super::specialty::ensure_video_relay(client).await;
 }
-/// Fetch addressable event by coordinate with relay hints
-/// Two-phase loading: DB first (instant), then relay (if not found)
+/// Fetch addressable event by coordinate with relay hints using 5-phase targeted strategy.
+///
+/// 1. DB check (instant)
+/// 2. Broadcast to connected relays (fast, 3s)
+/// 3. Relay hints from naddr (ephemeral connections, cleaned up)
+/// 4. Author relays via NIP-65 resolution (ephemeral connections, cleaned up)
+/// 5. Gossip/outbox fallback (last resort)
 pub async fn fetch_event_by_coordinate_with_relays(
-    client: &Client,
+    client: &std::sync::Arc<Client>,
     kind: u16,
     pubkey: &str,
     identifier: &str,
@@ -290,37 +295,103 @@ pub async fn fetch_event_by_coordinate_with_relays(
         .author(author)
         .identifier(identifier.to_string())
         .limit(1);
+
+    // Phase 1: DB check (instant)
     if let Ok(db_events) = client.database().query(filter.clone()).await {
         if let Some(event) = db_events.into_iter().next() {
-            log::debug!("Found event kind {} in DB: {}:{}", kind, pubkey, identifier);
+            log::debug!(
+                "fetch_event_by_coordinate: found kind {} in DB: {}:{}",
+                kind, pubkey, identifier
+            );
             return Ok(Some(event));
         }
     }
+
     log::info!(
-        "Fetching event kind {} from relay: {}:{}",
-        kind,
-        pubkey,
-        identifier
+        "fetch_event_by_coordinate: fetching kind {} {}:{}",
+        kind, pubkey, identifier
     );
-    if !relay_hints.is_empty() {
-        let added = super::specialty::add_relays_from_strings(client, &relay_hints).await;
-        let fetch_result = client
-            .fetch_events(filter.clone(), Duration::from_secs(5))
-            .await;
-        if !added.is_empty() {
-            super::specialty::remove_relays(client, &added).await;
+
+    // Phase 2: Broadcast to connected relays (fast, 3s)
+    match crate::stores::nostr_client::fetching::fetch_events_from_connected_relays_with_client(
+        client,
+        filter.clone(),
+        Duration::from_secs(3),
+    )
+    .await
+    {
+        Ok(events) if !events.is_empty() => {
+            log::debug!("fetch_event_by_coordinate: found via broadcast");
+            return Ok(events.into_iter().next());
         }
-        if let Ok(events) = fetch_result {
+        _ => {}
+    }
+
+    // Phase 3: Relay hints from naddr (ephemeral)
+    if !relay_hints.is_empty() {
+        let ephemeral =
+            super::coverage::connect_ephemeral_relays(client, &relay_hints).await;
+        if !ephemeral.connected.is_empty() {
+            let result = fetch_events_from_relays(
+                client,
+                filter.clone(),
+                ephemeral.connected.clone(),
+                Duration::from_secs(10),
+            )
+            .await;
+            super::coverage::cleanup_ephemeral_relays(client, &ephemeral.newly_added).await;
+            if let Ok(events) = result {
+                if let Some(event) = events.into_iter().next() {
+                    log::debug!("fetch_event_by_coordinate: found via relay hints");
+                    return Ok(Some(event));
+                }
+            }
+        }
+    }
+
+    // Phase 4: Author relays via NIP-65 (ephemeral)
+    let author_relay_urls = super::coverage::resolve_user_relays(
+        pubkey,
+        super::coverage::RelayPurpose::Write,
+    )
+    .await;
+    let ephemeral =
+        super::coverage::connect_ephemeral_relays(client, &author_relay_urls).await;
+    if !ephemeral.connected.is_empty() {
+        let result = fetch_events_from_relays(
+            client,
+            filter.clone(),
+            ephemeral.connected.clone(),
+            Duration::from_secs(10),
+        )
+        .await;
+        super::coverage::cleanup_ephemeral_relays(client, &ephemeral.newly_added).await;
+        if let Ok(events) = result {
             if let Some(event) = events.into_iter().next() {
+                log::debug!("fetch_event_by_coordinate: found via author relays");
                 return Ok(Some(event));
             }
         }
     }
-    ensure_relays_ready(client).await;
-    match client.fetch_events(filter, Duration::from_secs(10)).await {
-        Ok(events) => Ok(events.into_iter().next()),
+
+    // Phase 5: Gossip/outbox fallback
+    match crate::stores::nostr_client::fetching::fetch_events_aggregated_outbox_with_client(
+        client,
+        filter,
+        Duration::from_secs(10),
+    )
+    .await
+    {
+        Ok(events) => {
+            if events.is_empty() {
+                log::debug!("fetch_event_by_coordinate: not found (all phases exhausted)");
+            } else {
+                log::debug!("fetch_event_by_coordinate: found via gossip fallback");
+            }
+            Ok(events.into_iter().next())
+        }
         Err(e) => {
-            log::error!("Failed to fetch event: {}", e);
+            log::error!("fetch_event_by_coordinate: gossip fallback failed: {}", e);
             Err(format!("Failed to fetch event: {}", e))
         }
     }

--- a/src/stores/relay/coverage.rs
+++ b/src/stores/relay/coverage.rs
@@ -381,6 +381,26 @@ pub async fn cleanup_ephemeral_relays(client: &Client, urls: &[String]) {
     }
 }
 
+/// Remove gossip-only relays from the pool.
+///
+/// Preserves user-configured relays (which have READ/WRITE flags) and
+/// discovery relays (which have DISCOVERY flag). Only removes relays
+/// that have GOSSIP flag with no READ, WRITE, or DISCOVERY flags.
+#[allow(dead_code)]
+pub async fn cleanup_gossip_relays(client: &Client) {
+    let all = client.pool().all_relays().await;
+    for (url, relay) in all {
+        let flags = relay.flags();
+        if flags.has_gossip()
+            && !flags.has_read()
+            && !flags.has_write()
+            && !flags.has_discovery()
+        {
+            let _ = client.force_remove_relay(url.as_str()).await;
+        }
+    }
+}
+
 /// Start a provenance recorder that listens to all relay notifications.
 ///
 /// Records:

--- a/src/stores/relay/mod.rs
+++ b/src/stores/relay/mod.rs
@@ -75,7 +75,8 @@ pub use nip65::{
     PROXY_RELAYS, SEARCH_RELAYS, TRUSTED_RELAYS, USER_RELAY_METADATA,
 };
 pub use pool::{
-    add_relay, apply_relay_lists_to_client, is_relay_blocked, remove_relay, DEFAULT_RELAYS,
+    add_relay, apply_relay_lists_to_client, is_relay_blocked, remove_relay,
+    reset_pool_to_defaults, DEFAULT_RELAYS,
 };
 pub use signals::{
     RelayInfo, RelaySource, RelayPoolStore, RelayPoolStoreStoreExt, RelayStatus, RELAY_CONNECTED,

--- a/src/stores/relay/pool.rs
+++ b/src/stores/relay/pool.rs
@@ -51,6 +51,39 @@ pub async fn remove_blocked_relays_from_pool(client: &Client) {
         relays.len()
     );
 }
+/// Reset relay pool to default relays only, removing all user-specific relays.
+/// Call this on logout to prevent relay accumulation across account switches.
+pub async fn reset_pool_to_defaults(client: &Client) {
+    let relays = client.relays().await;
+    let mut removed_count = 0usize;
+    for (url, _) in relays {
+        let url_str = url.to_string();
+        let normalized = url_str.trim_end_matches('/');
+        if DEFAULT_RELAYS
+            .iter()
+            .any(|d| d.trim_end_matches('/') == normalized)
+        {
+            continue;
+        }
+        log::debug!("Removing user relay on logout: {}", url_str);
+        let _ = client.force_remove_relay(url).await;
+        removed_count += 1;
+    }
+    *USER_RELAY_METADATA.write() = None;
+    let store = RELAY_POOL.read();
+    let mut data = store.data();
+    let mut pool = data.write();
+    pool.retain(|r| {
+        DEFAULT_RELAYS
+            .iter()
+            .any(|d| d.trim_end_matches('/') == r.url.trim_end_matches('/'))
+    });
+    log::info!(
+        "Reset relay pool to defaults: removed {} user relays, {} defaults remaining",
+        removed_count,
+        pool.len()
+    );
+}
 /// Default relays to connect to
 pub const DEFAULT_RELAYS: &[&str] = &[
     "wss://relay.damus.io",

--- a/src/stores/relay/specialty.rs
+++ b/src/stores/relay/specialty.rs
@@ -53,6 +53,7 @@ pub async fn add_relays(client: &Client, relay_urls: &[RelayUrl]) -> Vec<RelayUr
     added
 }
 /// Add relays from string URLs, returning which ones were newly added.
+#[allow(dead_code)]
 pub async fn add_relays_from_strings(client: &Client, urls: &[String]) -> Vec<RelayUrl> {
     let relay_urls: Vec<RelayUrl> = urls
         .iter()

--- a/src/stores/social/pin_boards_store/fetch.rs
+++ b/src/stores/social/pin_boards_store/fetch.rs
@@ -234,12 +234,17 @@ pub async fn fetch_pinboard_by_naddr(naddr: &str) -> std::result::Result<Option<
     if let Some(cached) = get_cached_pinboard_by_naddr(naddr) {
         return Ok(Some(cached));
     }
-    let coord = Coordinate::from_bech32(naddr).map_err(|e| format!("Invalid naddr: {}", e))?;
-    let filter = pinboard_by_coord_filter(coord.public_key, &coord.identifier);
+    let parsed = crate::utils::nip19::parse_naddr(naddr)?;
     let current_user = crate::stores::auth_store::get_pubkey();
-    let events = nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10)).await?;
-    if let Some(event) = events.first() {
-        if let Some(board) = parse_pinboard_event(event, current_user.as_deref()) {
+    let event = nostr_client::fetch_event_by_coordinate_with_relays(
+        parsed.kind,
+        parsed.pubkey,
+        parsed.identifier,
+        parsed.relay_hints,
+    )
+    .await?;
+    if let Some(event) = event {
+        if let Some(board) = parse_pinboard_event(&event, current_user.as_deref()) {
             cache_pinboard(board.clone());
             return Ok(Some(board));
         }

--- a/src/stores/social/pin_boards_store/mod.rs
+++ b/src/stores/social/pin_boards_store/mod.rs
@@ -413,7 +413,9 @@ fn is_image_url(url: &str) -> bool {
 }
 /// Check if URL is a video
 fn is_video_url(url: &str) -> bool {
-    let extensions = [".mp4", ".webm", ".mov", ".avi", ".mkv", ".m4v"];
+    let extensions = [
+        ".mp4", ".m4v", ".webm", ".mov", ".avi", ".mkv", ".ogg", ".ogv", ".3gp", ".3gpp", ".flv",
+    ];
     extensions.iter().any(|ext| url.ends_with(ext))
         || url.contains("youtube.com")
         || url.contains("youtu.be")

--- a/src/stores/social/reactions_store.rs
+++ b/src/stores/social/reactions_store.rs
@@ -1,6 +1,7 @@
 use crate::hooks::ReactionEmoji;
 use crate::platform::storage;
 use crate::stores::sidebar_store::Nip78LoadState;
+use crate::stores::relay::USER_RELAYS_APPLIED;
 use crate::stores::{auth_store, nostr_client};
 /// NIP-78: Preferred Reactions Storage
 /// Stores user's preferred reaction emojis on Nostr relays using kind 30078 events
@@ -164,12 +165,12 @@ pub async fn load_preferred_reactions() {
                 .or_else(|_| nostr_sdk::PublicKey::from_hex(pk_str))
             {
                 Ok(pk) => pk,
-                Err(e) => {
+                    Err(e) => {
                     log::error!("Invalid pubkey: {}", e);
                     *REACTIONS_STATE.write() = if loaded_from_cache {
                         Nip78LoadState::Loaded
                     } else {
-                        Nip78LoadState::LoadedDefaults
+                        Nip78LoadState::Failed(format!("Invalid pubkey: {}", e))
                     };
                     return;
                 }
@@ -180,7 +181,7 @@ pub async fn load_preferred_reactions() {
             *REACTIONS_STATE.write() = if loaded_from_cache {
                 Nip78LoadState::Loaded
             } else {
-                Nip78LoadState::LoadedDefaults
+                Nip78LoadState::Failed("No pubkey available".into())
             };
             return;
         }
@@ -241,7 +242,7 @@ pub async fn load_preferred_reactions() {
                         *REACTIONS_STATE.write() = if loaded_from_cache {
                             Nip78LoadState::Loaded
                         } else {
-                            Nip78LoadState::LoadedDefaults
+                            Nip78LoadState::Failed(format!("Parse error: {}", e))
                         };
                     }
                 }
@@ -249,6 +250,10 @@ pub async fn load_preferred_reactions() {
                 log::info!("No reactions preferences found on relays");
                 *REACTIONS_STATE.write() = if loaded_from_cache {
                     Nip78LoadState::Loaded
+                } else if !*USER_RELAYS_APPLIED.peek() {
+                    Nip78LoadState::Failed(
+                        "User relays not applied, retry needed".into(),
+                    )
                 } else {
                     Nip78LoadState::LoadedDefaults
                 };

--- a/src/stores/ui/ai_provider_store.rs
+++ b/src/stores/ui/ai_provider_store.rs
@@ -250,13 +250,17 @@ pub async fn sync_provider_state_from_relays() {
     };
     match serde_json::from_str::<AiProviderState>(&decrypted) {
         Ok(relay_state) => {
+            let migrated = migrate_legacy_state(relay_state);
             log::info!(
                 "sync_provider_state: loaded state from relays (provider={}, {} custom providers)",
-                relay_state.selected_provider_id,
-                relay_state.custom_providers.len()
+                migrated.selected_provider_id,
+                migrated.custom_providers.len()
             );
+            if let Err(e) = cache_provider_state(&migrated) {
+                log::warn!("sync_provider_state: failed to cache: {}", e);
+            }
             *pending_relay_state().lock().expect("relay state lock poisoned") =
-                Some(migrate_legacy_state(relay_state));
+                Some(migrated);
         }
         Err(e) => {
             log::warn!("sync_provider_state: parse failed: {}", e);

--- a/src/stores/ui/sidebar_store.rs
+++ b/src/stores/ui/sidebar_store.rs
@@ -1,5 +1,6 @@
 use crate::platform::storage;
 use crate::routes::Route;
+use crate::stores::relay::USER_RELAYS_APPLIED;
 use crate::stores::{auth_store, nostr_client};
 /// NIP-78: Sidebar Preferences Storage
 /// Stores user's sidebar layout preferences on Nostr relays using kind 30078 events
@@ -451,12 +452,12 @@ pub async fn load_sidebar_preferences() {
                 .or_else(|_| nostr_sdk::PublicKey::from_hex(pk_str))
             {
                 Ok(pk) => pk,
-                Err(e) => {
+                    Err(e) => {
                     log::error!("Invalid pubkey: {}", e);
                     *SIDEBAR_STATE.write() = if loaded_from_cache {
                         Nip78LoadState::Loaded
                     } else {
-                        Nip78LoadState::LoadedDefaults
+                        Nip78LoadState::Failed(format!("Invalid pubkey: {}", e))
                     };
                     return;
                 }
@@ -467,7 +468,7 @@ pub async fn load_sidebar_preferences() {
             *SIDEBAR_STATE.write() = if loaded_from_cache {
                 Nip78LoadState::Loaded
             } else {
-                Nip78LoadState::LoadedDefaults
+                Nip78LoadState::Failed("No pubkey available".into())
             };
             return;
         }
@@ -520,7 +521,7 @@ pub async fn load_sidebar_preferences() {
                         *SIDEBAR_STATE.write() = if loaded_from_cache {
                             Nip78LoadState::Loaded
                         } else {
-                            Nip78LoadState::LoadedDefaults
+                            Nip78LoadState::Failed(format!("Parse error: {}", e))
                         };
                     }
                 }
@@ -528,6 +529,10 @@ pub async fn load_sidebar_preferences() {
                 log::info!("No sidebar preferences found on relays");
                 *SIDEBAR_STATE.write() = if loaded_from_cache {
                     Nip78LoadState::Loaded
+                } else if !*USER_RELAYS_APPLIED.peek() {
+                    Nip78LoadState::Failed(
+                        "User relays not applied, retry needed".into(),
+                    )
                 } else {
                     Nip78LoadState::LoadedDefaults
                 };

--- a/src/utils/nip19.rs
+++ b/src/utils/nip19.rs
@@ -48,12 +48,10 @@ pub fn parse_naddr(naddr: &str) -> Result<ParsedNaddr, String> {
                 relay_hints: vec![],
             })
         } else if parts.len() == 2 {
-            Ok(ParsedNaddr {
-                kind: 0,
-                pubkey: parts[0].to_string(),
-                identifier: parts[1].to_string(),
-                relay_hints: vec![],
-            })
+            Err(format!(
+                "Invalid naddr format (missing kind): {}. Expected kind:pubkey:identifier or naddr1...",
+                naddr
+            ))
         } else {
             Err(format!("Invalid naddr format: {}", naddr))
         }

--- a/src/utils/nip19.rs
+++ b/src/utils/nip19.rs
@@ -1,7 +1,13 @@
 use nostr_sdk::prelude::*;
-/// Normalize a pubkey string to canonical hex format
-/// Accepts both npub (bech32) and hex formats
-/// Returns canonical hex string or error
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ParsedNaddr {
+    pub kind: u16,
+    pub pubkey: String,
+    pub identifier: String,
+    pub relay_hints: Vec<String>,
+}
+
 pub fn normalize_pubkey(pubkey_str: &str) -> Result<String, String> {
     if pubkey_str.starts_with("npub") {
         match Nip19::from_bech32(pubkey_str) {
@@ -17,23 +23,37 @@ pub fn normalize_pubkey(pubkey_str: &str) -> Result<String, String> {
     }
 }
 
-pub fn parse_naddr(naddr: &str) -> Result<(String, String), String> {
+pub fn parse_naddr(naddr: &str) -> Result<ParsedNaddr, String> {
     if naddr.starts_with("naddr") {
         let nip19 = Nip19::from_bech32(naddr).map_err(|e| format!("Invalid naddr: {}", e))?;
         match nip19 {
-            Nip19::Coordinate(coord) => {
-                let pubkey = coord.coordinate.public_key.to_hex();
-                let d_tag = coord.coordinate.identifier;
-                Ok((pubkey, d_tag))
-            }
+            Nip19::Coordinate(coord) => Ok(ParsedNaddr {
+                kind: coord.coordinate.kind.as_u16(),
+                pubkey: coord.coordinate.public_key.to_hex(),
+                identifier: coord.coordinate.identifier,
+                relay_hints: coord.relays.iter().map(|r| r.to_string()).collect(),
+            }),
             _ => Err("Expected naddr coordinate".to_string()),
         }
     } else {
         let parts: Vec<&str> = naddr.splitn(3, ':').collect();
         if parts.len() >= 3 {
-            Ok((parts[1].to_string(), parts[2].to_string()))
+            let kind = parts[0]
+                .parse::<u16>()
+                .map_err(|_| format!("Invalid kind: {}", parts[0]))?;
+            Ok(ParsedNaddr {
+                kind,
+                pubkey: parts[1].to_string(),
+                identifier: parts[2].to_string(),
+                relay_hints: vec![],
+            })
         } else if parts.len() == 2 {
-            Ok((parts[0].to_string(), parts[1].to_string()))
+            Ok(ParsedNaddr {
+                kind: 0,
+                pubkey: parts[0].to_string(),
+                identifier: parts[1].to_string(),
+                relay_hints: vec![],
+            })
         } else {
             Err(format!("Invalid naddr format: {}", naddr))
         }

--- a/src/utils/nips/nip58.rs
+++ b/src/utils/nips/nip58.rs
@@ -197,6 +197,7 @@ pub fn build_badge_naddr(pubkey: &str, badge_id: &str) -> Option<String> {
     nip19.to_bech32().ok()
 }
 /// Parse a badge naddr back to (pubkey, badge_id)
+#[allow(dead_code)]
 pub fn parse_badge_naddr(naddr: &str) -> Result<(String, String), String> {
     let nip19 = Nip19Coordinate::from_bech32(naddr).map_err(|e| format!("Invalid naddr: {}", e))?;
     if nip19.coordinate.kind.as_u16() != KIND_BADGE_DEFINITION {
@@ -212,18 +213,23 @@ pub fn parse_badge_naddr(naddr: &str) -> Result<(String, String), String> {
 }
 /// Fetch a badge definition by naddr
 pub async fn fetch_badge_definition(naddr: &str) -> Result<BadgeDefinition, String> {
-    let (pubkey, badge_id) = parse_badge_naddr(naddr)?;
-    let pk = PublicKey::from_hex(&pubkey).map_err(|e| format!("Invalid pubkey: {}", e))?;
-    let filter = Filter::new()
-        .kind(Kind::Custom(KIND_BADGE_DEFINITION))
-        .author(pk)
-        .identifier(&badge_id)
-        .limit(1);
-    let events = nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10)).await?;
-    events
-        .into_iter()
-        .filter_map(|e| parse_badge_definition(&e).ok())
-        .max_by_key(|b| b.created_at)
+    let parsed = crate::utils::nip19::parse_naddr(naddr)?;
+    if parsed.kind != KIND_BADGE_DEFINITION {
+        return Err(format!(
+            "Expected kind {}, got {}",
+            KIND_BADGE_DEFINITION,
+            parsed.kind,
+        ));
+    }
+    let event = nostr_client::fetch_event_by_coordinate_with_relays(
+        parsed.kind,
+        parsed.pubkey,
+        parsed.identifier,
+        parsed.relay_hints,
+    )
+    .await?;
+    event
+        .and_then(|e| parse_badge_definition(&e).ok())
         .ok_or_else(|| "Badge not found".to_string())
 }
 /// Fetch a badge definition by coordinate string ("30009:pubkey:badge_id")

--- a/src/utils/parsing/content_parser.rs
+++ b/src/utils/parsing/content_parser.rs
@@ -401,14 +401,18 @@ fn is_video_url(url: &str) -> bool {
         return false;
     }
     let path = lower.split('?').next().unwrap_or(&lower);
+    let path = path.split('#').next().unwrap_or(path);
     path.ends_with(".mp4")
+        || path.ends_with(".m4v")
         || path.ends_with(".webm")
         || path.ends_with(".mov")
         || path.ends_with(".avi")
         || path.ends_with(".mkv")
         || path.ends_with(".ogg")
+        || path.ends_with(".ogv")
         || path.ends_with(".3gp")
         || path.ends_with(".3gpp")
+        || path.ends_with(".flv")
 }
 /// Extract profile name from mention string
 #[allow(dead_code)]

--- a/src/utils/parsing/markdown.rs
+++ b/src/utils/parsing/markdown.rs
@@ -1,5 +1,12 @@
 /// Markdown rendering utilities for NIP-23 long-form content
+use once_cell::sync::Lazy;
 use pulldown_cmark::{html, Options, Parser};
+use regex::Regex;
+
+static NOSTR_URI_PATTERN: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)nostr:(npub1|nprofile1|note1|nevent1|naddr1)[a-zA-Z0-9]+")
+        .expect("Failed to compile nostr URI regex")
+});
 /// Render markdown to safe HTML
 /// Uses pulldown-cmark for parsing and ammonia for sanitization.
 /// Mermaid code blocks are converted to `<div class="mermaid">` for client-side rendering.
@@ -14,7 +21,60 @@ pub fn render_markdown(markdown: &str) -> String {
     let mut html_output = String::new();
     html::push_html(&mut html_output, parser);
     let sanitized = sanitize_html(&html_output);
-    convert_mermaid_blocks(&sanitized)
+    let linked = auto_link_bare_urls(&sanitized);
+    convert_mermaid_blocks(&linked)
+}
+
+fn auto_link_bare_urls(html: &str) -> String {
+    static A_TAG: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"<a\s[^>]*>.*?</a>").expect("a tag regex"));
+    static IMG_TAG: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"<img\s[^>]*/?>").expect("img tag regex"));
+    static BARE_URL: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r#"https?://[^\s<>"']+"#).expect("bare url regex"));
+
+    let mut placeholders: Vec<String> = Vec::new();
+    let protected = A_TAG
+        .replace_all(html, |caps: &regex::Captures| {
+            let idx = placeholders.len();
+            placeholders.push(caps[0].to_string());
+            format!("\x00AURL{}\x00", idx)
+        })
+        .to_string();
+    let protected = IMG_TAG
+        .replace_all(&protected, |caps: &regex::Captures| {
+            let idx = placeholders.len();
+            placeholders.push(caps[0].to_string());
+            format!("\x00IURL{}\x00", idx)
+        })
+        .to_string();
+
+    let linked = BARE_URL
+        .replace_all(&protected, |caps: &regex::Captures| {
+            let url = &caps[0];
+            format!(
+                r#"<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>"#,
+                url, url
+            )
+        })
+        .to_string();
+
+    let mut result = linked;
+    for (idx, original) in placeholders.iter().enumerate() {
+        result = result.replace(&format!("\x00AURL{}\x00", idx), original);
+        result = result.replace(&format!("\x00IURL{}\x00", idx), original);
+    }
+    result
+}
+
+pub fn extract_nostr_uris(content: &str) -> (String, Vec<String>) {
+    let mut uris = Vec::new();
+    let result = NOSTR_URI_PATTERN.replace_all(content, |caps: &regex::Captures| {
+        let idx = uris.len();
+        uris.push(caps[0].to_string());
+        format!("%%NOSTR_BLUE_EMBED_{}%%", idx)
+    });
+    (result.to_string(), uris)
 }
 
 /// Convert mermaid code blocks from `<pre><code class="language-mermaid">...</code></pre>`


### PR DESCRIPTION
Features
- Relay Feeds — Browse content from specific relays or relay sets with real-time subscriptions
- Article Embeds — Render nostr URI embeds (npub/note/naddr) inline in articles, auto-link bare URLs in markdown
- Profile Overhaul — NIP-05 verification with badge, zaps tab, 3-tier profile cache, retry on failure, cross-platform follower counts
- Video Thumbnails — Cross-platform blurhash decoding + canvas frame capture, replacing web_sys with document::eval() for mobile support
- Video Preloading — #t=0.1 media fragments and preload=metadata for videos without thumbnails

Performance
- Interaction Loading — 4x larger batch size (100), local DB fast-path with zero relay round-trips, combined filters, global interaction queue
- Instant Reply Loading — DB-first architecture displays cached replies instantly (~1ms) before relay responses arrive, with parallel fetching and streaming dedup
- Feed Optimizations — NDB live replies, merge-based feed assembly, LRU bridge cache (10K entries) for nostrdb ingestion gap

Fixes
- Remove 50-relay pool cap causing "too many relays" errors on detail pages (fixes #318)
- Fix relay connection timing for post-login init — await user relays before NIP-78 loads
- Fix RSS podcast/music image loading — self-closing tag parsing, HTTPS upgrade, onerror fallbacks
- Fix NIP-05 polling loop on terminal states, naddr parsing for 2-part coordinates
- Fix AI chat tool use overflow, cross-platform scroll-to-top, music player AlreadyBorrowed crash
- CI: populate docs submodules, resolve relative URLs for reqwest WASM (closes #321)