### PR TITLE
feat: topics NIP-73 migration, followers modal, relay-aware live chat, and 30+ bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "nostrblue"
-version = "0.8.16"
+version = "0.8.17"
 dependencies = [
  "ammonia",
  "arboard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5513,6 +5513,7 @@ dependencies = [
  "instant",
  "jni 0.21.1",
  "js-sys",
+ "lightning-invoice",
  "log",
  "lru",
  "maplit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostrblue"
-version = "0.8.16"
+version = "0.8.17"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Patrick Ulrich"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 sha2 = "0.10"
 bitcoin = "0.32"
 bitcoin_hashes = "0.14"
+lightning-invoice = { version = "0.34.0", default-features = false }
 bip39 = "2.2"
 
 # Async runtime

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A multi-platform Nostr client built using **Rust + Dioxus + rust-nostr** with integrated CDK wallet.
 
-![Version](https://img.shields.io/badge/version-0.8.16-blue)
+![Version](https://img.shields.io/badge/version-0.8.17-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Rust](https://img.shields.io/badge/rust-1.82+-orange)
 ![Platforms](https://img.shields.io/badge/platforms-Web%20%7C%20Android%20%7C%20Desktop-blue)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostrblue",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Nostr.blue Rust client",
   "scripts": {
     "dev": "npm run build:assets && dx serve",

--- a/public/docs/changelogs/0.8.17.md
+++ b/public/docs/changelogs/0.8.17.md
@@ -1,0 +1,11 @@
+- Followers/Following Modal
+- Relay-Aware Live Chat
+- NIP-73 Web URL Topics with real-time updates
+- DB-First Note Threads with NIP-22 comment support
+- Gap-Aware Feed Pagination
+- Nests audio engine rewrite
+- Cashu wallet seed zeroization
+- Bolt11 invoice parsing fix
+- Blossom server URL validation
+- Subscription leak and notification lifecycle fixes
+- Bug fixes and performance improvements

--- a/public/moq-nest.js
+++ b/public/moq-nest.js
@@ -8,7 +8,7 @@ window.nestAudioManager = window.nestAudioManager || {
         if (this._moqLoading) return this._moqLoading;
         this._moqLoading = (async () => {
             try {
-                this._moqModule = await import('https://esm.sh/@kixelated/moq@0.9.4');
+                this._moqModule = await import('https://esm.sh/@moq/net@0.1.2');
                 return this._moqModule;
             } catch (e) {
                 this._moqLoading = null;
@@ -26,15 +26,14 @@ window.nestAudioManager = window.nestAudioManager || {
         if (this.connections.has(publisherId)) return { type: 'success' };
         this.connections.set(publisherId, {
             state: 'disconnected',
-            session: null,
-            publisher: null,
+            connection: null,
+            myPubkeyHex: null,
+            publisherBroadcast: null,
+            publisherTracks: new Set(),
             subscribers: new Map(),
             audioEncoder: null,
-            audioDecoder: null,
-            audioContext: null,
             mediaStream: null,
             micMuted: false,
-            namespace: null,
             error: null,
             participantTracks: [],
         });
@@ -51,15 +50,17 @@ window.nestAudioManager = window.nestAudioManager || {
         }
     },
 
-    async connect(publisherId, authUrl, relayUrl, namespace, jwt) {
+    async connect(publisherId, authUrl, relayUrl, namespace, jwt, myPubkeyHex) {
         const conn = this._getConnection(publisherId);
         if (!conn) return { type: 'error', error: 'Not initialized' };
         try {
             conn.state = 'connecting';
+            const Moq = this._moqModule;
             const url = new URL(relayUrl);
+            url.pathname = '/' + namespace;
             if (jwt) url.searchParams.set('jwt', jwt);
-            conn.session = new this._moqModule.Session(url.toString());
-            conn.namespace = namespace;
+            conn.connection = await Moq.Connection.connect(url);
+            conn.myPubkeyHex = myPubkeyHex;
             conn.state = 'connected';
             return { type: 'success' };
         } catch (e) {
@@ -72,21 +73,51 @@ window.nestAudioManager = window.nestAudioManager || {
     async publishAudio(publisherId) {
         const conn = this._getConnection(publisherId);
         if (!conn) return { type: 'error', error: 'Not initialized' };
-        if (!conn.session) return { type: 'error', error: 'Not connected' };
+        if (!conn.connection) return { type: 'error', error: 'Not connected' };
+        if (conn.publisherBroadcast) return { type: 'success' };
         try {
+            const Moq = this._moqModule;
             conn.state = 'publishing';
+
+            const broadcast = new Moq.Broadcast();
+            conn.publisherBroadcast = broadcast;
+            conn.connection.publish(Moq.Path.from(conn.myPubkeyHex), broadcast);
+
+            (async () => {
+                try {
+                    for (;;) {
+                        const request = await broadcast.requested();
+                        if (!request) break;
+                        if (request.track.name === 'audio/data') {
+                            conn.publisherTracks.add(request.track);
+                            request.track.closed.then(() => {
+                                conn.publisherTracks.delete(request.track);
+                            });
+                        }
+                    }
+                } catch (e) {
+                    if (conn.state === 'publishing') {
+                        console.error('[MoQ Nest] Publisher requested() error:', e);
+                    }
+                }
+            })();
+
             conn.mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
-            conn.audioContext = new AudioContext({ sampleRate: 48000 });
-            const source = conn.audioContext.createMediaStreamSource(conn.mediaStream);
             const processor = new MediaStreamTrackProcessor({ track: conn.mediaStream.getAudioTracks()[0] });
             const reader = processor.readable.getReader();
-            conn.publisher = conn.session.publish(conn.namespace);
-            const track = conn.publisher.createTrack('audio');
+
             conn.audioEncoder = new AudioEncoder({
                 output: (chunk, _metadata) => {
                     const buffer = new ArrayBuffer(chunk.byteLength);
                     chunk.copyTo(buffer);
-                    track.writeChunk(buffer);
+                    const data = new Uint8Array(buffer);
+                    const varintBytes = Moq.Varint.encode(chunk.timestamp);
+                    const frame = new Uint8Array(varintBytes.length + data.length);
+                    frame.set(varintBytes, 0);
+                    frame.set(data, varintBytes.length);
+                    for (const track of conn.publisherTracks) {
+                        try { track.writeFrame(frame); } catch (_) {}
+                    }
                 },
                 error: (e) => {
                     console.error('[MoQ Nest] AudioEncoder error:', e);
@@ -98,13 +129,13 @@ window.nestAudioManager = window.nestAudioManager || {
                 numberOfChannels: 1,
                 bitrate: 64000,
             });
+
             (async () => {
                 try {
                     while (true) {
                         const result = await reader.read();
                         if (result.done) break;
-                        if (conn.micMuted) continue;
-                        if (conn.audioEncoder.state === 'configured') {
+                        if (!conn.micMuted && conn.audioEncoder.state === 'configured') {
                             conn.audioEncoder.encode(result.value);
                         }
                         result.value.close();
@@ -126,13 +157,16 @@ window.nestAudioManager = window.nestAudioManager || {
     async subscribeAudio(publisherId, participantPubkey) {
         const conn = this._getConnection(publisherId);
         if (!conn) return { type: 'error', error: 'Not initialized' };
-        if (!conn.session) return { type: 'error', error: 'Not connected' };
+        if (!conn.connection) return { type: 'error', error: 'Not connected' };
         if (conn.subscribers.has(participantPubkey)) return { type: 'success' };
         try {
-            const trackName = participantPubkey + '/audio';
-            const subscription = conn.session.subscribe(conn.namespace, trackName);
+            const Moq = this._moqModule;
+            const broadcast = conn.connection.consume(Moq.Path.from(participantPubkey));
+            const track = broadcast.subscribe('audio/data', 128);
+
             const subState = {
-                subscription,
+                broadcast,
+                track,
                 audioContext: new AudioContext({ sampleRate: 48000 }),
                 audioDecoder: null,
                 active: true,
@@ -178,17 +212,17 @@ window.nestAudioManager = window.nestAudioManager || {
                 sampleRate: 48000,
                 numberOfChannels: 1,
             });
-            let frameIndex = 0;
             (async () => {
                 try {
                     while (subState.active) {
-                        const chunk = await subscription.readChunk();
-                        if (!subState.active) break;
+                        const frame = await track.readFrame();
+                        if (!subState.active || !frame) break;
+                        const [timestampUs, payload] = Moq.Varint.decode(frame);
                         if (subState.audioDecoder.state === 'configured') {
                             const data = new EncodedAudioChunk({
                                 type: 'key',
-                                timestamp: frameIndex++ * 20000,
-                                data: chunk,
+                                timestamp: timestampUs,
+                                data: payload,
                             });
                             subState.audioDecoder.decode(data);
                         }
@@ -215,6 +249,7 @@ window.nestAudioManager = window.nestAudioManager || {
         const subState = conn.subscribers.get(participantPubkey);
         if (subState) {
             subState.active = false;
+            try { if (subState.track) subState.track.close(); } catch (_) {}
             try { if (subState.audioDecoder) subState.audioDecoder.close(); } catch (_) {}
             try { if (subState.audioContext) subState.audioContext.close(); } catch (_) {}
             conn.subscribers.delete(participantPubkey);
@@ -246,6 +281,7 @@ window.nestAudioManager = window.nestAudioManager || {
         try {
             for (const [_pubkey, sub] of conn.subscribers.entries()) {
                 sub.active = false;
+                try { if (sub.track) sub.track.close(); } catch (_) {}
                 try { if (sub.audioDecoder) sub.audioDecoder.close(); } catch (_) {}
                 try { if (sub.audioContext) sub.audioContext.close(); } catch (_) {}
             }
@@ -254,18 +290,18 @@ window.nestAudioManager = window.nestAudioManager || {
                 try { conn.audioEncoder.close(); } catch (_) {}
                 conn.audioEncoder = null;
             }
-            if (conn.audioContext) {
-                try { conn.audioContext.close(); } catch (_) {}
-                conn.audioContext = null;
-            }
             if (conn.mediaStream) {
                 conn.mediaStream.getTracks().forEach(t => t.stop());
                 conn.mediaStream = null;
             }
-            conn.publisher = null;
-            if (conn.session) {
-                try { conn.session.close(); } catch (_) {}
-                conn.session = null;
+            if (conn.publisherBroadcast) {
+                try { conn.publisherBroadcast.close(); } catch (_) {}
+                conn.publisherBroadcast = null;
+            }
+            conn.publisherTracks.clear();
+            if (conn.connection) {
+                try { conn.connection.close(); } catch (_) {}
+                conn.connection = null;
             }
             conn.state = 'disconnected';
             conn.error = null;

--- a/public/moq-nest.js
+++ b/public/moq-nest.js
@@ -58,6 +58,11 @@ window.nestAudioManager = window.nestAudioManager || {
             const Moq = this._moqModule;
             const url = new URL(relayUrl);
             url.pathname = '/' + namespace;
+            // NOTE: WebTransport does not support custom headers on the HTTP/3 CONNECT
+            // request, so the JWT must be passed as a URL query parameter. This is a
+            // known security trade-off: the token may appear in server access logs,
+            // browser history, and Referer headers. Mitigation: ensure the JWT has a
+            // short TTL (e.g., 60 seconds).
             if (jwt) url.searchParams.set('jwt', jwt);
             conn.connection = await Moq.Connection.connect(url);
             conn.myPubkeyHex = myPubkeyHex;

--- a/src/components/followers_modal.rs
+++ b/src/components/followers_modal.rs
@@ -1,0 +1,522 @@
+use crate::services::social_graph::{self, ProfileMetadata};
+use crate::stores::{auth_store, nostr_client, profiles};
+use crate::utils::format::truncate_pubkey;
+use dioxus::prelude::*;
+use nostr_sdk::prelude::*;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FollowersTab {
+    Following,
+    Followers,
+}
+
+#[derive(Props, Clone, PartialEq)]
+pub struct FollowersModalProps {
+    pub pubkey: String,
+    pub initial_tab: FollowersTab,
+    pub open: Signal<bool>,
+}
+
+#[derive(Debug, Clone)]
+struct UserEntry {
+    pubkey: String,
+    display_name: String,
+    picture: Option<String>,
+    npub: String,
+}
+
+fn get_display_name_from_metadata(meta: &ProfileMetadata) -> String {
+    if let Some(name) = &meta.display_name {
+        if !name.trim().is_empty() {
+            return name.clone();
+        }
+    }
+    if let Some(name) = &meta.name {
+        if !name.trim().is_empty() {
+            return name.clone();
+        }
+    }
+    truncate_pubkey(&meta.pubkey)
+}
+
+fn get_display_name_from_profile(profile: &profiles::Profile) -> String {
+    profile.get_display_name()
+}
+
+fn get_picture_from_metadata(meta: &ProfileMetadata) -> Option<String> {
+    meta.picture.as_ref().filter(|p| !p.trim().is_empty()).cloned()
+}
+
+#[component]
+pub fn FollowersModal(props: FollowersModalProps) -> Element {
+    let mut open = props.open;
+    if !*open.read() {
+        return rsx! {};
+    }
+
+    let mut active_tab = use_signal(|| props.initial_tab);
+    let mut following_entries = use_signal(Vec::<UserEntry>::new);
+    let mut followers_entries = use_signal(Vec::<UserEntry>::new);
+    let mut following_total = use_signal(|| 0i64);
+    let mut followers_total = use_signal(|| 0i64);
+    let mut following_loaded = use_signal(|| 0i64);
+    let mut followers_loaded = use_signal(|| 0i64);
+    let mut loading = use_signal(|| false);
+    let mut initial_load_done = use_signal(|| false);
+
+    let hex_pubkey = {
+        crate::utils::nip19_urls::parse_profile_id(&props.pubkey)
+            .map(|pk| pk.to_hex())
+            .unwrap_or_else(|| props.pubkey.clone())
+    };
+
+    let hex_for_initial = hex_pubkey.clone();
+    let hex_for_following_tab = hex_pubkey.clone();
+    let hex_for_followers_tab = hex_pubkey.clone();
+    let hex_for_load_more = hex_pubkey.clone();
+
+    use_effect(use_reactive(&(*open.read()), move |is_open| {
+        if !is_open {
+            return;
+        }
+        if *initial_load_done.read() {
+            return;
+        }
+        initial_load_done.set(true);
+
+        let hex = hex_for_initial.clone();
+        let tab = *active_tab.read();
+
+        spawn(async move {
+            loading.set(true);
+
+            let fetch_follows = matches!(tab, FollowersTab::Following);
+            let fetch_followers = matches!(tab, FollowersTab::Followers);
+
+            let result = social_graph::fetch_social_graph(
+                &hex,
+                if fetch_follows { 100 } else { 0 },
+                0,
+                if fetch_followers { 100 } else { 0 },
+                0,
+            )
+            .await;
+
+            match result {
+                Ok(response) => {
+                    if fetch_follows {
+                        following_total.set(response.follows.count);
+                        following_loaded.set(response.follows.pubkeys.len() as i64);
+                        let entries = resolve_pubkeys(response.follows.pubkeys).await;
+                        following_entries.set(entries);
+                    }
+                    if fetch_followers {
+                        followers_total.set(response.followers.count);
+                        followers_loaded.set(response.followers.pubkeys.len() as i64);
+                        let entries = resolve_pubkeys(response.followers.pubkeys).await;
+                        followers_entries.set(entries);
+                    }
+                }
+                Err(e) => {
+                    log::error!("Failed to fetch social graph: {}", e);
+                }
+            }
+
+            loading.set(false);
+        });
+    }));
+
+    let current_entries = match *active_tab.read() {
+        FollowersTab::Following => following_entries.read().clone(),
+        FollowersTab::Followers => followers_entries.read().clone(),
+    };
+    let (current_total, current_loaded) = match *active_tab.read() {
+        FollowersTab::Following => (*following_total.read(), *following_loaded.read()),
+        FollowersTab::Followers => (*followers_total.read(), *followers_loaded.read()),
+    };
+    let has_more = current_loaded > 0 && current_total > current_loaded;
+
+    let following_count_str = if *following_total.read() > 0 {
+        format!(" ({})", *following_total.read())
+    } else {
+        String::new()
+    };
+    let followers_count_str = if *followers_total.read() > 0 {
+        format!(" ({})", *followers_total.read())
+    } else {
+        String::new()
+    };
+
+    rsx! {
+        div {
+            class: "fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm",
+            onclick: move |_| open.set(false),
+            div {
+                class: "bg-card border border-border rounded-lg shadow-xl w-full max-w-lg max-h-[85vh] flex flex-col",
+                onclick: move |e: MouseEvent| e.stop_propagation(),
+
+                // Header with tabs
+                div { class: "flex items-center justify-between border-b border-border px-4 pt-4",
+                    div { class: "flex gap-1",
+                        button {
+                            class: if matches!(*active_tab.read(), FollowersTab::Following) {
+                                "px-4 py-2 text-sm font-semibold border-b-2 border-foreground text-foreground"
+                            } else {
+                                "px-4 py-2 text-sm font-semibold border-b-2 border-transparent text-muted-foreground hover:text-foreground transition"
+                            },
+                            onclick: move |_| {
+                                active_tab.set(FollowersTab::Following);
+                                if *following_total.read() == 0 && following_entries.read().is_empty() {
+                                    let hex = hex_for_following_tab.clone();
+                                    loading.set(true);
+                                    spawn(async move {
+                                        match social_graph::fetch_social_graph(&hex, 100, 0, 0, 0).await {
+                                            Ok(response) => {
+                                                following_total.set(response.follows.count);
+                                                following_loaded.set(response.follows.pubkeys.len() as i64);
+                                                let entries = resolve_pubkeys(response.follows.pubkeys).await;
+                                                following_entries.set(entries);
+                                            }
+                                            Err(e) => log::error!("Failed to fetch following: {}", e),
+                                        }
+                                        loading.set(false);
+                                    });
+                                }
+                            },
+                            "Following{following_count_str}"
+                        }
+                        button {
+                            class: if matches!(*active_tab.read(), FollowersTab::Followers) {
+                                "px-4 py-2 text-sm font-semibold border-b-2 border-foreground text-foreground"
+                            } else {
+                                "px-4 py-2 text-sm font-semibold border-b-2 border-transparent text-muted-foreground hover:text-foreground transition"
+                            },
+                            onclick: move |_| {
+                                active_tab.set(FollowersTab::Followers);
+                                if *followers_total.read() == 0 && followers_entries.read().is_empty() {
+                                    let hex = hex_for_followers_tab.clone();
+                                    loading.set(true);
+                                    spawn(async move {
+                                        match social_graph::fetch_social_graph(&hex, 0, 0, 100, 0).await {
+                                            Ok(response) => {
+                                                followers_total.set(response.followers.count);
+                                                followers_loaded.set(response.followers.pubkeys.len() as i64);
+                                                let entries = resolve_pubkeys(response.followers.pubkeys).await;
+                                                followers_entries.set(entries);
+                                            }
+                                            Err(e) => log::error!("Failed to fetch followers: {}", e),
+                                        }
+                                        loading.set(false);
+                                    });
+                                }
+                            },
+                            "Followers{followers_count_str}"
+                        }
+                    }
+                    button {
+                        class: "p-2 rounded-full hover:bg-accent text-muted-foreground hover:text-foreground transition",
+                        onclick: move |_| open.set(false),
+                        svg {
+                            class: "w-5 h-5",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "2",
+                            view_box: "0 0 24 24",
+                            path {
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                d: "M6 18L18 6M6 6l12 12",
+                            }
+                        }
+                    }
+                }
+
+                // User list
+                div { class: "flex-1 overflow-y-auto",
+                    if *loading.read() && current_entries.is_empty() {
+                        div { class: "flex items-center justify-center py-12",
+                            div { class: "animate-spin w-8 h-8 border-2 border-foreground border-t-transparent rounded-full" }
+                        }
+                    } else if current_entries.is_empty() && !*loading.read() {
+                        div { class: "text-center py-12",
+                            p { class: "text-muted-foreground",
+                                match *active_tab.read() {
+                                    FollowersTab::Following => "Not following anyone yet",
+                                    FollowersTab::Followers => "No followers yet",
+                                }
+                            }
+                        }
+                    } else {
+                        {current_entries.into_iter().map(|entry| {
+                            let pk_for_nav = entry.npub.clone();
+                            let pk_for_follow = entry.pubkey.clone();
+                            let display_name = entry.display_name.clone();
+                            let picture = entry.picture.clone();
+                            let initial = display_name.chars().next().unwrap_or('?').to_uppercase().to_string();
+
+                            rsx! {
+                                UserRow {
+                                    key: "{pk_for_follow}",
+                                    pubkey: pk_for_follow,
+                                    display_name: display_name,
+                                    picture: picture,
+                                    initial: initial,
+                                    npub: pk_for_nav,
+                                    hex_for_follow: entry.pubkey.clone(),
+                                }
+                            }
+                        })}
+                        if has_more {
+                            div { class: "p-4 flex justify-center",
+                                button {
+                                    class: "px-4 py-2 text-sm border border-border rounded-lg hover:bg-accent transition disabled:opacity-50",
+                                    disabled: *loading.read(),
+                                    onclick: move |_| {
+                                        let tab = *active_tab.read();
+                                        let hex = hex_for_load_more.clone();
+                                        loading.set(true);
+                                        spawn(async move {
+                                            match tab {
+                                                FollowersTab::Following => {
+                                                    let offset = *following_loaded.read();
+                                                    match social_graph::fetch_social_graph(&hex, 100, offset, 0, 0).await {
+                                                        Ok(response) => {
+                                                            let new_entries = resolve_pubkeys(response.follows.pubkeys).await;
+                                                            following_loaded.set(offset + new_entries.len() as i64);
+                                                            let mut current = following_entries.read().clone();
+                                                            current.extend(new_entries);
+                                                            following_entries.set(current);
+                                                        }
+                                                        Err(e) => log::error!("Failed to load more: {}", e),
+                                                    }
+                                                }
+                                                FollowersTab::Followers => {
+                                                    let offset = *followers_loaded.read();
+                                                    match social_graph::fetch_social_graph(&hex, 0, 0, 100, offset).await {
+                                                        Ok(response) => {
+                                                            let new_entries = resolve_pubkeys(response.followers.pubkeys).await;
+                                                            followers_loaded.set(offset + new_entries.len() as i64);
+                                                            let mut current = followers_entries.read().clone();
+                                                            current.extend(new_entries);
+                                                            followers_entries.set(current);
+                                                        }
+                                                        Err(e) => log::error!("Failed to load more: {}", e),
+                                                    }
+                                                }
+                                            }
+                                            loading.set(false);
+                                        });
+                                    },
+                                    if *loading.read() { "Loading..." } else { "Load more" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct UserRowProps {
+    pubkey: String,
+    display_name: String,
+    picture: Option<String>,
+    initial: String,
+    npub: String,
+    hex_for_follow: String,
+}
+
+#[component]
+fn UserRow(props: UserRowProps) -> Element {
+    let mut is_following = use_signal(|| false);
+    let mut follow_loading = use_signal(|| false);
+    let mut follow_checked = use_signal(|| false);
+
+    let hex_for_check = props.hex_for_follow.clone();
+    let hex_for_toggle = props.hex_for_follow.clone();
+    let npub_for_nav = props.npub.clone();
+
+    let is_authenticated = auth_store::is_authenticated();
+
+    use_effect(move || {
+        if *follow_checked.read() {
+            return;
+        }
+        if !is_authenticated {
+            follow_checked.set(true);
+            return;
+        }
+        let hex = hex_for_check.clone();
+        spawn(async move {
+            if let Ok(following) = nostr_client::is_following(hex).await {
+                is_following.set(following);
+            }
+            follow_checked.set(true);
+        });
+    });
+
+    let npub_short = truncate_pubkey(&props.pubkey);
+
+    rsx! {
+        div { class: "flex items-center gap-3 px-4 py-3 hover:bg-accent/50 transition cursor-pointer",
+            onclick: move |_| {
+                let nav = navigator();
+                nav.push(crate::routes::Route::AddressViewer {
+                    address: npub_for_nav.clone(),
+                });
+            },
+            div { class: "w-10 h-10 rounded-full bg-muted shrink-0 overflow-hidden",
+                if let Some(url) = &props.picture {
+                    img { src: "{url}", class: "w-full h-full object-cover", alt: "Profile picture" }
+                } else {
+                    div { class: "w-full h-full flex items-center justify-center text-muted-foreground font-bold text-sm",
+                        "{props.initial}"
+                    }
+                }
+            }
+            div { class: "flex-1 min-w-0",
+                p { class: "font-medium text-sm truncate", "{props.display_name}" }
+                p { class: "text-xs text-muted-foreground truncate", "{npub_short}" }
+            }
+            if is_authenticated {
+                button {
+                    class: if *is_following.read() {
+                        "px-3 py-1.5 text-xs border border-border rounded-full font-semibold hover:bg-accent transition shrink-0"
+                    } else {
+                        "px-3 py-1.5 text-xs bg-foreground text-background rounded-full font-semibold hover:opacity-90 transition shrink-0"
+                    },
+                    disabled: *follow_loading.read(),
+                    onclick: move |e: MouseEvent| {
+                        e.stop_propagation();
+                        let hex = hex_for_toggle.clone();
+                        let current = *is_following.read();
+                        follow_loading.set(true);
+                        spawn(async move {
+                            let result = if current {
+                                nostr_client::unfollow_user(hex).await
+                            } else {
+                                nostr_client::follow_user(hex).await
+                            };
+                            match result {
+                                Ok(_) => {
+                                    is_following.set(!current);
+                                }
+                                Err(e) => {
+                                    log::error!("Failed to follow/unfollow: {}", e);
+                                }
+                            }
+                            follow_loading.set(false);
+                        });
+                    },
+                    if *follow_loading.read() {
+                        "..."
+                    } else if *is_following.read() {
+                        "Following"
+                    } else {
+                        "Follow"
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn resolve_pubkeys(pubkeys: Vec<String>) -> Vec<UserEntry> {
+    if pubkeys.is_empty() {
+        return Vec::new();
+    }
+
+    let mut entries = Vec::new();
+    let mut uncached = Vec::new();
+
+    for pk in &pubkeys {
+        let cache = profiles::PROFILE_CACHE.read();
+        if let Some(profile) = cache.peek(pk) {
+            let npub = PublicKey::parse(pk)
+                .ok()
+                .and_then(|p| p.to_bech32().ok())
+                .unwrap_or_else(|| pk.clone());
+            entries.push(UserEntry {
+                pubkey: pk.clone(),
+                display_name: get_display_name_from_profile(profile),
+                picture: profile.picture.clone(),
+                npub,
+            });
+        } else {
+            uncached.push(pk.clone());
+        }
+    }
+
+    if !uncached.is_empty() {
+        let batch_size = 500;
+        for chunk in uncached.chunks(batch_size) {
+            let chunk_vec = chunk.to_vec();
+            match social_graph::fetch_profiles_metadata(chunk_vec).await {
+                Ok(metadata_list) => {
+                    for meta in metadata_list {
+                        let npub = PublicKey::parse(&meta.pubkey)
+                            .ok()
+                            .and_then(|p| p.to_bech32().ok())
+                            .unwrap_or_else(|| meta.pubkey.clone());
+                        let picture = get_picture_from_metadata(&meta);
+                        let display_name = get_display_name_from_metadata(&meta);
+
+                        {
+                            let profile = profiles::Profile {
+                                pubkey: meta.pubkey.clone(),
+                                name: meta.name.clone(),
+                                display_name: meta.display_name.clone(),
+                                about: meta.about.clone(),
+                                picture: picture.clone(),
+                                banner: None,
+                                nip05: meta.nip05.clone(),
+                                lud16: None,
+                                lud06: None,
+                                website: None,
+                                bot: None,
+                                birthday: None,
+                                fetched_at: chrono::Utc::now(),
+                                raw_metadata_json: None,
+                            };
+                            profiles::PROFILE_CACHE
+                                .write()
+                                .put(meta.pubkey.clone(), profile);
+                        }
+
+                        entries.push(UserEntry {
+                            pubkey: meta.pubkey.clone(),
+                            display_name,
+                            picture,
+                            npub,
+                        });
+                    }
+                }
+                Err(e) => {
+                    log::error!("Failed to fetch profile metadata batch: {}", e);
+                    for pk in chunk {
+                        let npub = PublicKey::parse(pk)
+                            .ok()
+                            .and_then(|p| p.to_bech32().ok())
+                            .unwrap_or_else(|| pk.clone());
+                        entries.push(UserEntry {
+                            pubkey: pk.clone(),
+                            display_name: truncate_pubkey(pk),
+                            picture: None,
+                            npub,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    let mut pubkey_order: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for (i, pk) in pubkeys.iter().enumerate() {
+        pubkey_order.insert(pk.clone(), i);
+    }
+    entries.sort_by_key(|e| pubkey_order.get(&e.pubkey).copied().unwrap_or(usize::MAX));
+
+    entries
+}

--- a/src/components/followers_modal.rs
+++ b/src/components/followers_modal.rs
@@ -50,9 +50,6 @@ fn get_picture_from_metadata(meta: &ProfileMetadata) -> Option<String> {
 #[component]
 pub fn FollowersModal(props: FollowersModalProps) -> Element {
     let mut open = props.open;
-    if !*open.read() {
-        return rsx! {};
-    }
 
     let mut active_tab = use_signal(|| props.initial_tab);
     let mut following_entries = use_signal(Vec::<UserEntry>::new);
@@ -62,7 +59,7 @@ pub fn FollowersModal(props: FollowersModalProps) -> Element {
     let mut following_loaded = use_signal(|| 0i64);
     let mut followers_loaded = use_signal(|| 0i64);
     let mut loading = use_signal(|| false);
-    let mut initial_load_done = use_signal(|| false);
+    let mut error = use_signal(|| None::<String>);
 
     let hex_pubkey = {
         crate::utils::nip19_urls::parse_profile_id(&props.pubkey)
@@ -70,21 +67,33 @@ pub fn FollowersModal(props: FollowersModalProps) -> Element {
             .unwrap_or_else(|| props.pubkey.clone())
     };
 
-    let hex_for_initial = hex_pubkey.clone();
     let hex_for_following_tab = hex_pubkey.clone();
     let hex_for_followers_tab = hex_pubkey.clone();
     let hex_for_load_more = hex_pubkey.clone();
+    let hex_for_retry = hex_pubkey.clone();
 
-    use_effect(use_reactive(&(*open.read()), move |is_open| {
-        if !is_open {
+    let is_open_for_effect = *open.read();
+    let pubkey_for_effect = props.pubkey.clone();
+
+    use_effect(use_reactive!(|(
+        is_open_for_effect,
+        pubkey_for_effect,
+    )| {
+        if !is_open_for_effect {
             return;
         }
-        if *initial_load_done.read() {
-            return;
-        }
-        initial_load_done.set(true);
 
-        let hex = hex_for_initial.clone();
+        following_entries.set(Vec::new());
+        followers_entries.set(Vec::new());
+        following_total.set(0);
+        followers_total.set(0);
+        following_loaded.set(0);
+        followers_loaded.set(0);
+        error.set(None);
+
+        let hex = crate::utils::nip19_urls::parse_profile_id(&pubkey_for_effect)
+            .map(|pk| pk.to_hex())
+            .unwrap_or_else(|| pubkey_for_effect.clone());
         let tab = *active_tab.read();
 
         spawn(async move {
@@ -93,16 +102,15 @@ pub fn FollowersModal(props: FollowersModalProps) -> Element {
             let fetch_follows = matches!(tab, FollowersTab::Following);
             let fetch_followers = matches!(tab, FollowersTab::Followers);
 
-            let result = social_graph::fetch_social_graph(
+            match social_graph::fetch_social_graph(
                 &hex,
                 if fetch_follows { 100 } else { 0 },
                 0,
                 if fetch_followers { 100 } else { 0 },
                 0,
             )
-            .await;
-
-            match result {
+            .await
+            {
                 Ok(response) => {
                     if fetch_follows {
                         following_total.set(response.follows.count);
@@ -119,12 +127,17 @@ pub fn FollowersModal(props: FollowersModalProps) -> Element {
                 }
                 Err(e) => {
                     log::error!("Failed to fetch social graph: {}", e);
+                    error.set(Some("Failed to load data. Please try again.".to_string()));
                 }
             }
 
             loading.set(false);
         });
     }));
+
+    if !*open.read() {
+        return rsx! {};
+    }
 
     let current_entries = match *active_tab.read() {
         FollowersTab::Following => following_entries.read().clone(),
@@ -167,6 +180,7 @@ pub fn FollowersModal(props: FollowersModalProps) -> Element {
                             onclick: move |_| {
                                 active_tab.set(FollowersTab::Following);
                                 if *following_total.read() == 0 && following_entries.read().is_empty() {
+                                    error.set(None);
                                     let hex = hex_for_following_tab.clone();
                                     loading.set(true);
                                     spawn(async move {
@@ -177,7 +191,10 @@ pub fn FollowersModal(props: FollowersModalProps) -> Element {
                                                 let entries = resolve_pubkeys(response.follows.pubkeys).await;
                                                 following_entries.set(entries);
                                             }
-                                            Err(e) => log::error!("Failed to fetch following: {}", e),
+                                            Err(e) => {
+                                                log::error!("Failed to fetch following: {}", e);
+                                                error.set(Some("Failed to load following list.".to_string()));
+                                            }
                                         }
                                         loading.set(false);
                                     });
@@ -194,6 +211,7 @@ pub fn FollowersModal(props: FollowersModalProps) -> Element {
                             onclick: move |_| {
                                 active_tab.set(FollowersTab::Followers);
                                 if *followers_total.read() == 0 && followers_entries.read().is_empty() {
+                                    error.set(None);
                                     let hex = hex_for_followers_tab.clone();
                                     loading.set(true);
                                     spawn(async move {
@@ -204,7 +222,10 @@ pub fn FollowersModal(props: FollowersModalProps) -> Element {
                                                 let entries = resolve_pubkeys(response.followers.pubkeys).await;
                                                 followers_entries.set(entries);
                                             }
-                                            Err(e) => log::error!("Failed to fetch followers: {}", e),
+                                            Err(e) => {
+                                                log::error!("Failed to fetch followers: {}", e);
+                                                error.set(Some("Failed to load followers list.".to_string()));
+                                            }
                                         }
                                         loading.set(false);
                                     });
@@ -233,7 +254,54 @@ pub fn FollowersModal(props: FollowersModalProps) -> Element {
 
                 // User list
                 div { class: "flex-1 overflow-y-auto",
-                    if *loading.read() && current_entries.is_empty() {
+                    if let Some(err) = error.read().as_ref() {
+                        div { class: "flex flex-col items-center justify-center py-12 gap-3",
+                            p { class: "text-red-500 text-sm text-center px-4", "{err}" }
+                            button {
+                                class: "px-4 py-2 text-sm border border-border rounded-lg hover:bg-accent transition",
+                                onclick: move |_| {
+                                    error.set(None);
+                                    let hex = hex_for_retry.clone();
+                                    let tab = *active_tab.read();
+                                    loading.set(true);
+                                    spawn(async move {
+                                        let fetch_follows = matches!(tab, FollowersTab::Following);
+                                        let fetch_followers = matches!(tab, FollowersTab::Followers);
+                                        match social_graph::fetch_social_graph(
+                                            &hex,
+                                            if fetch_follows { 100 } else { 0 },
+                                            0,
+                                            if fetch_followers { 100 } else { 0 },
+                                            0,
+                                        )
+                                        .await
+                                        {
+                                            Ok(response) => {
+                                                if fetch_follows {
+                                                    following_total.set(response.follows.count);
+                                                    following_loaded.set(response.follows.pubkeys.len() as i64);
+                                                    let entries = resolve_pubkeys(response.follows.pubkeys).await;
+                                                    following_entries.set(entries);
+                                                }
+                                                if fetch_followers {
+                                                    followers_total.set(response.followers.count);
+                                                    followers_loaded.set(response.followers.pubkeys.len() as i64);
+                                                    let entries = resolve_pubkeys(response.followers.pubkeys).await;
+                                                    followers_entries.set(entries);
+                                                }
+                                            }
+                                            Err(e) => {
+                                                log::error!("Retry failed: {}", e);
+                                                error.set(Some("Failed to load data. Please try again.".to_string()));
+                                            }
+                                        }
+                                        loading.set(false);
+                                    });
+                                },
+                                "Retry"
+                            }
+                        }
+                    } else if *loading.read() && current_entries.is_empty() {
                         div { class: "flex items-center justify-center py-12",
                             div { class: "animate-spin w-8 h-8 border-2 border-foreground border-t-transparent rounded-full" }
                         }
@@ -272,6 +340,7 @@ pub fn FollowersModal(props: FollowersModalProps) -> Element {
                                     class: "px-4 py-2 text-sm border border-border rounded-lg hover:bg-accent transition disabled:opacity-50",
                                     disabled: *loading.read(),
                                     onclick: move |_| {
+                                        error.set(None);
                                         let tab = *active_tab.read();
                                         let hex = hex_for_load_more.clone();
                                         loading.set(true);
@@ -287,7 +356,10 @@ pub fn FollowersModal(props: FollowersModalProps) -> Element {
                                                             current.extend(new_entries);
                                                             following_entries.set(current);
                                                         }
-                                                        Err(e) => log::error!("Failed to load more: {}", e),
+                                                        Err(e) => {
+                                                            log::error!("Failed to load more: {}", e);
+                                                            error.set(Some("Failed to load more.".to_string()));
+                                                        }
                                                     }
                                                 }
                                                 FollowersTab::Followers => {
@@ -300,7 +372,10 @@ pub fn FollowersModal(props: FollowersModalProps) -> Element {
                                                             current.extend(new_entries);
                                                             followers_entries.set(current);
                                                         }
-                                                        Err(e) => log::error!("Failed to load more: {}", e),
+                                                        Err(e) => {
+                                                            log::error!("Failed to load more: {}", e);
+                                                            error.set(Some("Failed to load more.".to_string()));
+                                                        }
                                                     }
                                                 }
                                             }

--- a/src/components/live/chat.rs
+++ b/src/components/live/chat.rs
@@ -88,7 +88,7 @@ pub fn LiveChat(stream_author_pubkey: String, stream_d_tag: String, #[props(defa
                 if !relays.is_empty() {
                     let ephemeral = connect_ephemeral_relays(&client, &relays).await;
                     if !ephemeral.newly_added.is_empty() {
-                        let mut guard = connected_relays.lock().unwrap();
+                        let mut guard = connected_relays.lock().unwrap_or_else(|e| e.into_inner());
                         *guard = ephemeral.newly_added.clone();
                         drop(guard);
                     }
@@ -171,7 +171,7 @@ pub fn LiveChat(stream_author_pubkey: String, stream_d_tag: String, #[props(defa
     let ephemeral_relays_for_send_click = ephemeral_relays.read().clone();
     let ephemeral_cleanup = connected_relays.clone();
     use_drop(move || {
-        let to_cleanup = ephemeral_cleanup.lock().unwrap().clone();
+        let to_cleanup = ephemeral_cleanup.lock().unwrap_or_else(|e| e.into_inner()).clone();
         if !to_cleanup.is_empty() {
             spawn(async move {
                 if let Some(client) = get_client() {

--- a/src/components/live/chat.rs
+++ b/src/components/live/chat.rs
@@ -1,9 +1,10 @@
 use crate::components::icons::{MaximizeIcon, XIcon};
 use crate::components::{EmojiPicker, RichContent};
-use crate::hooks::{use_mute_block_cache, use_relay_subscription};
+use crate::hooks::{use_mute_block_cache, use_relay_subscription_to};
 use crate::routes::Route;
-use crate::stores::nostr_client::{self, fetch_events_aggregated, get_client, HAS_SIGNER};
+use crate::stores::nostr_client::{self, get_client, HAS_SIGNER};
 use crate::stores::profiles;
+use crate::stores::relay::coverage::{connect_ephemeral_relays, cleanup_ephemeral_relays};
 use crate::utils::custom_emoji::{build_custom_emoji_tags, EmojiSelection};
 use crate::utils::profile_prefetch;
 use crate::utils::truncate_pubkey;
@@ -12,11 +13,10 @@ use nostr::TagKind;
 use nostr_sdk::{
     Event, EventBuilder, Filter, Kind, PublicKey,
     SingleLetterTag, Alphabet,
-    Tag, Timestamp,
+    Tag,
 };
 use std::collections::HashSet;
 use std::rc::Rc;
-use std::time::Duration;
 #[cfg(feature = "web")]
 use wasm_bindgen::prelude::*;
 #[cfg(feature = "web")]
@@ -42,7 +42,7 @@ extern "C" {
     fn isScrolledNearBottom(element_id: &str, threshold: f64) -> bool;
 }
 #[component]
-pub fn LiveChat(stream_author_pubkey: String, stream_d_tag: String) -> Element {
+pub fn LiveChat(stream_author_pubkey: String, stream_d_tag: String, #[props(default)] stream_relays: Vec<String>) -> Element {
     let mut messages = use_signal(Vec::<Event>::new);
     let mut loading = use_signal(|| false);
     let mut message_input = use_signal(String::new);
@@ -58,28 +58,78 @@ pub fn LiveChat(stream_author_pubkey: String, stream_d_tag: String) -> Element {
     let a_tag_for_send_keydown = a_tag.clone();
     let a_tag_for_send_click = a_tag.clone();
     let chat_id_for_auto_scroll = chat_container_id.clone();
+    let mut ephemeral_relays = use_signal(Vec::<String>::new);
+    let connected_relays: std::sync::Arc<std::sync::Mutex<Vec<String>>> = use_hook(|| {
+        std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()))
+    });
+    let connected_relays_clone = connected_relays.clone();
+    let relay_urls_for_sub = stream_relays.clone();
+    let relay_urls_for_sub_clone = relay_urls_for_sub.clone();
     use_effect(use_reactive(
-        (&stream_author_pubkey, &stream_d_tag),
-        move |(author, dtag)| {
+        (&stream_author_pubkey, &stream_d_tag, &stream_relays),
+        move |(author, dtag, relays)| {
             let tag = format!("30311:{}:{}", author, dtag);
             messages.set(Vec::new());
             loading.set(true);
+            let connected_relays = connected_relays_clone.clone();
             spawn(async move {
-                if PublicKey::parse(&author).is_ok() {
-                    let filter = Filter::new()
-                        .kind(Kind::from(1311))
-                        .custom_tag(SingleLetterTag::lowercase(Alphabet::A), tag.as_str())
-                        .limit(200);
-                    match fetch_events_aggregated(filter, Duration::from_secs(10)).await {
-                        Ok(events) => {
-                            let mut sorted_messages = events;
-                            sorted_messages.sort_by_key(|a| a.created_at);
-                            messages.set(sorted_messages);
-                            log::info!("Loaded {} chat messages", messages.read().len());
-                        }
-                        Err(e) => {
-                            log::error!("Failed to fetch chat messages: {}", e);
-                        }
+                if PublicKey::parse(&author).is_err() {
+                    loading.set(false);
+                    return;
+                }
+                let client = match get_client() {
+                    Some(c) => c,
+                    None => {
+                        loading.set(false);
+                        return;
+                    }
+                };
+                let mut resolved_relays: Vec<String> = Vec::new();
+                if !relays.is_empty() {
+                    let ephemeral = connect_ephemeral_relays(&client, &relays).await;
+                    if !ephemeral.newly_added.is_empty() {
+                        let mut guard = connected_relays.lock().unwrap();
+                        *guard = ephemeral.newly_added.clone();
+                        drop(guard);
+                    }
+                    resolved_relays = ephemeral.connected;
+                }
+                if resolved_relays.is_empty() {
+                    resolved_relays = client
+                        .pool()
+                        .__read_relay_urls()
+                        .await
+                        .into_iter()
+                        .map(|u| u.to_string())
+                        .collect();
+                }
+                ephemeral_relays.set(resolved_relays.clone());
+                let filter = Filter::new()
+                    .kind(Kind::from(1311))
+                    .custom_tag(SingleLetterTag::lowercase(Alphabet::A), tag.as_str())
+                    .limit(200);
+                let result = if resolved_relays.is_empty() {
+                    client.fetch_events_from(
+                        client.pool().__read_relay_urls().await,
+                        filter,
+                        std::time::Duration::from_secs(10),
+                    ).await
+                } else {
+                    client.fetch_events_from(
+                        &resolved_relays,
+                        filter,
+                        std::time::Duration::from_secs(10),
+                    ).await
+                };
+                match result {
+                    Ok(events) => {
+                        let mut sorted_messages: Vec<Event> = events.into_iter().collect();
+                        sorted_messages.sort_by_key(|a| a.created_at);
+                        messages.set(sorted_messages);
+                        log::info!("Loaded {} chat messages", messages.read().len());
+                    }
+                    Err(e) => {
+                        log::error!("Failed to fetch chat messages: {}", e);
                     }
                 }
                 loading.set(false);
@@ -89,18 +139,18 @@ pub fn LiveChat(stream_author_pubkey: String, stream_d_tag: String) -> Element {
 
     {
         let a_tag = format!("30311:{}:{}", stream_author_pubkey, stream_d_tag);
+        let relay_urls = relay_urls_for_sub_clone.clone();
         let chat_filter = if PublicKey::parse(&stream_author_pubkey).is_ok() {
             Some(
                 Filter::new()
                     .kind(Kind::from(1311))
                     .custom_tag(SingleLetterTag::lowercase(Alphabet::A), a_tag.as_str())
-                    .since(Timestamp::now())
-                    .limit(0),
+                    .limit(200),
             )
         } else {
             None
         };
-        use_relay_subscription(chat_filter, move |event: &nostr::Event| {
+        use_relay_subscription_to(chat_filter, None, relay_urls, move |event: &nostr::Event| {
             let already_exists = messages.read().iter().any(|e| e.id == event.id);
             if !already_exists {
                 log::info!("New chat message via streaming: {}", event.id.to_hex());
@@ -117,6 +167,19 @@ pub fn LiveChat(stream_author_pubkey: String, stream_d_tag: String) -> Element {
             }
         });
     }
+    let ephemeral_relays_for_send_keydown = ephemeral_relays.read().clone();
+    let ephemeral_relays_for_send_click = ephemeral_relays.read().clone();
+    let ephemeral_cleanup = connected_relays.clone();
+    use_drop(move || {
+        let to_cleanup = ephemeral_cleanup.lock().unwrap().clone();
+        if !to_cleanup.is_empty() {
+            spawn(async move {
+                if let Some(client) = get_client() {
+                    cleanup_ephemeral_relays(&client, &to_cleanup).await;
+                }
+            });
+        }
+    });
     let mut is_first_load = use_signal(|| true);
     let mut chat_scroll_gen = use_signal(|| 0u32);
     use_effect(use_reactive(
@@ -167,7 +230,7 @@ pub fn LiveChat(stream_author_pubkey: String, stream_d_tag: String) -> Element {
             profile_prefetch::prefetch_event_authors(&current_messages).await;
         });
     });
-    let perform_send = move |content: String, tag_clone: String| {
+    let perform_send = move |content: String, tag_clone: String, relays: Vec<String>| {
         spawn(async move {
             match get_client() {
                 Some(_client) => {
@@ -179,10 +242,15 @@ pub fn LiveChat(stream_author_pubkey: String, stream_d_tag: String) -> Element {
                         .await
                     {
                         Ok(event) => {
+                            let target_relays = if relays.is_empty() {
+                                None
+                            } else {
+                                Some(relays)
+                            };
                             crate::stores::publish_queue::enqueue(
                                 event.clone(),
                                 crate::stores::publish_queue::types::QueueEventType::Other("live".to_string()),
-                                None,
+                                target_relays,
                                 std::collections::HashMap::new(),
                             ).await;
                             message_input.set(String::new());
@@ -307,7 +375,7 @@ pub fn LiveChat(stream_author_pubkey: String, stream_d_tag: String) -> Element {
                                         return;
                                     }
                                     sending.set(true);
-                                    perform_send(content, a_tag_for_send_keydown.clone());
+                                    perform_send(content, a_tag_for_send_keydown.clone(), ephemeral_relays_for_send_keydown.clone());
                                 }
                             },
                         }
@@ -320,7 +388,7 @@ pub fn LiveChat(stream_author_pubkey: String, stream_d_tag: String) -> Element {
                                     return;
                                 }
                                 sending.set(true);
-                                perform_send(content, a_tag_for_send_click.clone());
+                                perform_send(content, a_tag_for_send_click.clone(), ephemeral_relays_for_send_click.clone());
                             },
                             if *sending.read() {
                                 "Sending..."

--- a/src/components/mobile_search_slideout.rs
+++ b/src/components/mobile_search_slideout.rs
@@ -29,6 +29,20 @@ pub fn MobileSearchSlideout(show: bool, on_close: EventHandler<()>) -> Element {
         });
     });
 
+    let cached_results = use_memo(move || {
+        let q = query.read().clone();
+        if q.is_empty() {
+            return Vec::<ProfileSearchResult>::new();
+        }
+        let contacts = contact_pubkeys.read().clone();
+        search_cached_profiles(&q, 10, &contacts, &[])
+    });
+
+    use_effect(move || {
+        let results = cached_results.read().clone();
+        search_results.set(results);
+    });
+
     use_effect(use_reactive(&show, move |is_open| {
         if !is_open {
             query.set(String::new());
@@ -60,11 +74,7 @@ pub fn MobileSearchSlideout(show: bool, on_close: EventHandler<()>) -> Element {
         show_dropdown.set(true);
         selected_index.set(0);
 
-        let contacts = contact_pubkeys.read().clone();
-        let cached_results = search_cached_profiles(&new_value, 10, &contacts, &[]);
-        search_results.set(cached_results.clone());
-
-        if new_value.len() >= 2 && cached_results.len() < 5 {
+        if new_value.len() >= 2 && cached_results.read().len() < 5 {
             is_searching.set(true);
             if let Some(task) = relay_search_task.take() {
                 task.cancel();

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,6 +2,7 @@ pub mod ai_settings_panel;
 pub mod article_card;
 pub mod article_content;
 pub mod badge_detail_modal;
+pub mod followers_modal;
 pub mod book_picker_modal;
 #[cfg(feature = "cashu")]
 pub mod cashu;
@@ -87,6 +88,7 @@ pub use ai_settings_panel::AiSettingsPanel;
 pub use article_card::{ArticleCard, ArticleCardSkeleton};
 pub use article_content::ArticleContent;
 pub use client_initializing::ClientInitializing;
+pub use followers_modal::{FollowersModal, FollowersTab};
 #[allow(unused_imports)]
 pub use shared_states::{ApiAuthRequiredState, ApiInitializingState};
 pub use composer_body::ComposerBody;

--- a/src/components/nests/nest_reactions.rs
+++ b/src/components/nests/nest_reactions.rs
@@ -22,8 +22,12 @@ pub fn NestReactions(props: NestReactionsProps) -> Element {
     let reaction_counter = use_signal(|| 0u32);
 
     {
+        let is_joined = props.is_joined;
         let mut reactions = floating_reactions;
         use_future(move || async move {
+            if !is_joined {
+                return;
+            }
             loop {
                 crate::platform::timer::sleep_ms(1000).await;
                 let now = crate::platform::timestamp::now_secs();

--- a/src/components/search_input.rs
+++ b/src/components/search_input.rs
@@ -25,6 +25,18 @@ pub fn SearchInput() -> Element {
             contact_pubkeys.set(contacts);
         });
     });
+    let cached_results = use_memo(move || {
+        let q = query.read().clone();
+        if q.is_empty() {
+            return Vec::<ProfileSearchResult>::new();
+        }
+        let contacts = contact_pubkeys.read().clone();
+        search_cached_profiles(&q, 10, &contacts, &[])
+    });
+    use_effect(move || {
+        let results = cached_results.read().clone();
+        search_results.set(results);
+    });
     let handle_input = move |evt: DioxusEvent<FormData>| {
         let new_value = evt.value().clone();
         query.set(new_value.clone());
@@ -36,10 +48,7 @@ pub fn SearchInput() -> Element {
         }
         show_dropdown.set(true);
         selected_index.set(0);
-        let contacts = contact_pubkeys.read().clone();
-        let cached_results = search_cached_profiles(&new_value, 10, &contacts, &[]);
-        search_results.set(cached_results.clone());
-        if new_value.len() >= 2 && cached_results.len() < 5 {
+        if new_value.len() >= 2 && cached_results.read().len() < 5 {
             is_searching.set(true);
             if let Some(task) = relay_search_task.read().as_ref() {
                 task.cancel();

--- a/src/components/viewers/livestream_viewer.rs
+++ b/src/components/viewers/livestream_viewer.rs
@@ -310,8 +310,9 @@ pub fn LiveStreamViewer(note_id: String) -> Element {
                                     let p = (*parsed_naddr.read()).clone();
                                     let author_pk = p.as_ref().map(|p| p.pubkey.clone()).unwrap_or_default();
                                     let dtag = p.as_ref().map(|p| p.identifier.clone()).unwrap_or_default();
+                                    let relays = stream_meta.read().as_ref().map(|m| m.relays.clone()).unwrap_or_default();
                                     rsx! {
-                                        LiveChat { stream_author_pubkey: author_pk, stream_d_tag: dtag }
+                                        LiveChat { stream_author_pubkey: author_pk, stream_d_tag: dtag, stream_relays: relays }
                                     }
                                 }
                             }

--- a/src/components/viewers/nest_viewer.rs
+++ b/src/components/viewers/nest_viewer.rs
@@ -279,7 +279,7 @@ pub fn NestViewer(naddr: String) -> Element {
                 loop {
                     crate::platform::timer::sleep_ms(60_000).await;
                     if !*is_joined_hb.read() {
-                        break;
+                        continue;
                     }
                     let _ = crate::hooks::use_nest_audio::publish_presence(
                         &coord,
@@ -337,6 +337,7 @@ pub fn NestViewer(naddr: String) -> Element {
         let mut audio_error_cb = audio_error;
         let mut is_joined_cb = is_joined;
         let mut is_muted_cb = is_muted;
+        let my_pk = (*my_pubkey.read()).clone();
         move |_: Event<MouseData>| {
             let ms = space_val.read().clone();
             let Some(ms) = ms else {
@@ -346,11 +347,12 @@ pub fn NestViewer(naddr: String) -> Element {
             let relay_url = ms.endpoint_url.clone().unwrap_or_default();
             let coordinate = coord.clone();
             let pid = pid.clone();
+            let my_pk = my_pk.clone();
             spawn(async move {
                 audio_error_cb.set(None);
                 let namespace = format!("nests/{}", coordinate);
                 match crate::hooks::use_nest_audio::join_room_with_retry(
-                    &pid, &auth_url, &relay_url, &namespace, 3,
+                    &pid, &auth_url, &relay_url, &namespace, &my_pk, 3,
                 )
                 .await
                 {

--- a/src/components/viewers/note_viewer.rs
+++ b/src/components/viewers/note_viewer.rs
@@ -400,6 +400,45 @@ fn merge_new_replies(
     }
 }
 
+async fn fetch_parents_db(parent_ids: &[EventId]) -> Vec<NostrEvent> {
+    if parent_ids.is_empty() {
+        return Vec::new();
+    }
+
+    let Some(client) = nostr_client::get_client() else {
+        return Vec::new();
+    };
+
+    let filter = Filter::new()
+        .ids(parent_ids.iter().copied())
+        .kinds(vec![
+            Kind::TextNote,
+            Kind::VoiceMessage,
+            Kind::VoiceMessageReply,
+            Kind::Comment,
+        ]);
+
+    let mut db_parents = Vec::new();
+
+    if let Ok(events) = client.database().query(filter).await {
+        db_parents.extend(events);
+    }
+
+    #[cfg(feature = "native")]
+    {
+        let found_ids: HashSet<EventId> = db_parents.iter().map(|e| e.id).collect();
+        for id in parent_ids {
+            if !found_ids.contains(id) {
+                if let Some(event) = crate::stores::ndb::get_cached_event(&id.to_bytes()) {
+                    db_parents.push(event);
+                }
+            }
+        }
+    }
+
+    dedup_replies(db_parents)
+}
+
 async fn fetch_replies_db(
     event_id: EventId,
 ) -> std::result::Result<Vec<NostrEvent>, String> {
@@ -411,6 +450,7 @@ async fn fetch_replies_db(
     let filter_lower = Filter::new()
         .kinds(vec![
             Kind::TextNote,
+            Kind::Comment,
             Kind::VoiceMessage,
             Kind::VoiceMessageReply,
             Kind::Custom(crate::stores::nostr_client::edits::KIND_NOTE_EDIT),
@@ -492,6 +532,7 @@ async fn fetch_replies_bfs(
 
     let reply_kinds = vec![
         Kind::TextNote,
+        Kind::Comment,
         Kind::VoiceMessage,
         Kind::VoiceMessageReply,
         Kind::Custom(crate::stores::nostr_client::edits::KIND_NOTE_EDIT),
@@ -859,6 +900,13 @@ pub fn NoteViewer(note_id: String, from_voice: Option<String>) -> Element {
             let thread_root_id = resolve_thread_root_id(&clicked_note)
                 .unwrap_or(clicked_note.id);
 
+            let db_parents = fetch_parents_db(&parent_ids).await;
+            if !db_parents.is_empty() {
+                let mut sorted = db_parents;
+                sorted.sort_by_key(|a| a.created_at);
+                parent_events.set(sorted);
+            }
+
             let (parents_result, relay_replies_result) = tokio::join!(
                 fetch_parents_with_hints(parent_ids, &clicked_note, 5),
                 fetch_replies_from_relays(event_id, Some(root_author))
@@ -869,15 +917,21 @@ pub fn NoteViewer(note_id: String, from_voice: Option<String>) -> Element {
             }
 
             if let Ok(parent_fetch) = parents_result {
-                let mut parents = parent_fetch.parents;
+                let parents = parent_fetch.parents;
                 let missing = parent_fetch.missing_ids;
-                parents.sort_by_key(|a| a.created_at);
+                let mut merged: Vec<NostrEvent> = parent_events.peek().clone();
+                for p in &parents {
+                    if !merged.iter().any(|e| e.id == p.id) {
+                        merged.push(p.clone());
+                    }
+                }
+                merged.sort_by_key(|a| a.created_at);
                 back_navigation::set_active_note_back_context(
                     note_id_str.clone(),
-                    parents.iter().map(|event| event.id.to_hex()).collect(),
+                    merged.iter().map(|event| event.id.to_hex()).collect(),
                     note_data.peek().as_ref().is_some_and(is_voice_message),
                 );
-                parent_events.set(parents);
+                parent_events.set(merged);
 
                 if !missing.is_empty() {
                     let pe = parent_events;
@@ -994,6 +1048,9 @@ pub fn NoteViewer(note_id: String, from_voice: Option<String>) -> Element {
                     event.id.to_hex()
                 );
                 replies.write().push(event.clone());
+                if let Some(note) = note_data.peek().as_ref() {
+                    crate::utils::thread_tree::invalidate_thread_tree_cache(&note.id);
+                }
             }
         });
     }
@@ -1022,6 +1079,9 @@ pub fn NoteViewer(note_id: String, from_voice: Option<String>) -> Element {
                     event.id.to_hex()
                 );
                 replies.write().push(event.clone());
+                if let Some(note) = note_data.peek().as_ref() {
+                    crate::utils::thread_tree::invalidate_thread_tree_cache(&note.id);
+                }
             }
         });
     }
@@ -1161,6 +1221,12 @@ pub fn NoteViewer(note_id: String, from_voice: Option<String>) -> Element {
                     let (proposals, actual_replies): (Vec<NostrEvent>, Vec<NostrEvent>) = reply_vec
                         .into_iter()
                         .partition(|e| e.kind == edit_kind && e.pubkey != event.pubkey);
+                    let parent_ids: HashSet<EventId> = parent_events.peek().iter().map(|e| e.id).collect();
+                    let clicked_id = event.id;
+                    let actual_replies: Vec<NostrEvent> = actual_replies
+                        .into_iter()
+                        .filter(|e| !parent_ids.contains(&e.id) && e.id != clicked_id)
+                        .collect();
                     let root_event_id = event.id;
                     let original_for_proposals = event.clone();
                     let has_content = !actual_replies.is_empty() || !proposals.is_empty();

--- a/src/components/viewers/note_viewer.rs
+++ b/src/components/viewers/note_viewer.rs
@@ -813,18 +813,16 @@ pub fn NoteViewer(note_id: String, from_voice: Option<String>) -> Element {
             },
         };
 
-        let mut replies_early = replies;
-        let mut reply_ids_early = reply_ids;
+        let replies_early = replies;
+        let reply_ids_early = reply_ids;
         let lg = load_generation;
         let gen = this_generation;
 
         spawn(async move {
             if let Ok(db_replies) = fetch_replies_db(event_id).await {
                 if *lg.peek() != gen { return; }
-                let db_ids: HashSet<EventId> = db_replies.iter().map(|e| e.id).collect();
                 let db_count = db_replies.len();
-                reply_ids_early.set(db_ids);
-                replies_early.set(db_replies);
+                merge_new_replies(db_replies, replies_early, reply_ids_early);
                 loading_parents.set(false);
                 log::info!("Phase 0: loaded {} replies from DB cache", db_count);
             }

--- a/src/components/viewers/profile_viewer.rs
+++ b/src/components/viewers/profile_viewer.rs
@@ -2,7 +2,7 @@ use crate::components::dialog::{DialogDescription, DialogRoot, DialogTitle};
 use crate::components::icons::{InfoIcon, ListIcon, MailIcon};
 use crate::components::rich_content::mentions::{MentionRenderer, TextLinkMention};
 use crate::components::{
-    AddToPeopleListModal, ArticleCard, ArticleCardSkeleton, ClientInitializing, ExternalIdentitiesSection, Nip05Badge, NoteCard,
+    AddToPeopleListModal, ArticleCard, ArticleCardSkeleton, ClientInitializing, ExternalIdentitiesSection, FollowersModal, FollowersTab, Nip05Badge, NoteCard,
     PhotoCard, PinnedNotesCarousel, ProfileBadgesSection, ProfileEditorModal, VideoCard,
 };
 use crate::hooks::{use_infinite_scroll, use_mute_block_cache};
@@ -109,6 +109,8 @@ pub fn ProfileViewer(pubkey: String) -> Element {
     let mut dm_error = use_signal(|| None::<String>);
     let mut show_info_dialog = use_signal(|| false);
     let mut show_add_to_list_modal = use_signal(|| false);
+    let mut show_followers_modal = use_signal(|| false);
+    let mut followers_modal_tab = use_signal(|| FollowersTab::Following);
     let mut pinned_events = use_signal(Vec::<NostrEvent>::new);
     let mut pinned_loading = use_signal(|| true);
     let mut user_write_relays = use_signal(Vec::<String>::new);
@@ -1078,11 +1080,21 @@ pub fn ProfileViewer(pubkey: String) -> Element {
                         }
                     }
                     div { class: "flex gap-4 mt-3",
-                        div { class: "hover:underline cursor-pointer",
+                        div {
+                            class: "hover:underline cursor-pointer",
+                            onclick: move |_| {
+                                followers_modal_tab.set(FollowersTab::Following);
+                                show_followers_modal.set(true);
+                            },
                             span { class: "font-bold", "{following_count.read()}" }
                             span { class: "text-muted-foreground ml-1", "Following" }
                         }
-                        div { class: "hover:underline cursor-pointer",
+                        div {
+                            class: "hover:underline cursor-pointer",
+                            onclick: move |_| {
+                                followers_modal_tab.set(FollowersTab::Followers);
+                                show_followers_modal.set(true);
+                            },
                             span { class: "font-bold", "{followers_count.read()}" }
                             span { class: "text-muted-foreground ml-1", "Followers" }
                         }
@@ -1117,11 +1129,21 @@ pub fn ProfileViewer(pubkey: String) -> Element {
                         }
                     }
                     div { class: "flex gap-4 mt-3",
-                        div { class: "hover:underline cursor-pointer",
+                        div {
+                            class: "hover:underline cursor-pointer",
+                            onclick: move |_| {
+                                followers_modal_tab.set(FollowersTab::Following);
+                                show_followers_modal.set(true);
+                            },
                             span { class: "font-bold", "{following_count.read()}" }
                             span { class: "text-muted-foreground ml-1", "Following" }
                         }
-                        div { class: "hover:underline cursor-pointer",
+                        div {
+                            class: "hover:underline cursor-pointer",
+                            onclick: move |_| {
+                                followers_modal_tab.set(FollowersTab::Followers);
+                                show_followers_modal.set(true);
+                            },
                             span { class: "font-bold", "{followers_count.read()}" }
                             span { class: "text-muted-foreground ml-1", "Followers" }
                         }
@@ -1359,6 +1381,11 @@ pub fn ProfileViewer(pubkey: String) -> Element {
             }
         }
         ProfileEditorModal { show: show_profile_modal }
+        FollowersModal {
+            pubkey: pubkey.clone(),
+            initial_tab: *followers_modal_tab.read(),
+            open: show_followers_modal,
+        }
         DialogRoot { open: *show_dm_dialog.read(),
             div {
                 class: "fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4",

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -34,7 +34,7 @@ pub use use_lists::{delete_list, use_user_lists, UserList};
 pub use use_mute_block_cache::use_mute_block_cache;
 pub use use_reaction::{format_count, use_reaction, ReactionEmoji, ReactionState, UseReaction};
 #[allow(unused_imports)]
-pub use use_relay_subscription::{use_relay_subscription, use_relay_subscription_opts};
+pub use use_relay_subscription::{use_relay_subscription, use_relay_subscription_opts, use_relay_subscription_to};
 #[allow(unused_imports)]
 pub use use_unsaved_changes::{
     calculate_hash, calculate_multi_hash, use_unsaved_changes, UseUnsavedChanges,

--- a/src/hooks/use_author_metadata.rs
+++ b/src/hooks/use_author_metadata.rs
@@ -1,51 +1,22 @@
-//! Author Metadata Hook
-//!
-//! Reusable hook for fetching author metadata with database-first, network-fallback pattern.
-//! This reduces code duplication across components that need to display author information.
-use crate::stores::nostr_client::get_client;
+use crate::stores::profiles;
 use dioxus::prelude::*;
 use nostr_sdk::prelude::*;
-use std::time::Duration;
-/// Fetch author metadata reactively with database-first, network-fallback pattern.
-///
-/// # Arguments
-/// * `pubkey` - The hex-encoded public key of the author
-///
-/// # Returns
-/// A signal containing the author's metadata, or None if not yet fetched
-///
-/// # Example
-/// ```rust
-/// let metadata = use_author_metadata(author_pubkey.clone());
-/// let display_name = metadata.read().as_ref()
-///     .and_then(|m| m.display_name.clone().or(m.name.clone()))
-///     .unwrap_or_else(|| truncate_pubkey(&author_pubkey));
-/// ```
 pub fn use_author_metadata(pubkey: String) -> Signal<Option<Metadata>> {
     let mut metadata = use_signal(|| None::<Metadata>);
     use_effect(use_reactive!(|pubkey| {
         let pubkey_str = pubkey.clone();
+        if let Some(cached) = profiles::get_profile(&pubkey_str) {
+            metadata.set(Some(cached));
+            return;
+        }
         spawn(async move {
-            let pk = match PublicKey::from_hex(&pubkey_str) {
-                Ok(pk) => pk,
+            match profiles::fetch_profile(pubkey_str).await {
+                Ok(profile) => {
+                    metadata.set(Some(profiles::profile_to_metadata(&profile)));
+                }
                 Err(e) => {
-                    log::warn!("Invalid author pubkey: {}", e);
-                    return;
+                    log::debug!("Failed to fetch profile for author metadata: {}", e);
                 }
-            };
-            let client = match get_client() {
-                Some(c) => c,
-                None => {
-                    log::error!("Client not initialized, cannot fetch author metadata");
-                    return;
-                }
-            };
-            if let Ok(Some(m)) = client.database().metadata(pk).await {
-                metadata.set(Some(m));
-                return;
-            }
-            if let Ok(Some(m)) = client.fetch_metadata(pk, Duration::from_secs(5)).await {
-                metadata.set(Some(m));
             }
         });
     }));

--- a/src/hooks/use_composer_editor.rs
+++ b/src/hooks/use_composer_editor.rs
@@ -69,14 +69,18 @@ pub fn use_composer_editor(config: ComposerConfig) -> UseComposerEditor {
                 }
                 last_draft_save.set(now);
                 if let Some(pk) = auth_store::get_pubkey() {
-                    note_draft_store::save_note_draft(
-                        &pk,
-                        ctx,
-                        &note_draft_store::NoteDraft {
-                            content: text.clone(),
-                            saved_at: now,
-                        },
-                    );
+                    let ctx = ctx.clone();
+                    let text = text.clone();
+                    spawn(async move {
+                        note_draft_store::save_note_draft(
+                            &pk,
+                            &ctx,
+                            &note_draft_store::NoteDraft {
+                                content: text,
+                                saved_at: crate::platform::timestamp::now_secs(),
+                            },
+                        );
+                    });
                 }
             }
         }
@@ -91,14 +95,17 @@ pub fn use_composer_editor(config: ComposerConfig) -> UseComposerEditor {
                 let text = content_clone.peek().clone();
                 if !text.is_empty() {
                     if let Some(pk) = auth_store::get_pubkey() {
-                        note_draft_store::save_note_draft(
-                            &pk,
-                            ctx,
-                            &note_draft_store::NoteDraft {
-                                content: text,
-                                saved_at: crate::platform::timestamp::now_secs(),
-                            },
-                        );
+                        let ctx = ctx.clone();
+                        spawn(async move {
+                            note_draft_store::save_note_draft(
+                                &pk,
+                                &ctx,
+                                &note_draft_store::NoteDraft {
+                                    content: text,
+                                    saved_at: crate::platform::timestamp::now_secs(),
+                                },
+                            );
+                        });
                     }
                 }
             }

--- a/src/hooks/use_global_interaction.rs
+++ b/src/hooks/use_global_interaction.rs
@@ -2,15 +2,17 @@ use crate::services::aggregation::{
     fetch_interaction_counts_batch, fetch_local_db_counts, InteractionCounts,
 };
 use dioxus::prelude::*;
-use std::collections::{HashMap, HashSet};
+use lru::LruCache;
+use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 static INTERACTION_QUEUE: GlobalSignal<HashSet<String>> = Signal::global(HashSet::new);
-static INTERACTION_GLOBAL_CACHE: GlobalSignal<HashMap<String, InteractionCounts>> =
-    Signal::global(HashMap::new);
+static INTERACTION_GLOBAL_CACHE: GlobalSignal<LruCache<String, InteractionCounts>> =
+    Signal::global(|| LruCache::new(NonZeroUsize::new(10_000).unwrap()));
 
 pub fn get_global_interaction(event_id: &str) -> Option<InteractionCounts> {
-    INTERACTION_GLOBAL_CACHE.read().get(event_id).cloned()
+    INTERACTION_GLOBAL_CACHE.read().peek(event_id).cloned()
 }
 
 pub fn enqueue_interaction_fetch(event_id: &str) {
@@ -43,11 +45,17 @@ pub async fn process_interaction_queue() {
 
     let local_counts = fetch_local_db_counts(&parsed).await;
     if !local_counts.is_empty() {
-        INTERACTION_GLOBAL_CACHE.write().extend(local_counts);
+        let mut cache = INTERACTION_GLOBAL_CACHE.write();
+        for (id, counts) in local_counts {
+            cache.put(id, counts);
+        }
     }
 
     if let Ok(counts) = fetch_interaction_counts_batch(parsed, Duration::from_secs(5)).await {
-        INTERACTION_GLOBAL_CACHE.write().extend(counts);
+        let mut cache = INTERACTION_GLOBAL_CACHE.write();
+        for (id, counts) in counts {
+            cache.put(id, counts);
+        }
     }
 }
 

--- a/src/hooks/use_group_subscription.rs
+++ b/src/hooks/use_group_subscription.rs
@@ -1,6 +1,7 @@
 use crate::stores::notification_dispatcher::DispatcherHandle;
 use dioxus::prelude::*;
 use nostr_sdk::prelude::*;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 type OnGroupEvent = Arc<Mutex<Box<dyn FnMut(&nostr::Event)>>>;
@@ -100,6 +101,8 @@ pub fn use_group_subscription(
 ) {
     let mut sub_state: Signal<Option<Arc<GroupSubState>>> = use_signal(|| None);
     let on_event: OnGroupEvent = Arc::new(Mutex::new(Box::new(on_event)));
+    let cancelled = use_hook(|| Arc::new(AtomicBool::new(false)));
+    let cancelled_drop = cancelled.clone();
 
     let relay_url = relay_url.to_string();
     let group_id = group_id.to_string();
@@ -108,6 +111,7 @@ pub fn use_group_subscription(
         let on_event = on_event.clone();
         let relay_url = relay_url.clone();
         let group_id = group_id.clone();
+        let cancelled = cancelled.clone();
         spawn(async move {
             let old_sub = sub_state.peek().clone();
             sub_state.set(None);
@@ -127,6 +131,10 @@ pub fn use_group_subscription(
                 }
             }
 
+            if cancelled.load(Ordering::Relaxed) {
+                return;
+            }
+
             let client = match crate::stores::nostr_client::get_client() {
                 Some(c) => c,
                 None => return,
@@ -134,6 +142,10 @@ pub fn use_group_subscription(
 
             let _ = client.add_relay(&relay_url).await;
             let _ = client.connect_relay(&relay_url).await;
+
+            if cancelled.load(Ordering::Relaxed) {
+                return;
+            }
 
             let filter =
                 crate::stores::social::group_store::group_subscription_filter(&group_id);
@@ -160,6 +172,17 @@ pub fn use_group_subscription(
                         );
                     }
 
+                    if cancelled.load(Ordering::Relaxed) {
+                        if let Some(handle) = handle {
+                            spawn(async move {
+                                handle.unregister().await;
+                            });
+                        } else {
+                            let _ = client.unsubscribe(&sub_id).await;
+                        }
+                        return;
+                    }
+
                     sub_state.set(Some(Arc::new(GroupSubState {
                         sub_id: sub_id.clone(),
                         client: client.clone(),
@@ -174,6 +197,7 @@ pub fn use_group_subscription(
     });
 
     use_drop(move || {
+        cancelled_drop.store(true, Ordering::Relaxed);
         if let Some(old) = sub_state() {
             if let Ok(s) = Arc::try_unwrap(old) {
                 if let Some(handle) = s.handle {

--- a/src/hooks/use_nest_audio.rs
+++ b/src/hooks/use_nest_audio.rs
@@ -5,11 +5,20 @@ pub async fn join_room(
     auth_url: &str,
     relay_url: &str,
     namespace: &str,
+    my_pubkey: &str,
 ) -> Result<(), String> {
-    let jwt = crate::services::nests_audio::authenticate_with_nest(auth_url).await?;
+    let jwt =
+        crate::services::nests_audio::authenticate_with_nest(auth_url, namespace, false).await?;
     crate::services::nests_audio::js_init(publisher_id).await?;
-    crate::services::nests_audio::js_connect(publisher_id, auth_url, relay_url, namespace, &jwt)
-        .await?;
+    crate::services::nests_audio::js_connect(
+        publisher_id,
+        auth_url,
+        relay_url,
+        namespace,
+        &jwt,
+        my_pubkey,
+    )
+    .await?;
     Ok(())
 }
 
@@ -18,6 +27,7 @@ pub async fn join_room_with_retry(
     auth_url: &str,
     relay_url: &str,
     namespace: &str,
+    my_pubkey: &str,
     max_retries: u32,
 ) -> Result<(), String> {
     let mut last_error = String::new();
@@ -26,7 +36,7 @@ pub async fn join_room_with_retry(
             let delay_ms: u32 = (1000u64 * 2u64.pow(attempt)).min(30_000) as u32;
             crate::platform::timer::sleep_ms(delay_ms).await;
         }
-        match join_room(publisher_id, auth_url, relay_url, namespace).await {
+        match join_room(publisher_id, auth_url, relay_url, namespace, my_pubkey).await {
             Ok(()) => return Ok(()),
             Err(e) => {
                 last_error = e;

--- a/src/hooks/use_relay_subscription.rs
+++ b/src/hooks/use_relay_subscription.rs
@@ -50,10 +50,20 @@ pub fn use_relay_subscription_opts(
     close_opts: Option<SubscribeAutoCloseOptions>,
     on_event: impl FnMut(&nostr::Event) + 'static,
 ) {
+    use_relay_subscription_to(filter, close_opts, Vec::<String>::new(), on_event);
+}
+
+#[allow(clippy::arc_with_non_send_sync)]
+pub fn use_relay_subscription_to(
+    filter: Option<Filter>,
+    close_opts: Option<SubscribeAutoCloseOptions>,
+    relay_urls: Vec<String>,
+    on_event: impl FnMut(&nostr::Event) + 'static,
+) {
     let mut sub_state: Signal<Option<Arc<SubState>>> = use_signal(|| None);
     let on_event: OnEvent = Arc::new(Mutex::new(Box::new(on_event)));
 
-    use_effect(use_reactive!(|filter| {
+    use_effect(use_reactive!(|filter, relay_urls| {
         let on_event = on_event.clone();
         spawn(async move {
             let old_sub = sub_state.peek().clone();
@@ -84,7 +94,18 @@ pub fn use_relay_subscription_opts(
                 None => return,
             };
 
-            match client.subscribe(filter, close_opts).await {
+            let urls: Vec<nostr::Url> = relay_urls
+                .iter()
+                .filter_map(|u| nostr::Url::parse(u).ok())
+                .collect();
+
+            let result = if urls.is_empty() {
+                client.subscribe(filter, close_opts).await
+            } else {
+                client.subscribe_to(urls, filter, close_opts).await
+            };
+
+            match result {
                 Ok(output) => {
                     let sub_id = output.val;
 

--- a/src/hooks/use_relay_subscription.rs
+++ b/src/hooks/use_relay_subscription.rs
@@ -3,6 +3,7 @@ use crate::stores::notification_dispatcher::DispatcherHandle;
 use dioxus::prelude::*;
 use nostr_sdk::prelude::*;
 use nostr_sdk::{Client, SubscribeAutoCloseOptions, SubscriptionId};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 type OnEvent = Arc<Mutex<Box<dyn FnMut(&nostr::Event)>>>;
@@ -62,9 +63,12 @@ pub fn use_relay_subscription_to(
 ) {
     let mut sub_state: Signal<Option<Arc<SubState>>> = use_signal(|| None);
     let on_event: OnEvent = Arc::new(Mutex::new(Box::new(on_event)));
+    let cancelled = use_hook(|| Arc::new(AtomicBool::new(false)));
+    let cancelled_drop = cancelled.clone();
 
     use_effect(use_reactive!(|filter, relay_urls| {
         let on_event = on_event.clone();
+        let cancelled = cancelled.clone();
         spawn(async move {
             let old_sub = sub_state.peek().clone();
             sub_state.set(None);
@@ -82,6 +86,10 @@ pub fn use_relay_subscription_to(
                         let _ = arc.client.unsubscribe(&arc.sub_id).await;
                     }
                 }
+            }
+
+            if cancelled.load(Ordering::Relaxed) {
+                return;
             }
 
             let filter = match filter {
@@ -105,6 +113,13 @@ pub fn use_relay_subscription_to(
                 client.subscribe_to(urls, filter, close_opts).await
             };
 
+            if cancelled.load(Ordering::Relaxed) {
+                if let Ok(output) = result {
+                    let _ = client.unsubscribe(&output.val).await;
+                }
+                return;
+            }
+
             match result {
                 Ok(output) => {
                     let sub_id = output.val;
@@ -117,6 +132,17 @@ pub fn use_relay_subscription_to(
 
                     if handle.is_none() {
                         spawn_fallback_listener(client.clone(), sub_id.clone(), on_event.clone());
+                    }
+
+                    if cancelled.load(Ordering::Relaxed) {
+                        if let Some(handle) = handle {
+                            spawn(async move {
+                                handle.unregister().await;
+                            });
+                        } else {
+                            let _ = client.unsubscribe(&sub_id).await;
+                        }
+                        return;
                     }
 
                     sub_state.set(Some(Arc::new(SubState {
@@ -133,6 +159,7 @@ pub fn use_relay_subscription_to(
     }));
 
     use_drop(move || {
+        cancelled_drop.store(true, Ordering::Relaxed);
         if let Some(old) = sub_state() {
             if let Ok(s) = Arc::try_unwrap(old) {
                 if let Some(handle) = s.handle {

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,32 +117,19 @@ fn App() -> Element {
             }
         });
     });
-    use_effect(move || {
-        let connected = *nostr_client::RELAY_CONNECTED.read();
-        if connected {
-            let sidebar_state = sidebar_store::SIDEBAR_STATE.read();
-            let reactions_state = reactions_store::REACTIONS_STATE.read();
-            let sidebar_failed = sidebar_state.is_failed();
-            let reactions_failed = reactions_state.is_failed();
-            if sidebar_failed || reactions_failed {
-                log::info!("Relay connected, retrying failed NIP-78 loads");
-                spawn(async move {
-                    if sidebar_failed {
-                        sidebar_store::load_sidebar_preferences().await;
-                    }
-                    if reactions_failed {
-                        reactions_store::load_preferred_reactions().await;
-                    }
-                });
+    use_effect(use_reactive(
+        (
+            &*nostr_client::RELAY_CONNECTED.read(),
+            &auth_store::AUTH_STATE.read().is_authenticated,
+        ),
+        move |(connected, is_authenticated)| {
+            if !connected || !is_authenticated {
+                return;
             }
-        }
-    });
-    use_effect(move || {
-        let is_authenticated = auth_store::AUTH_STATE.read().is_authenticated;
-        if is_authenticated {
             let sidebar_failed = sidebar_store::SIDEBAR_STATE.read().is_failed();
             let reactions_failed = reactions_store::REACTIONS_STATE.read().is_failed();
             if sidebar_failed || reactions_failed {
+                log::info!("Retrying failed NIP-78 loads");
                 spawn(async move {
                     if sidebar_store::SIDEBAR_STATE.peek().is_failed() {
                         sidebar_store::load_sidebar_preferences().await;
@@ -152,8 +139,8 @@ fn App() -> Element {
                     }
                 });
             }
-        }
-    });
+        },
+    ));
     let tailwind_css: Option<Asset> = option_asset!("/public/tailwind.css");
     rsx! {
         if let Some(css) = tailwind_css {

--- a/src/routes/blossom/blossom_home.rs
+++ b/src/routes/blossom/blossom_home.rs
@@ -272,7 +272,7 @@ pub fn BlossomPage() -> Element {
                 ServerList {
                     servers: servers.clone(),
                     on_add_server: move |url: String| {
-                        blossom_store::add_server(url);
+                        let _ = blossom_store::add_server(url);
                     },
                     on_remove_server: move |url: String| {
                         blossom_store::remove_server(&url);
@@ -1018,34 +1018,7 @@ fn UploadModal(on_close: EventHandler<()>, on_upload_complete: EventHandler<()>)
 }
 /// Validate and normalize a server URL
 fn validate_and_normalize_server_url(input: &str) -> Result<String, String> {
-    let trimmed = input.trim();
-    if trimmed.is_empty() {
-        return Err("URL cannot be empty".to_string());
-    }
-    let url_str = if !trimmed.starts_with("http://") && !trimmed.starts_with("https://") {
-        format!("https://{}", trimmed)
-    } else {
-        trimmed.to_string()
-    };
-    let url = url::Url::parse(&url_str).map_err(|e| format!("Invalid URL: {}", e))?;
-    if url.scheme() != "http" && url.scheme() != "https" {
-        return Err("URL must use http or https".to_string());
-    }
-    if url_str.matches("://").count() > 1 {
-        return Err("URL must not contain multiple scheme separators".to_string());
-    }
-    if !url.username().is_empty() || url.password().is_some() {
-        return Err("URL must not contain embedded credentials".to_string());
-    }
-    let host = url.host_str().ok_or("URL must have a host")?;
-    if host.is_empty() {
-        return Err("URL must have a host".to_string());
-    }
-    let mut normalized = format!("{}://{}", url.scheme(), host);
-    if let Some(port) = url.port() {
-        normalized.push_str(&format!(":{}", port));
-    }
-    Ok(normalized)
+    crate::utils::validation::validate_blossom_server_url(input)
 }
 /// Server list component for the Servers tab
 #[component]

--- a/src/routes/home/feed_loaders.rs
+++ b/src/routes/home/feed_loaders.rs
@@ -13,17 +13,18 @@ use std::time::Duration;
 const SINCE_BUFFER_SECS: u64 = 120;
 const RELAY_FEED_LIMIT: usize = 33;
 pub const FEED_LIMIT: usize = 33;
+#[cfg(feature = "native")]
+const NDB_FEED_LIMIT: usize = 200;
 
-fn resolve_since(adaptive_since: u64, cached_cursor: Option<u64>, cached_count: usize, feed_limit: usize) -> Option<u64> {
+fn resolve_since(adaptive_since: u64, cached_cursor: Option<u64>) -> Option<u64> {
     let eose_since = crate::stores::eose_tracker::EoseTracker::get_min_since();
-    match (eose_since, cached_cursor, cached_count) {
-        (_, _, count) if count > 0 && count < feed_limit => None,
-        (Some(eose), _, _) => Some(std::cmp::min(eose, adaptive_since)),
-        (None, Some(cursor), _) => {
+    match (eose_since, cached_cursor) {
+        (Some(eose), _) => Some(std::cmp::min(eose, adaptive_since)),
+        (None, Some(cursor)) => {
             let cursor_since = cursor.saturating_sub(SINCE_BUFFER_SECS);
             Some(std::cmp::min(cursor_since, adaptive_since))
         }
-        (None, None, _) => Some(adaptive_since),
+        (None, None) => Some(adaptive_since),
     }
 }
 
@@ -47,6 +48,7 @@ pub fn adaptive_since_window(author_count: usize) -> u64 {
     }
 }
 
+#[allow(dead_code)]
 pub fn exclusive_pagination_cursor(item: Option<&FeedItem>) -> Option<u64> {
     item.map(|entry| entry.sort_timestamp().as_secs())
 }
@@ -55,10 +57,6 @@ pub fn merge_paginated_feed_items(
     current: Vec<FeedItem>,
     fetched_page: Vec<FeedItem>,
 ) -> (Vec<FeedItem>, Vec<FeedItem>, Option<u64>) {
-    let next_cursor = fetched_page
-        .iter()
-        .min_by_key(|item| item.sort_timestamp())
-        .and_then(|item| exclusive_pagination_cursor(Some(item)));
     let existing_ids: HashSet<_> = current.iter().map(|item| item.event().id).collect();
     let unique_items: Vec<FeedItem> = fetched_page
         .into_iter()
@@ -67,10 +65,12 @@ pub fn merge_paginated_feed_items(
     let mut updated = current;
     updated.extend(unique_items.iter().cloned());
     updated.sort_by_key(|item| std::cmp::Reverse(item.sort_timestamp()));
+    let timestamps: Vec<u64> = updated.iter().map(|i| i.sort_timestamp().as_secs()).collect();
+    let next_cursor = crate::utils::pagination::safe_cursor_from_timestamps(&timestamps);
     (updated, unique_items, next_cursor)
 }
 
-pub fn build_global_feed_filter(until: Option<u64>, cached_cursor: Option<u64>, cached_count: usize) -> Filter {
+pub fn build_global_feed_filter(until: Option<u64>, cached_cursor: Option<u64>) -> Filter {
     let mut filter = Filter::new()
         .kinds(feed_kinds())
         .limit(FEED_LIMIT);
@@ -78,7 +78,7 @@ pub fn build_global_feed_filter(until: Option<u64>, cached_cursor: Option<u64>, 
         filter = filter.until(Timestamp::from(until_ts));
     } else {
         let adaptive_since = Timestamp::now().as_secs().saturating_sub(86400);
-        if let Some(since) = resolve_since(adaptive_since, cached_cursor, cached_count, FEED_LIMIT) {
+        if let Some(since) = resolve_since(adaptive_since, cached_cursor) {
             filter = filter.since(Timestamp::from(since));
         }
     }
@@ -90,7 +90,6 @@ pub fn build_following_feed_filter(
     until: Option<u64>,
     now: Timestamp,
     cached_cursor: Option<u64>,
-    cached_count: usize,
 ) -> Filter {
     let author_count = authors.len();
     let mut filter = Filter::new()
@@ -103,7 +102,7 @@ pub fn build_following_feed_filter(
     } else {
         let window = adaptive_since_window(author_count);
         let adaptive_since = now.as_secs().saturating_sub(window);
-        if let Some(since) = resolve_since(adaptive_since, cached_cursor, cached_count, FEED_LIMIT) {
+        if let Some(since) = resolve_since(adaptive_since, cached_cursor) {
             filter = filter.since(Timestamp::from(since));
         }
     }
@@ -116,7 +115,7 @@ pub async fn sync_global_feed_page(until: Option<u64>) {
         log::debug!("Skipping global feed negentropy sync: client unavailable");
         return;
     };
-    let filter = build_global_feed_filter(until, None, 0);
+    let filter = build_global_feed_filter(until, None);
     let sync_opts = SyncOptions::default()
         .direction(SyncDirection::Down)
         .initial_timeout(Duration::from_secs(5));
@@ -181,7 +180,7 @@ pub async fn load_paginated_global_feed(
 pub async fn load_following_feed(
     until: Option<u64>,
     cached_cursor: Option<u64>,
-    cached_count: usize,
+    _cached_count: usize,
 ) -> Result<(Vec<FeedItem>, bool), NostrBlueError> {
     let pubkey_str = auth_store::get_pubkey().ok_or(NostrBlueError::NotAuthenticated)?;
     log::info!(
@@ -217,7 +216,7 @@ pub async fn load_following_feed(
         let global = load_global_feed(until, None, 0).await?;
         return Ok((global, true));
     }
-    let filter = build_following_feed_filter(authors.clone(), until, Timestamp::now(), cached_cursor, cached_count);
+    let filter = build_following_feed_filter(authors.clone(), until, Timestamp::now(), cached_cursor);
     log::info!(
         "Fetching events from {} followed accounts",
         filter.authors.as_ref().map(|a| a.len()).unwrap_or(0)
@@ -332,7 +331,7 @@ async fn try_feed_from_favorite_relays(
         Some(c) => c,
         None => return Ok(Vec::new()),
     };
-    let filter = build_following_feed_filter(authors.to_vec(), until, Timestamp::now(), None, 0);
+    let filter = build_following_feed_filter(authors.to_vec(), until, Timestamp::now(), None);
     match client
         .fetch_events_from(relay_urls, filter, std::time::Duration::from_secs(8))
         .await
@@ -377,7 +376,7 @@ async fn try_feed_from_favorite_relays(
 pub async fn load_following_feed_streaming<F>(
     until: Option<u64>,
     cached_cursor: Option<u64>,
-    cached_count: usize,
+    _cached_count: usize,
     mut on_batch: F,
 ) -> Result<(Vec<FeedItem>, bool), NostrBlueError>
 where
@@ -418,14 +417,15 @@ where
         let global = load_global_feed(until, None, 0).await?;
         return Ok((global, true));
     }
-    let filter = build_following_feed_filter(authors, until, Timestamp::now(), cached_cursor, cached_count);
+    let filter = build_following_feed_filter(authors, until, Timestamp::now(), cached_cursor);
     let mut all_items: Vec<FeedItem> = Vec::new();
     let mut seen_ids: HashSet<nostr_sdk::EventId> = HashSet::new();
 
     #[cfg(feature = "native")]
     {
         if let Some(client) = nostr_client::get_client() {
-            if let Ok(db_events) = client.database().query(filter.clone()).await {
+            let ndb_filter = filter.clone().limit(NDB_FEED_LIMIT);
+            if let Ok(db_events) = client.database().query(ndb_filter).await {
                 if !db_events.is_empty() {
                     let db_items = process_events_to_feed_items(db_events.into_iter().collect());
                     log::info!("nostrdb pre-step: {} items for feed", db_items.len());
@@ -500,7 +500,7 @@ where
 pub async fn load_following_with_replies(
     until: Option<u64>,
     cached_cursor: Option<u64>,
-    cached_count: usize,
+    _cached_count: usize,
 ) -> Result<(Vec<FeedItem>, bool), NostrBlueError> {
     let pubkey_str = auth_store::get_pubkey().ok_or(NostrBlueError::NotAuthenticated)?;
     log::info!(
@@ -545,7 +545,7 @@ pub async fn load_following_with_replies(
     } else {
         let window = adaptive_since_window(authors.len());
         let adaptive_since = Timestamp::now().as_secs().saturating_sub(window);
-        if let Some(since) = resolve_since(adaptive_since, cached_cursor, cached_count, FEED_LIMIT) {
+        if let Some(since) = resolve_since(adaptive_since, cached_cursor) {
             filter = filter.since(Timestamp::from(since));
         }
     }
@@ -627,9 +627,9 @@ pub async fn load_following_with_replies(
     }
 }
 
-pub async fn load_global_feed(until: Option<u64>, cached_cursor: Option<u64>, cached_count: usize) -> Result<Vec<FeedItem>, NostrBlueError> {
+pub async fn load_global_feed(until: Option<u64>, cached_cursor: Option<u64>, _cached_count: usize) -> Result<Vec<FeedItem>, NostrBlueError> {
     log::info!("Loading global feed (until: {:?})...", until);
-    let filter = build_global_feed_filter(until, cached_cursor, cached_count);
+    let filter = build_global_feed_filter(until, cached_cursor);
     log::info!("Fetching events with filter: {:?}", filter);
     match nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10)).await {
         Ok(events) => {
@@ -748,14 +748,13 @@ pub async fn load_people_list_feed(
     list: &UserList,
     until: Option<u64>,
     cached_cursor: Option<u64>,
-    cached_count: usize,
+    _cached_count: usize,
 ) -> Result<Vec<FeedItem>, NostrBlueError> {
     log::info!(
-        "Loading people list feed for '{}' (until: {:?}, cursor: {:?}, count: {})",
+        "Loading people list feed for '{}' (until: {:?}, cursor: {:?})",
         list.name,
         until,
-        cached_cursor,
-        cached_count
+        cached_cursor
     );
     let members = get_all_list_members(&list.event).await.map_err(|e| {
         log::error!("Failed to get list members: {}", e);
@@ -779,7 +778,7 @@ pub async fn load_people_list_feed(
     } else {
         let window = adaptive_since_window(member_count);
         let adaptive_since = Timestamp::now().as_secs().saturating_sub(window);
-        if let Some(since) = resolve_since(adaptive_since, cached_cursor, cached_count, FEED_LIMIT) {
+        if let Some(since) = resolve_since(adaptive_since, cached_cursor) {
             filter = filter.since(Timestamp::from(since));
         }
     }
@@ -830,9 +829,9 @@ pub async fn load_relay_feed(
     relay_urls: Vec<String>,
     until: Option<u64>,
     cached_cursor: Option<u64>,
-    cached_count: usize,
+    _cached_count: usize,
 ) -> Result<Vec<FeedItem>, NostrBlueError> {
-    log::info!("Loading relay feed from {} relays (until: {:?}, cursor: {:?}, count: {})", relay_urls.len(), until, cached_cursor, cached_count);
+    log::info!("Loading relay feed from {} relays (until: {:?}, cursor: {:?})", relay_urls.len(), until, cached_cursor);
     let client = match crate::stores::nostr_client::get_client() {
         Some(c) => c,
         None => return Err(NostrBlueError::Other("Client not initialized".to_string())),
@@ -859,7 +858,7 @@ pub async fn load_relay_feed(
         filter = filter.until(Timestamp::from(until_ts));
     } else {
         let adaptive_since = Timestamp::now().as_secs().saturating_sub(86400);
-        if let Some(since) = resolve_since(adaptive_since, cached_cursor, cached_count, RELAY_FEED_LIMIT) {
+        if let Some(since) = resolve_since(adaptive_since, cached_cursor) {
             filter = filter.since(Timestamp::from(since));
         }
     }
@@ -932,7 +931,7 @@ mod tests {
         let now = Timestamp::from(200_000);
         let author = test_author();
 
-        let filter = build_following_feed_filter(vec![author], None, now, None, 0);
+        let filter = build_following_feed_filter(vec![author], None, now, None);
 
         assert_eq!(filter.authors.as_ref().map(|a| a.len()), Some(1));
         assert_eq!(filter.limit, Some(FEED_LIMIT));
@@ -948,7 +947,7 @@ mod tests {
         let now = Timestamp::from(200_000);
         let author = test_author();
 
-        let filter = build_following_feed_filter(vec![author], Some(123_456), now, None, 0);
+        let filter = build_following_feed_filter(vec![author], Some(123_456), now, None);
 
         assert_eq!(filter.authors.as_ref().map(|a| a.len()), Some(1));
         assert_eq!(filter.limit, Some(FEED_LIMIT));
@@ -971,7 +970,7 @@ mod tests {
             .map(|item| item.sort_timestamp().as_secs())
             .collect();
         assert_eq!(timestamps, vec![200, 175, 150, 125]);
-        assert_eq!(next_cursor, Some(125));
+        assert_eq!(next_cursor, Some(124));
     }
 
     #[test]
@@ -988,7 +987,7 @@ mod tests {
             .map(|item| item.sort_timestamp().as_secs())
             .collect();
         assert_eq!(timestamps, vec![120, 100, 90]);
-        assert_eq!(next_cursor, Some(90));
+        assert_eq!(next_cursor, Some(89));
     }
 
     #[test]

--- a/src/routes/home/mod.rs
+++ b/src/routes/home/mod.rs
@@ -52,6 +52,7 @@ pub fn Home(list: String) -> Element {
     let mut interaction_stream_handle: Signal<Option<InteractionStreamHandle>> =
         use_signal(|| None);
     let mut stale = use_stale_guard();
+    let mut realtime_stale = use_stale_guard();
     let mut last_loaded_trigger = use_signal(|| (0u32, FeedType::Following, false));
     let mut relay_feed_sub_id: Signal<Option<nostr_sdk::SubscriptionId>> =
         use_signal(|| None);
@@ -882,6 +883,8 @@ pub fn Home(list: String) -> Element {
             _ => Timestamp::now(),
         };
         realtime_started.set(true);
+        let rt_token = realtime_stale.bump();
+        let rt_stale = realtime_stale;
         spawn(async move {
             if current_feed_type.is_relay_feed() {
                 let urls = current_feed_type.relay_urls();
@@ -925,7 +928,13 @@ pub fn Home(list: String) -> Element {
                 let mut pending = pending_posts;
                 let fstate = feed_state;
                 let mut notifications = client.notifications();
-                while let Ok(notification) = notifications.recv().await {
+                loop {
+                    if rt_stale.is_stale(rt_token) {
+                        break;
+                    }
+                    let Ok(notification) = notifications.recv().await else {
+                        break;
+                    };
                     if let nostr_sdk::RelayPoolNotification::Event {
                         subscription_id: event_sub_id,
                         event,
@@ -1013,9 +1022,17 @@ pub fn Home(list: String) -> Element {
                 let fstate = feed_state;
                 let ftype = current_feed_type.clone();
                 let client_for_listener = client.clone();
+                let rt_stale_inner = rt_stale;
+                let rt_token_inner = rt_token;
                 spawn(async move {
                     let mut notifications = client_for_listener.notifications();
-                    while let Ok(notification) = notifications.recv().await {
+                    loop {
+                        if rt_stale_inner.is_stale(rt_token_inner) {
+                            break;
+                        }
+                        let Ok(notification) = notifications.recv().await else {
+                            break;
+                        };
                         if let nostr_sdk::RelayPoolNotification::Event {
                             subscription_id: event_sub_id,
                             event,

--- a/src/routes/home/mod.rs
+++ b/src/routes/home/mod.rs
@@ -19,7 +19,7 @@ use crate::utils::{get_item_count, DataState, FeedItem};
 use dioxus::prelude::*;
 use engagement::{fetch_and_stream_interactions, fetch_paginated_interactions};
 use feed_loaders::{
-    exclusive_pagination_cursor, feed_kinds, merge_paginated_feed_items, prefetch_author_metadata,
+    feed_kinds, merge_paginated_feed_items, prefetch_author_metadata,
     prefetch_author_metadata_with_relays,
     load_following_feed, load_following_feed_streaming, load_following_with_replies,
     load_global_feed, load_paginated_global_feed, load_people_list_feed, load_relay_feed,
@@ -360,8 +360,9 @@ pub fn Home(list: String) -> Element {
                             };
                             has_more.set(true);
                             accumulated_items = feed_cache::merge_feed_items(accumulated_items, feed_items.clone());
-                            if let Some(last_item) = accumulated_items.last() {
-                                oldest_timestamp.set(exclusive_pagination_cursor(Some(last_item)));
+                            {
+                                let timestamps: Vec<u64> = accumulated_items.iter().map(|i| i.sort_timestamp().as_secs()).collect();
+                                oldest_timestamp.set(crate::utils::pagination::safe_cursor_from_timestamps(&timestamps));
                             }
                             prefetch_author_metadata(&accumulated_items).await;
                             feed_state.set(DataState::Loaded(accumulated_items.clone()));
@@ -480,8 +481,9 @@ pub fn Home(list: String) -> Element {
                             };
                             has_more.set(true);
                             let merged = feed_cache::merge_feed_items(cached_items, feed_items.clone());
-                            if let Some(last_item) = merged.last() {
-                                oldest_timestamp.set(exclusive_pagination_cursor(Some(last_item)));
+                            {
+                                let timestamps: Vec<u64> = merged.iter().map(|i| i.sort_timestamp().as_secs()).collect();
+                                oldest_timestamp.set(crate::utils::pagination::safe_cursor_from_timestamps(&timestamps));
                             }
                             feed_state.set(DataState::Loaded(merged.clone()));
                             if !is_stale() {
@@ -571,8 +573,9 @@ pub fn Home(list: String) -> Element {
                     }
                     match result {
                         Ok(feed_items) => {
-                            if let Some(last_item) = feed_items.last() {
-                                oldest_timestamp.set(exclusive_pagination_cursor(Some(last_item)));
+                            {
+                                let timestamps: Vec<u64> = feed_items.iter().map(|i| i.sort_timestamp().as_secs()).collect();
+                                oldest_timestamp.set(crate::utils::pagination::safe_cursor_from_timestamps(&timestamps));
                             }
                             has_more.set(true);
                             feed_state.set(DataState::Loaded(feed_items.clone()));
@@ -664,8 +667,9 @@ pub fn Home(list: String) -> Element {
                     }
                     match result {
                         Ok(feed_items) => {
-                            if let Some(last_item) = feed_items.last() {
-                                oldest_timestamp.set(exclusive_pagination_cursor(Some(last_item)));
+                            {
+                                let timestamps: Vec<u64> = feed_items.iter().map(|i| i.sort_timestamp().as_secs()).collect();
+                                oldest_timestamp.set(crate::utils::pagination::safe_cursor_from_timestamps(&timestamps));
                             }
                             has_more.set(true);
                             feed_state.set(DataState::Loaded(feed_items.clone()));
@@ -745,8 +749,9 @@ pub fn Home(list: String) -> Element {
                     }
                     match result {
                         Ok(feed_items) => {
-                            if let Some(last_item) = feed_items.last() {
-                                oldest_timestamp.set(exclusive_pagination_cursor(Some(last_item)));
+                            {
+                                let timestamps: Vec<u64> = feed_items.iter().map(|i| i.sort_timestamp().as_secs()).collect();
+                                oldest_timestamp.set(crate::utils::pagination::safe_cursor_from_timestamps(&timestamps));
                             }
                             has_more.set(true);
                             feed_state.set(DataState::Loaded(feed_items.clone()));
@@ -1242,6 +1247,8 @@ pub fn Home(list: String) -> Element {
                         } else {
                             None
                         }
+                    } else if event.kind.as_u16() == crate::utils::nip_bb::KIND_BLOBBI_STATE {
+                        Some(FeedItem::OriginalPost(event))
                     } else {
                         None
                     };

--- a/src/routes/settings/home.rs
+++ b/src/routes/settings/home.rs
@@ -67,15 +67,15 @@ pub fn Settings() -> Element {
             server_error.set(Some("Please enter a server URL".to_string()));
             return;
         }
-        if !server_url.starts_with("https://") && !server_url.starts_with("http://") {
-            server_error.set(Some(
-                "Server URL must start with http:// or https://".to_string(),
-            ));
-            return;
+        match blossom_store::add_server(server_url) {
+            Ok(_) => {
+                new_server_input.set(String::new());
+                server_error.set(None);
+            }
+            Err(e) => {
+                server_error.set(Some(e));
+            }
         }
-        blossom_store::add_server(server_url);
-        new_server_input.set(String::new());
-        server_error.set(None);
     };
     let remove_blossom_server = move |url: String| {
         blossom_store::remove_server(&url);

--- a/src/routes/topics/browse.rs
+++ b/src/routes/topics/browse.rs
@@ -1,7 +1,9 @@
-//! Topics Browse Page
-//! Grid of TopicCards for discovery with search and subscribe
 use crate::components::TopicCard;
-use crate::stores::topic_store::{discover_topics, is_topic_subscribed, TopicInfo};
+use crate::hooks::use_stale_guard;
+use crate::stores::nostr_client::CLIENT_INITIALIZED;
+use crate::stores::topic_store::{
+    discover_topics, is_topic_subscribed, query_discover_topics_from_db, TopicInfo,
+};
 use dioxus::prelude::*;
 
 #[component]
@@ -9,14 +11,45 @@ pub fn TopicsBrowse() -> Element {
     let mut topics = use_signal(Vec::<TopicInfo>::new);
     let mut search_query = use_signal(String::new);
     let mut loading = use_signal(|| true);
+    let mut loading_new = use_signal(|| false);
+    let mut stale = use_stale_guard();
 
-    // Fetch discovered topics
-    let _resource = use_resource(move || async move {
-        loading.set(true);
-        if let Ok(discovered) = discover_topics(50).await {
-            topics.set(discovered);
+    use_effect(move || {
+        let client_initialized = *CLIENT_INITIALIZED.read();
+        if !client_initialized {
+            return;
         }
-        loading.set(false);
+        let token = stale.bump();
+        loading.set(true);
+        loading_new.set(false);
+
+        spawn(async move {
+            if stale.is_stale(token) {
+                return;
+            }
+
+            let db_topics = query_discover_topics_from_db(50).await;
+            if stale.is_stale(token) {
+                return;
+            }
+            if !db_topics.is_empty() {
+                topics.set(db_topics);
+                loading.set(false);
+                loading_new.set(true);
+            }
+
+            if stale.is_stale(token) {
+                return;
+            }
+            if let Ok(discovered) = discover_topics(50).await {
+                if stale.is_stale(token) {
+                    return;
+                }
+                topics.set(discovered);
+            }
+            loading.set(false);
+            loading_new.set(false);
+        });
     });
 
     let query = search_query.read().to_lowercase();
@@ -41,10 +74,33 @@ pub fn TopicsBrowse() -> Element {
                     oninput: move |e| search_query.set(e.value()),
                 }
             }
-            if *loading.read() {
+            if *loading.read() && topics.read().is_empty() {
                 div {
                     class: "flex justify-center py-12",
                     span { class: "inline-block w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin" }
+                }
+            } else if *loading_new.read() && !topics.read().is_empty() {
+                div {
+                    class: "flex flex-col gap-3",
+                    div {
+                        class: "sticky top-[57px] z-20 border-b border-border bg-muted/80 backdrop-blur-sm",
+                        div { class: "px-4 py-2 text-center",
+                            span { class: "inline-flex items-center gap-2 text-sm text-muted-foreground",
+                                span { class: "inline-block w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" }
+                                "Loading new topics..."
+                            }
+                        }
+                    }
+                    div {
+                        class: "grid grid-cols-1 md:grid-cols-2 gap-3",
+                        for info in &filtered {
+                            TopicCard {
+                                key: "{info.name}",
+                                topic_info: info.clone(),
+                                is_subscribed: is_topic_subscribed(&info.name),
+                            }
+                        }
+                    }
                 }
             } else if filtered.is_empty() {
                 div {

--- a/src/routes/topics/home.rs
+++ b/src/routes/topics/home.rs
@@ -247,18 +247,7 @@ pub fn TopicsHome() -> Element {
 
     let mut accept_pending_posts = move || {
         let pending: Vec<TopicPost> = pending_posts.write().drain(..).collect();
-        if pending.is_empty() {
-            return;
-        }
-        let mut current = posts.read().clone();
-        let existing: HashSet<String> = current.iter().map(|p| p.id.clone()).collect();
-        for p in pending {
-            if !existing.contains(&p.id) {
-                current.push(p);
-            }
-        }
-        current.sort_by_key(|b| std::cmp::Reverse(b.created_at));
-        posts.set(current);
+        crate::stores::social::topic_store::merge_pending_posts(posts, pending);
     };
 
     let load_more = move || {

--- a/src/routes/topics/home.rs
+++ b/src/routes/topics/home.rs
@@ -177,9 +177,17 @@ pub fn TopicsHome() -> Element {
                         let mut pending = pending_posts;
                         let current_posts = posts;
                         let _current_votes = vote_counts;
+                        let stale_check = stale;
+                        let stale_token = token;
                         spawn(async move {
                             let mut notifications = client.notifications();
-                            while let Ok(notification) = notifications.recv().await {
+                            loop {
+                                if stale_check.is_stale(stale_token) {
+                                    break;
+                                }
+                                let Ok(notification) = notifications.recv().await else {
+                                    break;
+                                };
                                 if let RelayPoolNotification::Event {
                                     subscription_id: event_sub_id,
                                     event,

--- a/src/routes/topics/home.rs
+++ b/src/routes/topics/home.rs
@@ -1,12 +1,13 @@
-//! Topics Home Page
-//! Tabs: "Your Feed" (subscribed topics) / "Recent" (all topics)
 use crate::components::TopicPostCard;
-use crate::hooks::use_infinite_scroll;
+use crate::hooks::{use_infinite_scroll, use_stale_guard};
 use crate::stores::auth_store;
+use crate::stores::nostr_client::{self, CLIENT_INITIALIZED};
 use crate::stores::profiles::prefetch_profiles;
+use crate::stores::subscription_manager;
 use crate::stores::topic_store::{
     fetch_recent_posts, fetch_subscribed_feed, fetch_subscriptions, fetch_votes_batch,
-    get_subscribed_topic_names, TopicPost, VoteCounts, LOADING_TOPIC_POSTS,
+    get_subscribed_topic_names, is_topic_post, query_topic_posts_from_db, query_votes_from_db,
+    recent_topic_posts_filter, topic_to_filter_urls, TopicPost, VoteCounts,
 };
 use dioxus::prelude::*;
 use nostr_sdk::prelude::*;
@@ -19,9 +20,13 @@ pub fn TopicsHome() -> Element {
     let mut vote_counts = use_signal(HashMap::<String, VoteCounts>::new);
     let mut has_more = use_signal(|| true);
     let mut pagination_loading = use_signal(|| false);
-    let loading = *LOADING_TOPIC_POSTS.read();
+    let mut loading = use_signal(|| true);
+    let mut loading_new = use_signal(|| false);
+    let mut pending_posts = use_signal(Vec::<TopicPost>::new);
+    let pending_count = use_memo(move || pending_posts.read().len());
+    let mut subscription_ids = use_signal(Vec::<SubscriptionId>::new);
+    let mut stale = use_stale_guard();
 
-    // Fetch subscriptions on mount
     let _subscriptions = use_resource(move || async move {
         if let Some(pk) = auth_store::get_pubkey() {
             if let Ok(pubkey) = PublicKey::from_hex(&pk) {
@@ -30,44 +35,224 @@ pub fn TopicsHome() -> Element {
         }
     });
 
-    // Fetch posts when tab changes
-    let tab = active_tab.read().clone();
-    let _posts_resource = use_resource(move || {
-        let tab = tab.clone();
-        async move {
-            let result = if tab == "feed" {
+    use_effect(move || {
+        let client_initialized = *CLIENT_INITIALIZED.read();
+        if !client_initialized {
+            return;
+        }
+        let tab = active_tab.read().clone();
+        let token = stale.bump();
+
+        let ids = subscription_ids.peek().clone();
+        if !ids.is_empty() {
+            spawn(async move {
+                if let Some(client) = nostr_client::get_client() {
+                    subscription_manager::unsubscribe_all(&client, &ids).await;
+                }
+            });
+        }
+        subscription_ids.write().clear();
+        pending_posts.set(Vec::new());
+        loading.set(true);
+        loading_new.set(false);
+
+        spawn(async move {
+            if stale.is_stale(token) {
+                return;
+            }
+            let is_stale = || stale.is_stale(token);
+
+            let filter = if tab == "feed" {
                 let subscribed = get_subscribed_topic_names();
                 if subscribed.is_empty() {
-                    Ok(Vec::new())
-                } else {
-                    fetch_subscribed_feed(&subscribed, 30, None).await
+                    loading.set(false);
+                    posts.set(Vec::new());
+                    return;
                 }
+                let topic_urls: Vec<String> = subscribed
+                    .iter()
+                    .flat_map(|t| topic_to_filter_urls(t))
+                    .collect();
+                Filter::new()
+                    .kind(Kind::Comment)
+                    .custom_tags(SingleLetterTag::uppercase(Alphabet::I), topic_urls)
+                    .custom_tag(SingleLetterTag::uppercase(Alphabet::K), "web".to_string())
+                    .limit(30)
+            } else {
+                recent_topic_posts_filter(30, None)
+            };
+
+            let db_posts = query_topic_posts_from_db(filter.clone()).await;
+            if is_stale() {
+                return;
+            }
+            if !db_posts.is_empty() {
+                let pubkeys: Vec<String> = db_posts.iter().map(|p| p.pubkey.clone()).collect();
+                spawn(prefetch_profiles(pubkeys));
+                let event_ids: Vec<EventId> = db_posts
+                    .iter()
+                    .filter_map(|p| EventId::from_hex(&p.id).ok())
+                    .collect();
+                let user_pk =
+                    auth_store::get_pubkey().and_then(|pk| PublicKey::from_hex(&pk).ok());
+                let db_votes = query_votes_from_db(event_ids, user_pk).await;
+                vote_counts.write().extend(db_votes);
+                has_more.set(db_posts.len() >= 30);
+                posts.set(db_posts);
+                loading.set(false);
+                loading_new.set(true);
+            }
+
+            if is_stale() {
+                return;
+            }
+            let result = if tab == "feed" {
+                let subscribed = get_subscribed_topic_names();
+                fetch_subscribed_feed(&subscribed, 30, None).await
             } else {
                 fetch_recent_posts(30, None).await
             };
 
+            if is_stale() {
+                return;
+            }
             if let Ok(fetched) = result {
-                // Prefetch author profiles
                 let pubkeys: Vec<String> = fetched.iter().map(|p| p.pubkey.clone()).collect();
                 spawn(prefetch_profiles(pubkeys));
-
-                // Fetch votes
                 let event_ids: Vec<EventId> = fetched
                     .iter()
                     .filter_map(|p| EventId::from_hex(&p.id).ok())
                     .collect();
-                let user_pk = auth_store::get_pubkey().and_then(|pk| PublicKey::from_hex(&pk).ok());
+                let user_pk =
+                    auth_store::get_pubkey().and_then(|pk| PublicKey::from_hex(&pk).ok());
                 if let Ok(votes) = fetch_votes_batch(event_ids, user_pk).await {
                     vote_counts.write().extend(votes);
                 }
-
                 has_more.set(fetched.len() >= 30);
                 posts.set(fetched);
             }
-        }
+            loading.set(false);
+            loading_new.set(false);
+
+            if is_stale() {
+                return;
+            }
+            if let Some(client) = nostr_client::get_client() {
+                let sub_filter = if tab == "feed" {
+                    let subscribed = get_subscribed_topic_names();
+                    if subscribed.is_empty() {
+                        return;
+                    }
+                    let topic_urls: Vec<String> = subscribed
+                        .iter()
+                        .flat_map(|t| topic_to_filter_urls(t))
+                        .collect();
+                    Filter::new()
+                        .kind(Kind::Comment)
+                        .custom_tags(
+                            SingleLetterTag::uppercase(Alphabet::I),
+                            topic_urls,
+                        )
+                        .custom_tag(
+                            SingleLetterTag::uppercase(Alphabet::K),
+                            "web".to_string(),
+                        )
+                        .since(Timestamp::now())
+                } else {
+                    Filter::new()
+                        .kind(Kind::Comment)
+                        .custom_tag(
+                            SingleLetterTag::uppercase(Alphabet::K),
+                            "web".to_string(),
+                        )
+                        .since(Timestamp::now())
+                };
+
+                match subscription_manager::subscribe_realtime(&client, sub_filter, Some(300))
+                    .await
+                {
+                    Ok(sub_id) => {
+                        subscription_ids.write().push(sub_id.clone());
+                        let active_ids = subscription_ids;
+                        let mut pending = pending_posts;
+                        let current_posts = posts;
+                        let _current_votes = vote_counts;
+                        spawn(async move {
+                            let mut notifications = client.notifications();
+                            while let Ok(notification) = notifications.recv().await {
+                                if let RelayPoolNotification::Event {
+                                    subscription_id: event_sub_id,
+                                    event,
+                                    ..
+                                } = notification
+                                {
+                                    let active = active_ids.read();
+                                    if !active.contains(&event_sub_id) {
+                                        continue;
+                                    }
+                                    drop(active);
+
+                                    if event.kind != Kind::Comment || !is_topic_post(&event) {
+                                        continue;
+                                    }
+                                    let is_reply = event
+                                        .tags
+                                        .iter()
+                                        .any(|t| t.is_reply() || t.is_root());
+                                    if is_reply {
+                                        continue;
+                                    }
+                                    if let Some(post) =
+                                        crate::stores::topic_store::parse_topic_post(&event)
+                                    {
+                                        let already_buffered = pending
+                                            .read()
+                                            .iter()
+                                            .any(|p| p.id == post.id);
+                                        let already_in_feed = current_posts
+                                            .read()
+                                            .iter()
+                                            .any(|p| p.id == post.id);
+                                        if !already_buffered && !already_in_feed {
+                                            let author_pk = post.pubkey.clone();
+                                            spawn(async move {
+                                                let _ =
+                                                    crate::stores::profiles::fetch_profile(
+                                                        author_pk,
+                                                    )
+                                                    .await;
+                                            });
+                                            pending.write().push(post);
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        log::warn!("Failed to subscribe to topic real-time: {}", e);
+                    }
+                }
+            }
+        });
     });
 
-    // Infinite scroll
+    let mut accept_pending_posts = move || {
+        let pending: Vec<TopicPost> = pending_posts.write().drain(..).collect();
+        if pending.is_empty() {
+            return;
+        }
+        let mut current = posts.read().clone();
+        let existing: HashSet<String> = current.iter().map(|p| p.id.clone()).collect();
+        for p in pending {
+            if !existing.contains(&p.id) {
+                current.push(p);
+            }
+        }
+        current.sort_by_key(|b| std::cmp::Reverse(b.created_at));
+        posts.set(current);
+    };
+
     let load_more = move || {
         let tab = active_tab.read().clone();
         let current_posts = posts.read().clone();
@@ -148,7 +333,33 @@ pub fn TopicsHome() -> Element {
                     }
                 }
             }
-            if loading && posts.read().is_empty() {
+            if *pending_count.read() > 0 {
+                {
+                    let count = *pending_count.read();
+                    let post_text = if count == 1 { "post" } else { "posts" };
+                    rsx! {
+                        div {
+                            class: "sticky top-[57px] z-20 border-b border-border bg-blue-500 hover:bg-blue-600 transition-colors cursor-pointer",
+                            onclick: move |_| accept_pending_posts(),
+                            div { class: "px-4 py-3 text-center",
+                                span { class: "text-white font-medium", "Show {count} new {post_text}" }
+                            }
+                        }
+                    }
+                }
+            }
+            if *loading_new.read() && !posts.read().is_empty() {
+                div {
+                    class: "sticky top-[57px] z-20 border-b border-border bg-muted/80 backdrop-blur-sm",
+                    div { class: "px-4 py-2 text-center",
+                        span { class: "inline-flex items-center gap-2 text-sm text-muted-foreground",
+                            span { class: "inline-block w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" }
+                            "Loading new posts..."
+                        }
+                    }
+                }
+            }
+            if *loading.read() && posts.read().is_empty() {
                 div {
                     class: "flex justify-center py-12",
                     span { class: "inline-block w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin" }

--- a/src/routes/topics/popular.rs
+++ b/src/routes/topics/popular.rs
@@ -1,11 +1,11 @@
-//! Topics Popular Page
-//! Hot-ranked posts and trending topics
 use crate::components::TopicPostCard;
+use crate::hooks::use_stale_guard;
 use crate::stores::auth_store;
+use crate::stores::nostr_client::CLIENT_INITIALIZED;
 use crate::stores::profiles::prefetch_profiles;
 use crate::stores::topic_store::{
-    compute_hot_score, fetch_recent_posts, fetch_votes_batch, ScoredPost, VoteCounts,
-    LOADING_TOPIC_POSTS,
+    compute_hot_score, fetch_recent_posts, fetch_votes_batch, query_topic_posts_from_db,
+    query_votes_from_db, recent_topic_posts_filter, ScoredPost, VoteCounts,
 };
 use dioxus::prelude::*;
 use nostr_sdk::prelude::*;
@@ -15,54 +15,136 @@ use std::collections::HashMap;
 pub fn TopicsPopular() -> Element {
     let mut scored_posts = use_signal(Vec::<ScoredPost>::new);
     let mut vote_counts = use_signal(HashMap::<String, VoteCounts>::new);
-    let loading = *LOADING_TOPIC_POSTS.read();
+    let mut loading = use_signal(|| true);
+    let mut loading_new = use_signal(|| false);
+    let mut stale = use_stale_guard();
 
-    // Fetch and rank posts
-    let _resource = use_resource(move || async move {
-        let result = fetch_recent_posts(100, None).await;
-        if let Ok(posts) = result {
-            let pubkeys: Vec<String> = posts.iter().map(|p| p.pubkey.clone()).collect();
-            spawn(prefetch_profiles(pubkeys));
-
-            // Fetch votes for scoring
-            let event_ids: Vec<EventId> = posts
-                .iter()
-                .filter_map(|p| EventId::from_hex(&p.id).ok())
-                .collect();
-            let user_pk = auth_store::get_pubkey().and_then(|pk| PublicKey::from_hex(&pk).ok());
-            let votes = fetch_votes_batch(event_ids, user_pk)
-                .await
-                .unwrap_or_default();
-            vote_counts.write().extend(votes.clone());
-
-            // Compute hot scores
-            let now = Timestamp::now().as_secs();
-            let mut scored: Vec<ScoredPost> = posts
-                .into_iter()
-                .filter(|p| p.is_root) // Only top-level posts
-                .map(|post| {
-                    let vc = votes.get(&post.id).cloned().unwrap_or_default();
-                    let score = compute_hot_score(&vc, 0, 0, post.created_at, now);
-                    ScoredPost { post, score }
-                })
-                .collect();
-            scored.sort_by(|a, b| {
-                b.score
-                    .partial_cmp(&a.score)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
-            scored_posts.set(scored);
+    use_effect(move || {
+        let client_initialized = *CLIENT_INITIALIZED.read();
+        if !client_initialized {
+            return;
         }
+        let token = stale.bump();
+        loading.set(true);
+        loading_new.set(false);
+
+        spawn(async move {
+            if stale.is_stale(token) {
+                return;
+            }
+            let is_stale = || stale.is_stale(token);
+
+            let filter = recent_topic_posts_filter(100, None);
+
+            let db_posts = query_topic_posts_from_db(filter.clone()).await;
+            if is_stale() {
+                return;
+            }
+            if !db_posts.is_empty() {
+                let pubkeys: Vec<String> = db_posts.iter().map(|p| p.pubkey.clone()).collect();
+                spawn(prefetch_profiles(pubkeys));
+                let event_ids: Vec<EventId> = db_posts
+                    .iter()
+                    .filter_map(|p| EventId::from_hex(&p.id).ok())
+                    .collect();
+                let user_pk =
+                    auth_store::get_pubkey().and_then(|pk| PublicKey::from_hex(&pk).ok());
+                let db_votes = query_votes_from_db(event_ids, user_pk).await;
+                vote_counts.write().extend(db_votes.clone());
+
+                let now = Timestamp::now().as_secs();
+                let mut scored: Vec<ScoredPost> = db_posts
+                    .into_iter()
+                    .filter(|p| p.is_root)
+                    .map(|post| {
+                        let vc = db_votes.get(&post.id).cloned().unwrap_or_default();
+                        let score = compute_hot_score(&vc, 0, 0, post.created_at, now);
+                        ScoredPost { post, score }
+                    })
+                    .collect();
+                scored.sort_by(|a, b| {
+                    b.score
+                        .partial_cmp(&a.score)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                scored_posts.set(scored);
+                loading.set(false);
+                loading_new.set(true);
+            }
+
+            if is_stale() {
+                return;
+            }
+            let result = fetch_recent_posts(100, None).await;
+            if is_stale() {
+                return;
+            }
+            if let Ok(posts) = result {
+                let pubkeys: Vec<String> = posts.iter().map(|p| p.pubkey.clone()).collect();
+                spawn(prefetch_profiles(pubkeys));
+
+                let event_ids: Vec<EventId> = posts
+                    .iter()
+                    .filter_map(|p| EventId::from_hex(&p.id).ok())
+                    .collect();
+                let user_pk =
+                    auth_store::get_pubkey().and_then(|pk| PublicKey::from_hex(&pk).ok());
+                let votes = fetch_votes_batch(event_ids, user_pk)
+                    .await
+                    .unwrap_or_default();
+                vote_counts.write().extend(votes.clone());
+
+                let now = Timestamp::now().as_secs();
+                let mut scored: Vec<ScoredPost> = posts
+                    .into_iter()
+                    .filter(|p| p.is_root)
+                    .map(|post| {
+                        let vc = votes.get(&post.id).cloned().unwrap_or_default();
+                        let score = compute_hot_score(&vc, 0, 0, post.created_at, now);
+                        ScoredPost { post, score }
+                    })
+                    .collect();
+                scored.sort_by(|a, b| {
+                    b.score
+                        .partial_cmp(&a.score)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                scored_posts.set(scored);
+            }
+            loading.set(false);
+            loading_new.set(false);
+        });
     });
 
     rsx! {
         div {
             class: "w-full max-w-6xl mx-auto px-4 py-4",
             h1 { class: "text-2xl font-bold text-foreground mb-4", "Popular" }
-            if loading && scored_posts.read().is_empty() {
+            if *loading.read() && scored_posts.read().is_empty() {
                 div {
                     class: "flex justify-center py-12",
                     span { class: "inline-block w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin" }
+                }
+            } else if *loading_new.read() && !scored_posts.read().is_empty() {
+                div {
+                    class: "flex flex-col gap-2",
+                    div {
+                        class: "sticky top-[57px] z-20 border-b border-border bg-muted/80 backdrop-blur-sm",
+                        div { class: "px-4 py-2 text-center",
+                            span { class: "inline-flex items-center gap-2 text-sm text-muted-foreground",
+                                span { class: "inline-block w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" }
+                                "Loading new posts..."
+                            }
+                        }
+                    }
+                    for scored in scored_posts.read().iter() {
+                        TopicPostCard {
+                            key: "{scored.post.id}",
+                            post: scored.post.clone(),
+                            vote_counts: vote_counts.read().get(&scored.post.id).cloned(),
+                            show_topic_badge: true,
+                        }
+                    }
                 }
             } else if scored_posts.read().is_empty() {
                 div {

--- a/src/routes/topics/topic_feed.rs
+++ b/src/routes/topics/topic_feed.rs
@@ -233,18 +233,7 @@ pub fn TopicFeed(topic: String) -> Element {
 
     let mut accept_pending_posts = move || {
         let pending: Vec<TopicPost> = pending_posts.write().drain(..).collect();
-        if pending.is_empty() {
-            return;
-        }
-        let mut current = posts.read().clone();
-        let existing: HashSet<String> = current.iter().map(|p| p.id.clone()).collect();
-        for p in pending {
-            if !existing.contains(&p.id) {
-                current.push(p);
-            }
-        }
-        current.sort_by_key(|b| std::cmp::Reverse(b.created_at));
-        posts.set(current);
+        crate::stores::social::topic_store::merge_pending_posts(posts, pending);
     };
 
     let load_more = move || {

--- a/src/routes/topics/topic_feed.rs
+++ b/src/routes/topics/topic_feed.rs
@@ -1,13 +1,14 @@
-//! Topic Feed Page
-//! Single topic: header, composer, posts with New/Hot/Top tabs
 use crate::components::{TopicPostCard, TopicPostComposer};
-use crate::hooks::use_infinite_scroll;
+use crate::hooks::{use_infinite_scroll, use_stale_guard};
 use crate::stores::auth_store;
-use crate::stores::nostr_client::HAS_SIGNER;
+use crate::stores::nostr_client::{self, CLIENT_INITIALIZED, HAS_SIGNER};
 use crate::stores::profiles::prefetch_profiles;
+use crate::stores::subscription_manager;
 use crate::stores::topic_store::{
-    compute_hot_score, fetch_topic_posts, fetch_votes_batch, is_topic_subscribed,
-    subscribe_to_topic, unsubscribe_from_topic, TopicPost, VoteCounts, LOADING_TOPIC_POSTS,
+    compute_hot_score, fetch_topic_posts, fetch_votes_batch, is_topic_post,
+    is_topic_subscribed, parse_topic_post, query_topic_posts_from_db, query_votes_from_db,
+    subscribe_to_topic, topic_posts_filter, topic_to_filter_urls, unsubscribe_from_topic,
+    TopicPost, VoteCounts,
 };
 use dioxus::prelude::*;
 use nostr_sdk::prelude::*;
@@ -28,33 +29,162 @@ pub fn TopicFeed(topic: String) -> Element {
     let mut subscribed = use_signal(|| is_topic_subscribed(&topic));
     let mut subscribing = use_signal(|| false);
     let has_signer = *HAS_SIGNER.read();
-    let loading = *LOADING_TOPIC_POSTS.read();
+    let mut loading = use_signal(|| true);
+    let mut loading_new = use_signal(|| false);
+    let mut pending_posts = use_signal(Vec::<TopicPost>::new);
+    let pending_count = use_memo(move || pending_posts.read().len());
+    let mut subscription_ids = use_signal(Vec::<SubscriptionId>::new);
+    let mut stale = use_stale_guard();
 
-    // Fetch posts for this topic
-    let _resource = use_resource(move || {
-        let topic = topic_sig.read().clone();
-        async move {
-            let result = fetch_topic_posts(&topic, 30, None).await;
+    use_effect(move || {
+        let client_initialized = *CLIENT_INITIALIZED.read();
+        if !client_initialized {
+            return;
+        }
+        let current_topic = topic_sig.read().clone();
+        let token = stale.bump();
+
+        let ids = subscription_ids.peek().clone();
+        if !ids.is_empty() {
+            spawn(async move {
+                if let Some(client) = nostr_client::get_client() {
+                    subscription_manager::unsubscribe_all(&client, &ids).await;
+                }
+            });
+        }
+        subscription_ids.write().clear();
+        pending_posts.set(Vec::new());
+        loading.set(true);
+        loading_new.set(false);
+
+        spawn(async move {
+            if stale.is_stale(token) {
+                return;
+            }
+            let is_stale = || stale.is_stale(token);
+
+            let filter = topic_posts_filter(&current_topic, 30, None);
+
+            let db_posts = query_topic_posts_from_db(filter.clone()).await;
+            if is_stale() {
+                return;
+            }
+            if !db_posts.is_empty() {
+                let pubkeys: Vec<String> = db_posts.iter().map(|p| p.pubkey.clone()).collect();
+                spawn(prefetch_profiles(pubkeys));
+                let event_ids: Vec<EventId> = db_posts
+                    .iter()
+                    .filter_map(|p| EventId::from_hex(&p.id).ok())
+                    .collect();
+                let user_pk =
+                    auth_store::get_pubkey().and_then(|pk| PublicKey::from_hex(&pk).ok());
+                let db_votes = query_votes_from_db(event_ids, user_pk).await;
+                vote_counts.write().extend(db_votes);
+                has_more.set(db_posts.len() >= 30);
+                posts.set(db_posts);
+                loading.set(false);
+                loading_new.set(true);
+            }
+
+            if is_stale() {
+                return;
+            }
+            let result = fetch_topic_posts(&current_topic, 30, None).await;
+            if is_stale() {
+                return;
+            }
             if let Ok(fetched) = result {
                 let pubkeys: Vec<String> = fetched.iter().map(|p| p.pubkey.clone()).collect();
                 spawn(prefetch_profiles(pubkeys));
-
                 let event_ids: Vec<EventId> = fetched
                     .iter()
                     .filter_map(|p| EventId::from_hex(&p.id).ok())
                     .collect();
-                let user_pk = auth_store::get_pubkey().and_then(|pk| PublicKey::from_hex(&pk).ok());
+                let user_pk =
+                    auth_store::get_pubkey().and_then(|pk| PublicKey::from_hex(&pk).ok());
                 if let Ok(votes) = fetch_votes_batch(event_ids, user_pk).await {
                     vote_counts.write().extend(votes);
                 }
-
                 has_more.set(fetched.len() >= 30);
                 posts.set(fetched);
             }
-        }
+            loading.set(false);
+            loading_new.set(false);
+
+            if is_stale() {
+                return;
+            }
+            if let Some(client) = nostr_client::get_client() {
+                let topic_urls = topic_to_filter_urls(&current_topic);
+                let sub_filter = Filter::new()
+                    .kind(Kind::Comment)
+                    .custom_tags(SingleLetterTag::uppercase(Alphabet::I), topic_urls)
+                    .custom_tag(SingleLetterTag::uppercase(Alphabet::K), "web".to_string())
+                    .since(Timestamp::now());
+
+                match subscription_manager::subscribe_realtime(&client, sub_filter, Some(300))
+                    .await
+                {
+                    Ok(sub_id) => {
+                        subscription_ids.write().push(sub_id.clone());
+                        let active_ids = subscription_ids;
+                        let mut pending = pending_posts;
+                        let current_posts = posts;
+                        let _current_votes = vote_counts;
+                        spawn(async move {
+                            let mut notifications = client.notifications();
+                            while let Ok(notification) = notifications.recv().await {
+                                if let RelayPoolNotification::Event {
+                                    subscription_id: event_sub_id,
+                                    event,
+                                    ..
+                                } = notification
+                                {
+                                    let active = active_ids.read();
+                                    if !active.contains(&event_sub_id) {
+                                        continue;
+                                    }
+                                    drop(active);
+
+                                    if event.kind != Kind::Comment || !is_topic_post(&event) {
+                                        continue;
+                                    }
+                                    if let Some(post) = parse_topic_post(&event) {
+                                        if post.topic != current_topic {
+                                            continue;
+                                        }
+                                        let already_buffered = pending
+                                            .read()
+                                            .iter()
+                                            .any(|p| p.id == post.id);
+                                        let already_in_feed = current_posts
+                                            .read()
+                                            .iter()
+                                            .any(|p| p.id == post.id);
+                                        if !already_buffered && !already_in_feed {
+                                            let author_pk = post.pubkey.clone();
+                                            spawn(async move {
+                                                let _ =
+                                                    crate::stores::profiles::fetch_profile(
+                                                        author_pk,
+                                                    )
+                                                    .await;
+                                            });
+                                            pending.write().push(post);
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        log::warn!("Failed to subscribe to topic real-time: {}", e);
+                    }
+                }
+            }
+        });
     });
 
-    // Sort posts based on mode
     let sorted_posts: Vec<TopicPost> = {
         let current_posts = posts.read().clone();
         let votes = vote_counts.read().clone();
@@ -88,13 +218,27 @@ pub fn TopicFeed(topic: String) -> Element {
                 top.into_iter().map(|(p, _)| p).collect()
             }
             _ => {
-                // "new" - chronological, root posts only
                 current_posts.into_iter().filter(|p| p.is_root).collect()
             }
         }
     };
 
-    // Infinite scroll
+    let mut accept_pending_posts = move || {
+        let pending: Vec<TopicPost> = pending_posts.write().drain(..).collect();
+        if pending.is_empty() {
+            return;
+        }
+        let mut current = posts.read().clone();
+        let existing: HashSet<String> = current.iter().map(|p| p.id.clone()).collect();
+        for p in pending {
+            if !existing.contains(&p.id) {
+                current.push(p);
+            }
+        }
+        current.sort_by_key(|b| std::cmp::Reverse(b.created_at));
+        posts.set(current);
+    };
+
     let load_more = move || {
         let topic = topic_sig.read().clone();
         let current_posts = posts.read().clone();
@@ -177,7 +321,6 @@ pub fn TopicFeed(topic: String) -> Element {
                 TopicPostComposer {
                     topic: Some(topic_val.clone()),
                     on_success: move |_: String| {
-                        // TODO: prepend new post to list
                     },
                 }
                 div { class: "h-4" }
@@ -202,7 +345,33 @@ pub fn TopicFeed(topic: String) -> Element {
                     }
                 }
             }
-            if loading && posts.read().is_empty() {
+            if *pending_count.read() > 0 {
+                {
+                    let count = *pending_count.read();
+                    let post_text = if count == 1 { "post" } else { "posts" };
+                    rsx! {
+                        div {
+                            class: "sticky top-[57px] z-20 border-b border-border bg-blue-500 hover:bg-blue-600 transition-colors cursor-pointer",
+                            onclick: move |_| accept_pending_posts(),
+                            div { class: "px-4 py-3 text-center",
+                                span { class: "text-white font-medium", "Show {count} new {post_text}" }
+                            }
+                        }
+                    }
+                }
+            }
+            if *loading_new.read() && !posts.read().is_empty() {
+                div {
+                    class: "sticky top-[57px] z-20 border-b border-border bg-muted/80 backdrop-blur-sm",
+                    div { class: "px-4 py-2 text-center",
+                        span { class: "inline-flex items-center gap-2 text-sm text-muted-foreground",
+                            span { class: "inline-block w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" }
+                            "Loading new posts..."
+                        }
+                    }
+                }
+            }
+            if *loading.read() && posts.read().is_empty() {
                 div {
                     class: "flex justify-center py-12",
                     span { class: "inline-block w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin" }

--- a/src/routes/topics/topic_feed.rs
+++ b/src/routes/topics/topic_feed.rs
@@ -131,9 +131,17 @@ pub fn TopicFeed(topic: String) -> Element {
                         let mut pending = pending_posts;
                         let current_posts = posts;
                         let _current_votes = vote_counts;
+                        let stale_check = stale;
+                        let stale_token = token;
                         spawn(async move {
                             let mut notifications = client.notifications();
-                            while let Ok(notification) = notifications.recv().await {
+                            loop {
+                                if stale_check.is_stale(stale_token) {
+                                    break;
+                                }
+                                let Ok(notification) = notifications.recv().await else {
+                                    break;
+                                };
                                 if let RelayPoolNotification::Event {
                                     subscription_id: event_sub_id,
                                     event,

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -56,6 +56,7 @@ pub mod openlibrary;
 pub mod pages;
 pub mod nip05;
 pub mod profile_stats;
+pub mod social_graph;
 pub mod scheduler;
 pub mod sync;
 pub mod wavlake;

--- a/src/services/nests_audio/mod.rs
+++ b/src/services/nests_audio/mod.rs
@@ -233,10 +233,10 @@ pub async fn authenticate_with_nest(
 
     let full_url = format!("{}/auth", auth_url.trim_end_matches('/'));
 
-    let body = format!(
-        "{{\"namespace\":\"{}\",\"publish\":{}}}",
-        namespace, publish
-    );
+    let body = serde_json::json!({
+        "namespace": namespace,
+        "publish": publish
+    }).to_string();
     let body_bytes = body.as_bytes();
     let payload_hash = bitcoin_hashes::sha256::Hash::hash(body_bytes);
 

--- a/src/services/nests_audio/mod.rs
+++ b/src/services/nests_audio/mod.rs
@@ -51,6 +51,7 @@ pub enum AudioEvent {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct AuthResponse {
+    #[serde(alias = "token")]
     jwt: String,
 }
 
@@ -93,14 +94,16 @@ pub async fn js_connect(
     relay_url: &str,
     namespace: &str,
     jwt: &str,
+    my_pubkey: &str,
 ) -> Result<(), String> {
     let pid = serde_json::to_string(publisher_id).map_err(|e| e.to_string())?;
     let aurl = serde_json::to_string(auth_url).map_err(|e| e.to_string())?;
     let rurl = serde_json::to_string(relay_url).map_err(|e| e.to_string())?;
     let ns = serde_json::to_string(namespace).map_err(|e| e.to_string())?;
     let j = serde_json::to_string(jwt).map_err(|e| e.to_string())?;
+    let mpk = serde_json::to_string(my_pubkey).map_err(|e| e.to_string())?;
     eval_nest_js(
-        &format!("return window.nestAudioManager.connect({pid}, {aurl}, {rurl}, {ns}, {j});"),
+        &format!("return window.nestAudioManager.connect({pid}, {aurl}, {rurl}, {ns}, {j}, {mpk});"),
         "Unknown connect error",
     )
     .await
@@ -218,18 +221,35 @@ pub async fn js_get_participant_tracks(publisher_id: &str) -> Vec<String> {
     }
 }
 
-pub async fn authenticate_with_nest(auth_url: &str) -> Result<String, String> {
+pub async fn authenticate_with_nest(
+    auth_url: &str,
+    namespace: &str,
+    publish: bool,
+) -> Result<String, String> {
     use crate::platform::http::http_client;
-    use crate::utils::nips::nip98::{create_auth_header, AuthResult};
+    use crate::utils::nips::nip98::{create_auth_header_with_payload, AuthResult};
+    use bitcoin_hashes::Hash as _;
     use nostr_sdk::nips::nip98;
 
+    let full_url = format!("{}/auth", auth_url.trim_end_matches('/'));
+
+    let body = format!(
+        "{{\"namespace\":\"{}\",\"publish\":{}}}",
+        namespace, publish
+    );
+    let body_bytes = body.as_bytes();
+    let payload_hash = bitcoin_hashes::sha256::Hash::hash(body_bytes);
+
     let auth: AuthResult =
-        create_auth_header(auth_url, nip98::HttpMethod::POST).await?;
+        create_auth_header_with_payload(&full_url, nip98::HttpMethod::POST, payload_hash).await?;
 
     let response = http_client()
         .map_err(|e| format!("HTTP client init failed: {}", e))?
         .post(&auth.signed_url)
         .header("Authorization", &auth.header)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .body(body)
         .send()
         .await
         .map_err(|e| format!("Auth request failed: {}", e))?;
@@ -259,14 +279,14 @@ mod desktop_bridges {
         Lazy::new(|| Mutex::new(HashMap::new()));
 
     pub fn get(publisher_id: &str) -> NativeBridge {
-        let mut map = BRIDGES.lock().unwrap();
+        let mut map = BRIDGES.lock().unwrap_or_else(|e| e.into_inner());
         map.entry(publisher_id.to_string())
             .or_insert_with(NativeBridge::new)
             .clone()
     }
 
     pub fn remove(publisher_id: &str) {
-        let mut map = BRIDGES.lock().unwrap();
+        let mut map = BRIDGES.lock().unwrap_or_else(|e| e.into_inner());
         map.remove(publisher_id);
     }
 }
@@ -293,6 +313,7 @@ pub async fn js_connect(
     relay_url: &str,
     namespace: &str,
     jwt: &str,
+    _my_pubkey: &str,
 ) -> Result<(), String> {
     let bridge = get_bridge(publisher_id);
     bridge.connect(relay_url, namespace, jwt).await

--- a/src/services/nests_audio/native.rs
+++ b/src/services/nests_audio/native.rs
@@ -148,7 +148,7 @@ impl NativeBridge {
             })
             .map_err(|e| e.to_string())?;
         rx.await.map_err(|e| e.to_string())??;
-        let mut s = self.shared.lock().unwrap();
+        let mut s = self.shared.lock().unwrap_or_else(|e| e.into_inner());
         if !s.tracks.contains(&pubkey.to_string()) {
             s.tracks.push(pubkey.to_string());
         }
@@ -164,7 +164,7 @@ impl NativeBridge {
             })
             .map_err(|e| e.to_string())?;
         rx.await.map_err(|e| e.to_string())??;
-        let mut s = self.shared.lock().unwrap();
+        let mut s = self.shared.lock().unwrap_or_else(|e| e.into_inner());
         s.tracks.retain(|t| t != pubkey);
         Ok(())
     }
@@ -180,15 +180,15 @@ impl NativeBridge {
     }
 
     pub fn connection_state(&self) -> ConnectionState {
-        self.shared.lock().unwrap().connection.clone()
+        self.shared.lock().unwrap_or_else(|e| e.into_inner()).connection.clone()
     }
 
     pub fn participant_tracks(&self) -> Vec<String> {
-        self.shared.lock().unwrap().tracks.clone()
+        self.shared.lock().unwrap_or_else(|e| e.into_inner()).tracks.clone()
     }
 
     fn set_state(&self, state: ConnectionState) {
-        self.shared.lock().unwrap().connection = state;
+        self.shared.lock().unwrap_or_else(|e| e.into_inner()).connection = state;
     }
 }
 
@@ -433,7 +433,7 @@ impl Engine {
             .build_output_stream(
                 &stream_config,
                 move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-                    let mut buf = ring_buf_out.lock().unwrap();
+                    let mut buf = ring_buf_out.lock().unwrap_or_else(|e| e.into_inner());
                     for sample in data.iter_mut() {
                         *sample = buf.pop_front().unwrap_or(0.0);
                     }
@@ -462,7 +462,7 @@ impl Engine {
                 match track.read_frame().await {
                     Ok(Some(frame)) => match decoder.decode_float(&frame, &mut output, false) {
                         Ok(len) => {
-                            let mut buf = ring_buf_dec.lock().unwrap();
+                            let mut buf = ring_buf_dec.lock().unwrap_or_else(|e| e.into_inner());
                             buf.extend(&output[..len]);
                             let excess = buf.len().saturating_sub(RING_BUFFER_MAX_SAMPLES);
                             if excess > 0 {
@@ -503,7 +503,7 @@ impl Engine {
         self.subscribers.clear();
         self.moq_session = None;
         self.origin = None;
-        let mut s = self.shared.lock().unwrap();
+        let mut s = self.shared.lock().unwrap_or_else(|e| e.into_inner());
         s.connection = ConnectionState::Disconnected;
         s.tracks.clear();
     }

--- a/src/services/scheduler.rs
+++ b/src/services/scheduler.rs
@@ -1,14 +1,6 @@
-//! Background task scheduler for nostr.blue
-//!
-//! Provides periodic background tasks using Dioxus `use_future` pattern.
-//! Cross-platform using crate::platform::timer for delays.
-//!
-//! Note: NIP-65/NIP-17 relay sync is NOT needed here - nostr-sdk's gossip
-//! layer handles that automatically on-demand.
 use dioxus::prelude::*;
 use std::time::Duration;
-/// Hook to start all background scheduler tasks
-/// Call once from App component
+
 pub fn use_background_scheduler() {
     use_future(|| async {
         loop {
@@ -17,9 +9,27 @@ pub fn use_background_scheduler() {
         }
     });
 }
-/// Stale profile cleanup - prune profiles not accessed recently
+
 async fn run_stale_profile_cleanup() {
-    use crate::stores::profiles::PROFILE_CACHE;
-    let cache_size = PROFILE_CACHE.read().len();
-    log::debug!("Profile cache size: {}", cache_size);
+    use crate::stores::profiles::{CACHE_TTL_SECONDS, PROFILE_CACHE};
+    let mut cache = PROFILE_CACHE.write();
+    let before = cache.len();
+    let stale_keys: Vec<String> = cache
+        .iter()
+        .filter(|(_, profile)| {
+            let age = chrono::Utc::now().signed_duration_since(profile.fetched_at);
+            age.num_seconds() >= CACHE_TTL_SECONDS
+        })
+        .map(|(k, _)| k.clone())
+        .collect();
+    for key in &stale_keys {
+        cache.pop(key);
+    }
+    if !stale_keys.is_empty() {
+        log::info!(
+            "Profile cache cleanup: removed {}/{} stale entries",
+            stale_keys.len(),
+            before
+        );
+    }
 }

--- a/src/services/search/profile_search.rs
+++ b/src/services/search/profile_search.rs
@@ -6,7 +6,7 @@ use dioxus::prelude::*;
 use nostr_sdk::prelude::*;
 use std::time::Duration;
 /// Result type for profile search
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ProfileSearchResult {
     pub pubkey: PublicKey,
     pub name: Option<String>,
@@ -277,6 +277,19 @@ pub async fn get_contact_pubkeys() -> Vec<PublicKey> {
         Some(c) => c,
         None => return Vec::new(),
     };
+    if let Some(pubkey_str) = crate::stores::auth_store::get_pubkey() {
+        if let Ok(pk) = PublicKey::from_hex(&pubkey_str) {
+            if let Ok(pubkeys) = client.database().contacts_public_keys(pk).await {
+                if !pubkeys.is_empty() {
+                    log::debug!(
+                        "Loaded {} contact pubkeys from SDK database",
+                        pubkeys.len()
+                    );
+                    return pubkeys.into_iter().collect();
+                }
+            }
+        }
+    }
     match client
         .get_contact_list_public_keys(Duration::from_secs(5))
         .await

--- a/src/services/social_graph.rs
+++ b/src/services/social_graph.rs
@@ -1,0 +1,194 @@
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "web")]
+use wasm_bindgen::JsCast;
+#[cfg(feature = "web")]
+use wasm_bindgen_futures::JsFuture;
+#[cfg(feature = "web")]
+use web_sys::{Request, RequestInit, RequestMode, Response};
+
+const NOSTR_ARCHIVES_API: &str = "https://api.nostrarchives.com";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SocialListResponse {
+    pub count: i64,
+    #[serde(default)]
+    pub pubkeys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SocialGraphResponse {
+    #[serde(default)]
+    pub follows: SocialListResponse,
+    #[serde(default)]
+    pub followers: SocialListResponse,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileMetadata {
+    pub pubkey: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub picture: Option<String>,
+    #[serde(default)]
+    pub about: Option<String>,
+    #[serde(default)]
+    pub nip05: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BatchMetadataRequest {
+    pubkeys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BatchMetadataResponse {
+    profiles: Vec<ProfileMetadata>,
+}
+
+#[cfg(feature = "web")]
+pub async fn fetch_social_graph(
+    pubkey: &str,
+    follows_limit: i64,
+    follows_offset: i64,
+    followers_limit: i64,
+    followers_offset: i64,
+) -> Result<SocialGraphResponse, String> {
+    let url = format!(
+        "{}/v1/social/{}?follows_limit={}&follows_offset={}&followers_limit={}&followers_offset={}",
+        NOSTR_ARCHIVES_API, pubkey, follows_limit, follows_offset, followers_limit, followers_offset
+    );
+    let opts = RequestInit::new();
+    opts.set_method("GET");
+    opts.set_mode(RequestMode::Cors);
+    let request = Request::new_with_str_and_init(&url, &opts)
+        .map_err(|e| format!("Failed to create request: {:?}", e))?;
+    request
+        .headers()
+        .set("Accept", "application/json")
+        .map_err(|e| format!("Failed to set header: {:?}", e))?;
+    let window = web_sys::window().ok_or("No window object")?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("Fetch failed: {:?}", e))?;
+    let resp: Response = resp_value
+        .dyn_into()
+        .map_err(|_| "Failed to cast to Response")?;
+    if !resp.ok() {
+        return Err(format!("API returned status: {}", resp.status()));
+    }
+    let json = JsFuture::from(
+        resp.json()
+            .map_err(|e| format!("Failed to get JSON: {:?}", e))?,
+    )
+    .await
+    .map_err(|e| format!("Failed to parse JSON: {:?}", e))?;
+    let response: SocialGraphResponse = serde_wasm_bindgen::from_value(json)
+        .map_err(|e| format!("Failed to deserialize: {:?}", e))?;
+    Ok(response)
+}
+
+#[cfg(not(feature = "web"))]
+pub async fn fetch_social_graph(
+    pubkey: &str,
+    follows_limit: i64,
+    follows_offset: i64,
+    followers_limit: i64,
+    followers_offset: i64,
+) -> Result<SocialGraphResponse, String> {
+    let url = format!(
+        "{}/v1/social/{}?follows_limit={}&follows_offset={}&followers_limit={}&followers_offset={}",
+        NOSTR_ARCHIVES_API, pubkey, follows_limit, follows_offset, followers_limit, followers_offset
+    );
+    let client = crate::platform::http::http_client()
+        .map_err(|e| format!("HTTP client error: {}", e))?;
+    let resp = client
+        .get(&url)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(|e| format!("Fetch failed: {}", e))?;
+    if !resp.status().is_success() {
+        return Err(format!("API returned status: {}", resp.status()));
+    }
+    let response: SocialGraphResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to deserialize: {}", e))?;
+    Ok(response)
+}
+
+#[cfg(feature = "web")]
+pub async fn fetch_profiles_metadata(
+    pubkeys: Vec<String>,
+) -> Result<Vec<ProfileMetadata>, String> {
+    if pubkeys.is_empty() {
+        return Ok(Vec::new());
+    }
+    let url = format!("{}/v1/profiles/metadata", NOSTR_ARCHIVES_API);
+    let body = serde_json::to_string(&BatchMetadataRequest { pubkeys })
+        .map_err(|e| format!("Failed to serialize: {:?}", e))?;
+    let opts = RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(RequestMode::Cors);
+    opts.set_body(&wasm_bindgen::JsValue::from_str(&body));
+    let request = Request::new_with_str_and_init(&url, &opts)
+        .map_err(|e| format!("Failed to create request: {:?}", e))?;
+    request
+        .headers()
+        .set("Accept", "application/json")
+        .map_err(|e| format!("Failed to set header: {:?}", e))?;
+    request
+        .headers()
+        .set("Content-Type", "application/json")
+        .map_err(|e| format!("Failed to set header: {:?}", e))?;
+    let window = web_sys::window().ok_or("No window object")?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("Fetch failed: {:?}", e))?;
+    let resp: Response = resp_value
+        .dyn_into()
+        .map_err(|_| "Failed to cast to Response")?;
+    if !resp.ok() {
+        return Err(format!("API returned status: {}", resp.status()));
+    }
+    let json = JsFuture::from(
+        resp.json()
+            .map_err(|e| format!("Failed to get JSON: {:?}", e))?,
+    )
+    .await
+    .map_err(|e| format!("Failed to parse JSON: {:?}", e))?;
+    let response: BatchMetadataResponse = serde_wasm_bindgen::from_value(json)
+        .map_err(|e| format!("Failed to deserialize: {:?}", e))?;
+    Ok(response.profiles)
+}
+
+#[cfg(not(feature = "web"))]
+pub async fn fetch_profiles_metadata(
+    pubkeys: Vec<String>,
+) -> Result<Vec<ProfileMetadata>, String> {
+    if pubkeys.is_empty() {
+        return Ok(Vec::new());
+    }
+    let url = format!("{}/v1/profiles/metadata", NOSTR_ARCHIVES_API);
+    let client = crate::platform::http::http_client()
+        .map_err(|e| format!("HTTP client error: {}", e))?;
+    let resp = client
+        .post(&url)
+        .header("Accept", "application/json")
+        .header("Content-Type", "application/json")
+        .json(&BatchMetadataRequest { pubkeys })
+        .send()
+        .await
+        .map_err(|e| format!("Fetch failed: {}", e))?;
+    if !resp.status().is_success() {
+        return Err(format!("API returned status: {}", resp.status()));
+    }
+    let response: BatchMetadataResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to deserialize: {}", e))?;
+    Ok(response.profiles)
+}

--- a/src/services/sync.rs
+++ b/src/services/sync.rs
@@ -359,10 +359,15 @@ async fn load_following_authors() -> Result<Vec<PublicKey>, String> {
 
 fn build_following_sync_filter(authors: Vec<PublicKey>) -> Filter {
     Filter::new()
-        .kinds(vec![Kind::TextNote, Kind::Repost, Kind::Comment])
+        .kinds(vec![
+            Kind::TextNote,
+            Kind::Repost,
+            Kind::Comment,
+            Kind::Custom(crate::utils::nip_bb::KIND_BLOBBI_STATE),
+        ])
         .authors(authors)
         .since(Timestamp::now() - Duration::from_secs(FOLLOWING_SYNC_WINDOW_SECS))
-        .limit(50)
+        .limit(100)
 }
 
 fn current_pubkey() -> Result<PublicKey, String> {

--- a/src/stores/audio/nostr_music.rs
+++ b/src/stores/audio/nostr_music.rs
@@ -428,38 +428,12 @@ pub async fn fetch_track_zap_totals(
             .iter()
             .find(|t| t.as_slice().first().map(|s| s.as_str()) == Some("bolt11"))
             .and_then(|t| t.as_slice().get(1))
-            .and_then(|bolt11| parse_bolt11_amount(bolt11));
+            .and_then(|bolt11| crate::utils::bolt11::parse_bolt11_amount_msats(bolt11));
         if let (Some(coord), Some(msats)) = (a_tag, amount) {
             *totals.entry(coord).or_default() += msats;
         }
     }
     Ok(totals)
-}
-/// Parse millisats amount from bolt11 invoice
-fn parse_bolt11_amount(bolt11: &str) -> Option<u64> {
-    let lower = bolt11.to_lowercase();
-    if !lower.starts_with("lnbc") {
-        return None;
-    }
-    let rest = &lower[4..];
-    let sep_pos = rest.find('1')?;
-    let amount_str = &rest[..sep_pos];
-    if amount_str.is_empty() {
-        return None;
-    }
-    let (num_str, multiplier) = if let Some(stripped) = amount_str.strip_suffix('m') {
-        (stripped, 100_000_000_u64)
-    } else if let Some(stripped) = amount_str.strip_suffix('u') {
-        (stripped, 100_000_u64)
-    } else if let Some(stripped) = amount_str.strip_suffix('n') {
-        (stripped, 100_u64)
-    } else if let Some(stripped) = amount_str.strip_suffix('p') {
-        (stripped, 1_u64)
-    } else {
-        (amount_str, 100_000_000_000_u64)
-    };
-    let amount: u64 = num_str.parse().ok()?;
-    Some(amount * multiplier)
 }
 /// Search nostr music tracks by title or artist name
 ///

--- a/src/stores/auth_store.rs
+++ b/src/stores/auth_store.rs
@@ -5,6 +5,7 @@ use dioxus::signals::ReadableExt;
 use nostr::{Keys, PublicKey};
 #[cfg(any(target_family = "wasm", feature = "mobile_platform"))]
 use nostr::nips::nip06::FromMnemonic;
+use nostr_sdk::prelude::NostrDatabaseExt;
 #[cfg(target_family = "wasm")]
 use nostr_browser_signer::BrowserSigner;
 use nostr_connect::client::NostrConnect;
@@ -712,6 +713,36 @@ pub async fn login_with_npub(npub: &str) -> Result<(), String> {
     crate::platform::storage::set(STORAGE_KEY_NPUB, &pubkey_str)?;
     crate::platform::storage::set(STORAGE_KEY_METHOD, "read_only")?;
     log::info!("Loaded read-only mode with pubkey: {}", pubkey_str);
+    if let Some(client) = nostr_client::get_client() {
+        match client.database().contacts(pubkey).await {
+            Ok(db_contacts) => {
+                let mut inserted = 0u32;
+                crate::stores::profiles::PROFILE_CACHE.with_mut(|cache| {
+                    for contact in &db_contacts {
+                        let pk_hex = contact.public_key().to_hex();
+                        if cache.peek(&pk_hex).is_some() {
+                            continue;
+                        }
+                        let metadata = contact.metadata();
+                        let profile = crate::stores::profiles::metadata_to_profile(
+                            pk_hex.clone(),
+                            &metadata,
+                        );
+                        cache.put(pk_hex, profile);
+                        inserted += 1;
+                    }
+                });
+                log::info!(
+                    "Read-only: loaded {}/{} profiles from SDK database",
+                    inserted,
+                    db_contacts.len()
+                );
+            }
+            Err(e) => {
+                log::debug!("Read-only: no contacts in SDK database ({})", e);
+            }
+        }
+    }
     Ok(())
 }
 /// Login with NIP-07 browser extension (official implementation)
@@ -834,10 +865,55 @@ async fn run_post_login_init() {
     crate::stores::notifications::start_realtime_subscription().await;
     crate::stores::relay::start_relay_list_subscription().await;
     crate::stores::emoji_store::init_emoji_fetch();
-    // Prefetch contacts into memory cache so Home feed loads faster
-    if let Some(pubkey) = get_pubkey() {
+    if let Some(pubkey_str) = get_pubkey() {
+        let pk = match PublicKey::from_hex(&pubkey_str) {
+            Ok(pk) => pk,
+            Err(_) => return,
+        };
+
+        // Phase 1: Populate PROFILE_CACHE from local SDK database (instant, no network).
+        // On browser reopen the SDK database (IndexedDB/nostrodb) still has all
+        // kind 0 events from the previous session, so this warms the cache
+        // immediately without waiting for relay round-trips.
+        if let Some(client) = nostr_client::get_client() {
+            match client.database().contacts(pk).await {
+                Ok(db_contacts) => {
+                    let count = db_contacts.len();
+                    if count > 0 {
+                        let mut inserted = 0u32;
+                        crate::stores::profiles::PROFILE_CACHE.with_mut(|cache| {
+                            for contact in &db_contacts {
+                                let pk_hex = contact.public_key().to_hex();
+                                if cache.peek(&pk_hex).is_some() {
+                                    continue;
+                                }
+                                let metadata = contact.metadata();
+                                let profile = crate::stores::profiles::metadata_to_profile(
+                                    pk_hex.clone(),
+                                    &metadata,
+                                );
+                                cache.put(pk_hex, profile);
+                                inserted += 1;
+                            }
+                        });
+                        log::info!(
+                            "Loaded {}/{} followed profiles into PROFILE_CACHE from SDK database",
+                            inserted,
+                            count
+                        );
+                    }
+                }
+                Err(e) => {
+                    log::warn!("Failed to load contacts from SDK database: {}", e);
+                }
+            }
+        }
+
+        // Phase 2: Spawn contact list prefetch (uses fetch_events_aggregated which
+        // is also DB-first, so this primarily benefits CONTACTS_CACHE).
+        let pubkey_for_contacts = pubkey_str.clone();
         spawn(async move {
-            match nostr_client::fetch_contacts(pubkey).await {
+            match nostr_client::fetch_contacts(pubkey_for_contacts).await {
                 Ok(contacts) => {
                     log::info!("Prefetched {} contacts into memory cache", contacts.len());
                 }
@@ -846,49 +922,39 @@ async fn run_post_login_init() {
                 }
             }
         });
-    }
-    spawn(async move {
-        if let Some(client) = crate::stores::nostr_client::get_client() {
-            log::info!("Prefetching metadata for all contacts...");
-            crate::stores::nostr_client::ensure_relays_ready(&client).await;
-            match client
-                .get_contact_list_metadata(std::time::Duration::from_secs(15))
-                .await
-            {
-                Ok(contacts) => {
-                    log::info!("Prefetched metadata for {} contacts", contacts.len());
-                    let mut inserted = 0u32;
-                    crate::stores::profiles::PROFILE_CACHE.with_mut(|cache| {
-                        for (pk, metadata) in &contacts {
-                            let pk_hex = pk.to_hex();
-                            if cache.peek(&pk_hex).is_some() {
-                                continue;
-                            }
-                            if let Some(profile) =
-                                crate::stores::profiles::metadata_to_profile(
-                                    pk_hex.clone(),
-                                    metadata,
-                                )
-                            {
-                                cache.put(pk_hex, profile);
-                                inserted += 1;
-                            }
-                        }
-                    });
+
+        // Phase 3: Background network refresh for profiles missing from local DB.
+        // fetch_profiles_batch_native has 3-tier cascade: cache → SDK DB → relays.
+        // After Phase 1 the cache is warm, so this only fetches what's truly missing.
+        let pubkey_for_batch = pubkey_str.clone();
+        spawn(async move {
+            let contact_pubkeys: std::collections::HashSet<PublicKey> =
+                match nostr_client::fetch_contacts(pubkey_for_batch).await {
+                    Ok(pubkeys) => pubkeys
+                        .into_iter()
+                        .filter_map(|pk| PublicKey::from_hex(&pk).ok())
+                        .collect(),
+                    Err(e) => {
+                        log::warn!("Cannot batch-fetch profiles, no contacts: {}", e);
+                        return;
+                    }
+                };
+            if contact_pubkeys.is_empty() {
+                return;
+            }
+            match crate::stores::profiles::fetch_profiles_batch_native(contact_pubkeys).await {
+                Ok(fetched) => {
                     log::info!(
-                        "Inserted {}/{} followed profiles into PROFILE_CACHE",
-                        inserted,
-                        contacts.len()
+                        "Background profile refresh: {} profiles up-to-date",
+                        fetched.len()
                     );
                 }
                 Err(e) => {
-                    log::warn!("Failed to prefetch contact metadata: {}", e);
+                    log::warn!("Background profile refresh failed: {}", e);
                 }
             }
-        } else {
-            log::debug!("Skipping contact metadata prefetch: no client available");
-        }
-    });
+        });
+    }
     // Prefetch relay lists for all followed users to warm the coverage map
     spawn(async move {
         crate::stores::relay::coverage::prefetch_relay_lists_for_follows().await;

--- a/src/stores/cashu/internal.rs
+++ b/src/stores/cashu/internal.rs
@@ -537,15 +537,15 @@ pub(crate) async fn cleanup_spent_proofs_internal(mint_url: &str) -> Result<(usi
     let allow_deletion = available_proofs.is_empty() || new_event_id.is_some();
     let mut deletion_recorded = !allow_deletion || event_ids_to_delete.is_empty();
     if allow_deletion && !event_ids_to_delete.is_empty() {
-        let valid_event_ids: Vec<_> = event_ids_to_delete
+        let valid_event_ids: Vec<EventId> = event_ids_to_delete
             .iter()
-            .filter(|id| EventId::from_hex(id).is_ok())
+            .filter_map(|id| EventId::from_hex(id).ok())
             .collect();
         if !valid_event_ids.is_empty() {
-            let mut tags = Vec::new();
-            for event_id in &valid_event_ids {
-                tags.push(nostr_sdk::Tag::event(EventId::from_hex(event_id).unwrap()));
-            }
+            let mut tags: Vec<nostr_sdk::Tag> = valid_event_ids
+                .iter()
+                .map(|id| nostr_sdk::Tag::event(*id))
+                .collect();
             tags.push(nostr_sdk::Tag::custom(
                 nostr_sdk::TagKind::custom("k"),
                 ["7375"],

--- a/src/stores/cashu/internal.rs
+++ b/src/stores/cashu/internal.rs
@@ -837,7 +837,7 @@ where
             );
             let normalized_mint = normalize_mint_url(mint_url);
             let proofs_to_recover = {
-                let mut states = MINT_RECOVERY_STATE.lock().unwrap();
+                let mut states = MINT_RECOVERY_STATE.lock().unwrap_or_else(|e| e.into_inner());
                 let state = states.entry(normalized_mint.clone()).or_default();
                 if state.in_recovery {
                     log::debug!(
@@ -863,7 +863,7 @@ where
                 }
                 loop {
                     let (queued_proofs, should_exit) = {
-                        let mut states = MINT_RECOVERY_STATE.lock().unwrap();
+                        let mut states = MINT_RECOVERY_STATE.lock().unwrap_or_else(|e| e.into_inner());
                         let state = states.entry(normalized_mint.clone()).or_default();
                         let proofs = std::mem::take(&mut state.pending_proofs);
                         if proofs.is_empty() {
@@ -962,7 +962,7 @@ pub(crate) async fn try_swap_or_recover(
             log::error!("Swap failed for {}: {}", mint_url, err_str);
             let normalized_mint = normalize_mint_url(mint_url);
             let proofs_to_recover = {
-                let mut states = MINT_RECOVERY_STATE.lock().unwrap();
+                let mut states = MINT_RECOVERY_STATE.lock().unwrap_or_else(|e| e.into_inner());
                 let state = states.entry(normalized_mint.clone()).or_default();
                 if state.in_recovery {
                     log::debug!(
@@ -990,7 +990,7 @@ pub(crate) async fn try_swap_or_recover(
                 }
                 loop {
                     let (queued_proofs, should_exit) = {
-                        let mut states = MINT_RECOVERY_STATE.lock().unwrap();
+                        let mut states = MINT_RECOVERY_STATE.lock().unwrap_or_else(|e| e.into_inner());
                         let state = states.entry(normalized_mint.clone()).or_default();
                         let proofs = std::mem::take(&mut state.pending_proofs);
                         if proofs.is_empty() {

--- a/src/stores/cashu/internal.rs
+++ b/src/stores/cashu/internal.rs
@@ -22,17 +22,34 @@ use lru::LruCache;
 use nostr_sdk::EventId;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex, OnceLock};
-static CACHED_SEED: OnceLock<std::sync::Mutex<Option<[u8; 64]>>> = OnceLock::new();
+use zeroize::Zeroize;
 
-fn get_seed_cache() -> &'static std::sync::Mutex<Option<[u8; 64]>> {
-    CACHED_SEED.get_or_init(|| std::sync::Mutex::new(None))
+struct ZeroizedSeed([u8; 64]);
+
+impl Drop for ZeroizedSeed {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl std::ops::Deref for ZeroizedSeed {
+    type Target = [u8; 64];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+static CACHED_SEED: OnceLock<Mutex<Option<ZeroizedSeed>>> = OnceLock::new();
+
+fn get_seed_cache() -> &'static Mutex<Option<ZeroizedSeed>> {
+    CACHED_SEED.get_or_init(|| Mutex::new(None))
 }
 
 pub fn clear_seed_cache() {
     let cache = get_seed_cache();
     let mut guard = cache
         .lock()
-        .unwrap_or_else(|e: std::sync::PoisonError<std::sync::MutexGuard<Option<[u8; 64]>>>| {
+        .unwrap_or_else(|e: std::sync::PoisonError<std::sync::MutexGuard<Option<ZeroizedSeed>>>| {
             e.into_inner()
         });
     *guard = None;
@@ -230,11 +247,11 @@ pub(crate) async fn derive_wallet_seed() -> Result<[u8; 64], String> {
         let guard = get_seed_cache().lock().unwrap_or_else(|e| e.into_inner());
         if let Some(cached) = &*guard {
             log::debug!("Using cached wallet seed");
-            return Ok(*cached);
+            return Ok(cached.0);
         }
     }
     use sha2::{Digest, Sha256};
-    let seed = if let Some(keys) = auth_store::get_keys() {
+    let mut seed = if let Some(keys) = auth_store::get_keys() {
         log::info!("Deriving seed from private key (nsec login)");
         let secret_key = keys.secret_key();
         let mut hasher = Sha256::new();
@@ -267,11 +284,13 @@ pub(crate) async fn derive_wallet_seed() -> Result<[u8; 64], String> {
         log::info!("Wallet seed derived from NIP-07 signature");
         seed
     };
+    let result = seed;
     {
         let mut guard = get_seed_cache().lock().unwrap_or_else(|e| e.into_inner());
-        *guard = Some(seed);
+        *guard = Some(ZeroizedSeed(seed));
     }
-    Ok(seed)
+    seed.zeroize();
+    Ok(result)
 }
 #[cfg(not(feature = "web"))]
 pub(crate) async fn derive_wallet_seed() -> Result<[u8; 64], String> {
@@ -634,7 +653,7 @@ pub(crate) async fn collect_p2pk_signing_keys() -> Vec<cdk::nuts::SecretKey> {
         }
     }
     if let Some(nostr_keys) = auth_store::get_keys() {
-        let secret_bytes = nostr_keys.secret_key().to_secret_bytes();
+        let mut secret_bytes = nostr_keys.secret_key().to_secret_bytes();
         match cdk::nuts::SecretKey::from_slice(&secret_bytes) {
             Ok(key) => {
                 log::debug!("Added Nostr identity key to P2PK signing keys");
@@ -644,6 +663,7 @@ pub(crate) async fn collect_p2pk_signing_keys() -> Vec<cdk::nuts::SecretKey> {
                 log::warn!("Failed to convert Nostr key for P2PK: {}", e);
             }
         }
+        secret_bytes.zeroize();
     }
     let mut seen_keys = std::collections::HashSet::new();
     keys.retain(|key| {

--- a/src/stores/cashu/lightning.rs
+++ b/src/stores/cashu/lightning.rs
@@ -759,15 +759,15 @@ async fn publish_melt_events(
         }
     }
     if !event_ids_to_delete.is_empty() {
-        let valid_event_ids: Vec<_> = event_ids_to_delete
+        let valid_event_ids: Vec<EventId> = event_ids_to_delete
             .iter()
-            .filter(|id| EventId::from_hex(id).is_ok())
+            .filter_map(|id| EventId::from_hex(id).ok())
             .collect();
         if !valid_event_ids.is_empty() {
-            let mut tags = Vec::new();
-            for event_id in &valid_event_ids {
-                tags.push(nostr_sdk::Tag::event(EventId::from_hex(event_id).unwrap()));
-            }
+            let mut tags: Vec<nostr_sdk::Tag> = valid_event_ids
+                .iter()
+                .map(|id| nostr_sdk::Tag::event(*id))
+                .collect();
             tags.push(nostr_sdk::Tag::custom(
                 nostr_sdk::TagKind::custom("k"),
                 ["7375"],

--- a/src/stores/cashu/mpp.rs
+++ b/src/stores/cashu/mpp.rs
@@ -402,15 +402,15 @@ pub async fn execute_mpp_melt(
             }
         }
         if !all_event_ids_to_delete.is_empty() {
-            let valid_event_ids: Vec<_> = all_event_ids_to_delete
+        let valid_event_ids: Vec<EventId> = all_event_ids_to_delete
+            .iter()
+            .filter_map(|id| EventId::from_hex(id).ok())
+            .collect();
+        if !valid_event_ids.is_empty() {
+            let mut tags: Vec<nostr_sdk::Tag> = valid_event_ids
                 .iter()
-                .filter(|id| EventId::from_hex(id).is_ok())
+                .map(|id| nostr_sdk::Tag::event(*id))
                 .collect();
-            if !valid_event_ids.is_empty() {
-                let mut tags = Vec::new();
-                for event_id in &valid_event_ids {
-                    tags.push(nostr_sdk::Tag::event(EventId::from_hex(event_id).unwrap()));
-                }
                 tags.push(nostr_sdk::Tag::custom(
                     nostr_sdk::TagKind::custom("k"),
                     ["7375"],

--- a/src/stores/cashu/receive.rs
+++ b/src/stores/cashu/receive.rs
@@ -273,28 +273,7 @@ pub async fn receive_tokens_with_options(
             log::debug!("Could not fetch keysets to verify status: {}", e);
         }
     }
-    match wallet.verify_token_dleq(&token).await {
-        Ok(()) => {
-            log::info!("DLEQ verification passed");
-        }
-        Err(e) => {
-            use cdk::Error as CdkError;
-            match &e {
-                CdkError::DleqProofNotProvided => {
-                    log::info!("Token has no DLEQ proofs — skipping verification");
-                }
-                CdkError::CouldNotVerifyDleq => {
-                    log::error!("DLEQ verification failed: invalid signature");
-                    return Err(
-                        "Token failed cryptographic verification — it may be invalid or tampered with.".to_string(),
-                    );
-                }
-                _ => {
-                    log::warn!("DLEQ verification error (continuing): {}", e);
-                }
-            }
-        }
-    }
+
     let p2pk_signing_keys = collect_p2pk_signing_keys().await;
     log::debug!(
         "Using {} P2PK signing keys for receive",

--- a/src/stores/cashu/send.rs
+++ b/src/stores/cashu/send.rs
@@ -643,15 +643,15 @@ async fn publish_send_events(
         new_event_id = Some(event_id_hex);
     }
     if !event_ids_to_delete.is_empty() {
-        let valid_event_ids: Vec<_> = event_ids_to_delete
+        let valid_event_ids: Vec<EventId> = event_ids_to_delete
             .iter()
-            .filter(|id| EventId::from_hex(id).is_ok())
+            .filter_map(|id| EventId::from_hex(id).ok())
             .collect();
         if !valid_event_ids.is_empty() {
-            let mut tags = Vec::new();
-            for event_id in &valid_event_ids {
-                tags.push(nostr_sdk::Tag::event(EventId::from_hex(event_id).unwrap()));
-            }
+            let mut tags: Vec<nostr_sdk::Tag> = valid_event_ids
+                .iter()
+                .map(|id| nostr_sdk::Tag::event(*id))
+                .collect();
             tags.push(nostr_sdk::Tag::custom(
                 nostr_sdk::TagKind::custom("k"),
                 ["7375"],

--- a/src/stores/content/zap_goals_store.rs
+++ b/src/stores/content/zap_goals_store.rs
@@ -410,7 +410,7 @@ fn extract_zap_amount_sats(event: &Event) -> Option<u64> {
             .unwrap_or(false)
     }) {
         if let Some(bolt11) = bolt11_tag.as_slice().get(1) {
-            if let Some(amount) = parse_bolt11_amount(bolt11.as_str()) {
+            if let Some(amount) = crate::utils::bolt11::parse_bolt11_amount(bolt11.as_str()) {
                 return Some(amount);
             }
         }
@@ -432,62 +432,8 @@ fn extract_zap_amount_sats(event: &Event) -> Option<u64> {
     }
 
     json.get("amount")
-        .and_then(|value| {
-            value
-                .as_u64()
-                .or_else(|| value.as_str()?.parse::<u64>().ok())
-        })
+        .and_then(|value| value.as_str()?.parse::<u64>().ok())
         .and_then(msats_to_sats)
-}
-
-fn parse_bolt11_amount(bolt11: &str) -> Option<u64> {
-    let lower = bolt11.to_lowercase();
-    if !lower.starts_with("lnbc") && !lower.starts_with("lntb") && !lower.starts_with("lnsb") {
-        return None;
-    }
-    let rest = &lower[4..];
-    if rest.starts_with('1')
-        && (rest.len() == 1
-            || !rest
-                .chars()
-                .nth(1)
-                .is_some_and(|ch| ch.is_ascii_digit() || ['m', 'u', 'n', 'p'].contains(&ch)))
-    {
-        return None;
-    }
-    let mut amount_end = 0;
-    let mut multiplier = None;
-    for (index, ch) in rest.chars().enumerate() {
-        if ch.is_ascii_digit() {
-            amount_end = index + 1;
-        } else if ['m', 'u', 'n', 'p'].contains(&ch) {
-            multiplier = Some(ch);
-            amount_end = index;
-            break;
-        } else {
-            amount_end = index;
-            break;
-        }
-    }
-    if amount_end == 0 {
-        return None;
-    }
-
-    let separator_index = amount_end + usize::from(multiplier.is_some());
-    if rest.chars().nth(separator_index) != Some('1') {
-        return None;
-    }
-
-    let amount: u64 = rest[..amount_end].parse().ok()?;
-    let amount_msats = match multiplier {
-        Some('m') => amount.checked_mul(100_000_000)?,
-        Some('u') => amount.checked_mul(100_000)?,
-        Some('n') => amount.checked_mul(100)?,
-        Some('p') => amount / 10,
-        Some(_) => return None,
-        None => amount.checked_mul(100_000_000_000)?,
-    };
-    msats_to_sats(amount_msats)
 }
 
 fn msats_to_sats(amount_msats: u64) -> Option<u64> {
@@ -760,34 +706,17 @@ pub fn format_goal_date(timestamp: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        extract_zap_amount_sats, normalize_relays, parse_bolt11_amount, parse_goal_event,
+        extract_zap_amount_sats, normalize_relays, parse_goal_event,
         receipt_targets_goal,
     };
     use nostr_sdk::{EventBuilder, Keys, Kind, Tag};
 
     #[test]
-    fn parse_bolt11_amount_accepts_amounts_starting_with_one() {
-        assert_eq!(parse_bolt11_amount("lnbc1m1example"), Some(100_000));
-        assert_eq!(parse_bolt11_amount("lnbc100m1example"), Some(10_000_000));
-    }
-
-    #[test]
-    fn parse_bolt11_amount_rejects_zero_amount_invoices() {
-        assert_eq!(parse_bolt11_amount("lnbc1"), None);
-        assert_eq!(parse_bolt11_amount("lnbc1qpayload"), None);
-    }
-
-    #[test]
-    fn parse_bolt11_amount_rejects_missing_separator() {
-        assert_eq!(parse_bolt11_amount("lnbc100uNOT_AN_INVOICE"), None);
-        assert_eq!(parse_bolt11_amount("lnbc100000invoicepayload"), None);
-    }
-
-    #[test]
-    fn parse_bolt11_amount_rejects_fractional_sat_amounts() {
-        assert_eq!(parse_bolt11_amount("lnbc5n1example"), None);
-        assert_eq!(parse_bolt11_amount("lnbc15000p1example"), None);
-        assert_eq!(parse_bolt11_amount("lnbc5p1example"), None);
+    fn parse_bolt11_rejects_invalid_strings() {
+        assert_eq!(crate::utils::bolt11::parse_bolt11_amount("lnbc1"), None);
+        assert_eq!(crate::utils::bolt11::parse_bolt11_amount("lnbc1qpayload"), None);
+        assert_eq!(crate::utils::bolt11::parse_bolt11_amount("not_an_invoice"), None);
+        assert_eq!(crate::utils::bolt11::parse_bolt11_amount(""), None);
     }
 
     #[test]

--- a/src/stores/eose_tracker.rs
+++ b/src/stores/eose_tracker.rs
@@ -43,7 +43,7 @@ impl EoseTracker {
                                 message: RelayMessage::EndOfStoredEvents(_),
                             }) => {
                                 let now = Timestamp::now().as_secs();
-                                let mut guard = inner.lock().unwrap();
+                                let mut guard = inner.lock().unwrap_or_else(|e| e.into_inner());
                                 guard
                                     .eose_map
                                     .entry(relay_url.to_string())
@@ -56,7 +56,7 @@ impl EoseTracker {
                             }
                             Ok(RelayPoolNotification::Event { relay_url, .. }) => {
                                 let now = Timestamp::now().as_secs();
-                                let mut guard = inner.lock().unwrap();
+                                let mut guard = inner.lock().unwrap_or_else(|e| e.into_inner());
                                 if let Some(ts) = guard.eose_map.get_mut(relay_url.as_str()) {
                                     if now > *ts {
                                         *ts = now;
@@ -83,7 +83,7 @@ impl EoseTracker {
                             message: RelayMessage::EndOfStoredEvents(_),
                         }) => {
                             let now = Timestamp::now().as_secs();
-                            let mut guard = inner.lock().unwrap();
+                            let mut guard = inner.lock().unwrap_or_else(|e| e.into_inner());
                             guard
                                 .eose_map
                                 .entry(relay_url.to_string())
@@ -96,7 +96,7 @@ impl EoseTracker {
                         }
                         Ok(RelayPoolNotification::Event { relay_url, .. }) => {
                             let now = Timestamp::now().as_secs();
-                            let mut guard = inner.lock().unwrap();
+                            let mut guard = inner.lock().unwrap_or_else(|e| e.into_inner());
                             if let Some(ts) = guard.eose_map.get_mut(relay_url.as_str()) {
                                 if now > *ts {
                                     *ts = now;
@@ -114,7 +114,7 @@ impl EoseTracker {
 
     pub fn get_min_since() -> Option<u64> {
         EOSE_TRACKER.get().and_then(|t| {
-            let map = t.inner.lock().unwrap();
+            let map = t.inner.lock().unwrap_or_else(|e| e.into_inner());
             map.eose_map
                 .values()
                 .min()
@@ -127,7 +127,7 @@ impl EoseTracker {
         EOSE_TRACKER.get().and_then(|t| {
             t.inner
                 .lock()
-                .unwrap()
+                .unwrap_or_else(|e| e.into_inner())
                 .eose_map
                 .get(relay_url)
                 .map(|ts| ts.saturating_sub(SINCE_BUFFER_SECS))

--- a/src/stores/media/blossom_store.rs
+++ b/src/stores/media/blossom_store.rs
@@ -227,14 +227,16 @@ fn is_valid_sha256(hash: &str) -> bool {
     hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit())
 }
 /// Add a custom Blossom server
-pub fn add_server(url: String) {
+pub fn add_server(url: String) -> Result<String, String> {
+    let normalized = crate::utils::validation::validate_blossom_server_url(&url)?;
     let store = BLOSSOM_SERVERS.read();
     let mut data = store.data();
     let mut servers = data.write();
-    if !servers.contains(&url) {
-        servers.push(url);
+    if !servers.contains(&normalized) {
+        servers.push(normalized.clone());
         save_servers_to_storage(&servers);
     }
+    Ok(normalized)
 }
 /// Remove a Blossom server
 pub fn remove_server(url: &str) {

--- a/src/stores/ndb/unknown_ids.rs
+++ b/src/stores/ndb/unknown_ids.rs
@@ -184,6 +184,6 @@ use once_cell::sync::Lazy;
 pub static UNKNOWN_IDS: Lazy<Mutex<UnknownIds>> = Lazy::new(|| Mutex::new(UnknownIds::new()));
 
 pub fn queue_event(event: nostr::Event) {
-    let mut ids = UNKNOWN_IDS.lock().unwrap();
+    let mut ids = UNKNOWN_IDS.lock().unwrap_or_else(|e| e.into_inner());
     ids.queue_event(event);
 }

--- a/src/stores/ndb/worker.rs
+++ b/src/stores/ndb/worker.rs
@@ -24,7 +24,7 @@ pub fn ndb_event_sender() -> Option<&'static tokio::sync::mpsc::UnboundedSender<
 pub fn take_event_receiver() -> Option<tokio::sync::mpsc::UnboundedReceiver<NdbEvent>> {
     NDB_EVENT_CHANNELS
         .get()
-        .and_then(|(_, rx_mutex)| rx_mutex.lock().unwrap().take())
+        .and_then(|(_, rx_mutex)| rx_mutex.lock().unwrap_or_else(|e| e.into_inner()).take())
 }
 
 pub fn start_ndb_worker() -> Result<(), String> {

--- a/src/stores/nostr_client/fetching.rs
+++ b/src/stores/nostr_client/fetching.rs
@@ -154,6 +154,59 @@ pub async fn fetch_chess_events(
 
     Ok(all_events)
 }
+/// Fetch topic posts using DB-first + relay-merge pattern.
+///
+/// Unlike the aggregated cache pattern (which returns stale DB data and discards
+/// fresh relay results in a fire-and-forget spawn), this:
+/// 1. Queries IndexedDB cache → return immediately for fast paint if found
+/// 2. Always fetches fresh from connected relays
+/// 3. Merges new relay events with DB events (deduped)
+/// 4. Returns the combined result so the UI always gets the latest data
+pub async fn fetch_topic_events(
+    filter: Filter,
+    timeout: Duration,
+) -> std::result::Result<Vec<nostr::Event>, String> {
+    let client = get_client().ok_or("Client not initialized")?;
+    ensure_relays_ready(&client).await;
+
+    let mut seen_ids: std::collections::HashSet<nostr::EventId> = std::collections::HashSet::new();
+    let mut all_events: Vec<nostr::Event> = vec![];
+
+    if let Ok(db_events) = client.database().query(filter.clone()).await {
+        if !db_events.is_empty() {
+            log::info!("Topic DB cache: {} events", db_events.len());
+            let db_vec: Vec<nostr::Event> = db_events.into_iter().collect();
+            for ev in &db_vec {
+                seen_ids.insert(ev.id);
+            }
+            all_events = db_vec;
+        }
+    }
+
+    match client.fetch_events(filter, timeout).await {
+        Ok(relay_events) => {
+            let mut new_count = 0;
+            for ev in relay_events {
+                if seen_ids.insert(ev.id) {
+                    new_count += 1;
+                    all_events.push(ev);
+                }
+            }
+            if new_count > 0 {
+                log::info!("Topic relay fetch: {} new events merged", new_count);
+            }
+        }
+        Err(e) => {
+            log::warn!(
+                "Topic relay fetch failed: {} (returning {} DB events)",
+                e,
+                all_events.len()
+            );
+        }
+    }
+
+    Ok(all_events)
+}
 /// Fetch radio events directly from relays, bypassing the aggregated cache.
 ///
 /// The aggregated cache pattern (`fetch_events_aggregated_with_client`) returns

--- a/src/stores/nostr_client/mod.rs
+++ b/src/stores/nostr_client/mod.rs
@@ -204,7 +204,7 @@ pub async fn initialize_client() -> std::result::Result<Arc<Client>, String> {
             .set_ingester_threads(2)
             .set_mapsize(1024usize * 1024 * 1024 * 1024)
             .set_sub_callback(move |_sub_id: u64| {
-                let _ = wake_tx.lock().unwrap().send(());
+                let _ = wake_tx.lock().unwrap_or_else(|e| e.into_inner()).send(());
             });
 
         let ndb = nostrdb::Ndb::new(&db_path_str, &config)
@@ -326,7 +326,7 @@ pub async fn initialize_client() -> std::result::Result<Arc<Client>, String> {
                 loop {
                     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
                     let mut ids = {
-                        let mut guard = crate::stores::ndb::unknown_ids::UNKNOWN_IDS.lock().unwrap();
+                        let mut guard = crate::stores::ndb::unknown_ids::UNKNOWN_IDS.lock().unwrap_or_else(|e| e.into_inner());
                         std::mem::take(&mut *guard)
                     };
                     if !ids.is_empty() {
@@ -338,7 +338,7 @@ pub async fn initialize_client() -> std::result::Result<Arc<Client>, String> {
                         }
                     }
                     {
-                        let mut guard = crate::stores::ndb::unknown_ids::UNKNOWN_IDS.lock().unwrap();
+                        let mut guard = crate::stores::ndb::unknown_ids::UNKNOWN_IDS.lock().unwrap_or_else(|e| e.into_inner());
                         std::mem::swap(&mut *guard, &mut ids);
                     }
                 }

--- a/src/stores/nostr_client/mod.rs
+++ b/src/stores/nostr_client/mod.rs
@@ -98,7 +98,7 @@ pub use fetching::{
     fetch_events_from_connected_relays, fetch_events_from_relays, fetch_metadata_targeted,
     fetch_profile_events_db, fetch_profile_events_from_relays,
     fetch_profile_events_from_relays_direct, fetch_profile_events_targeted,
-    fetch_radio_events, parse_event_id, ParsedEventId,
+    fetch_radio_events, fetch_topic_events, parse_event_id, ParsedEventId,
 };
 pub(crate) use fetching::fetch_events_from_connected_relays_with_client;
 #[cfg(feature = "native")]

--- a/src/stores/notification_dispatcher.rs
+++ b/src/stores/notification_dispatcher.rs
@@ -40,7 +40,7 @@ impl NotificationDispatcher {
         sub_id: SubscriptionId,
     ) -> (u64, tokio::sync::mpsc::UnboundedReceiver<std::sync::Arc<nostr::Event>>) {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         let id = inner.next_id;
         inner.next_id += 1;
         inner.subscribers.entry(sub_id).or_default().push((id, tx));
@@ -48,7 +48,7 @@ impl NotificationDispatcher {
     }
 
     pub fn unsubscribe(&self, sub_id: &SubscriptionId, callback_id: u64) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(senders) = inner.subscribers.get_mut(sub_id) {
             senders.retain(|(id, _)| *id != callback_id);
             if senders.is_empty() {
@@ -83,7 +83,7 @@ impl NotificationDispatcher {
                             crate::stores::ndb::cache_event(&event);
                             log::info!("notification_dispatcher: cached event {:?} in bridge cache", event.id.to_hex());
                         }
-                        let inner = inner.lock().unwrap();
+                        let inner = inner.lock().unwrap_or_else(|e| e.into_inner());
                         if let Some(senders) = inner.subscribers.get(&subscription_id) {
                             let event = Arc::new(*event.clone());
                             for (_, tx) in senders {
@@ -106,7 +106,7 @@ impl NotificationDispatcher {
                     ..
                 }) = notifications.recv().await
                 {
-                    let inner = inner.lock().unwrap();
+                    let inner = inner.lock().unwrap_or_else(|e| e.into_inner());
                     if let Some(senders) = inner.subscribers.get(&subscription_id) {
                         let event = Arc::new(*event.clone());
                         for (_, tx) in senders {

--- a/src/stores/notification_dispatcher.rs
+++ b/src/stores/notification_dispatcher.rs
@@ -71,27 +71,38 @@ impl NotificationDispatcher {
 
                 rt.block_on(async move {
                     let mut notifications = client.notifications();
-                    while let Ok(RelayPoolNotification::Event {
-                        subscription_id,
-                        event,
-                        ..
-                    }) = notifications.recv().await
-                    {
-                        #[cfg(feature = "native")]
-                        {
-                            crate::stores::ndb::unknown_ids::queue_event((*event).clone());
-                            crate::stores::ndb::cache_event(&event);
-                            log::info!("notification_dispatcher: cached event {:?} in bridge cache", event.id.to_hex());
-                        }
-                        let inner = inner.lock().unwrap_or_else(|e| e.into_inner());
-                        if let Some(senders) = inner.subscribers.get(&subscription_id) {
-                            let event = Arc::new(*event.clone());
-                            for (_, tx) in senders {
-                                let _ = tx.send(event.clone());
+                    loop {
+                        match notifications.recv().await {
+                            Ok(RelayPoolNotification::Event {
+                                subscription_id,
+                                event,
+                                ..
+                            }) => {
+                                #[cfg(feature = "native")]
+                                {
+                                    crate::stores::ndb::unknown_ids::queue_event((*event).clone());
+                                    crate::stores::ndb::cache_event(&event);
+                                    log::info!("notification_dispatcher: cached event {:?} in bridge cache", event.id.to_hex());
+                                }
+                                let inner = inner.lock().unwrap_or_else(|e| e.into_inner());
+                                if let Some(senders) = inner.subscribers.get(&subscription_id) {
+                                    let event = Arc::new(*event.clone());
+                                    for (_, tx) in senders {
+                                        let _ = tx.send(event.clone());
+                                    }
+                                }
                             }
+                            Ok(RelayPoolNotification::Shutdown) => {
+                                log::info!("notification_dispatcher: relay pool shutdown, exiting native listener");
+                                break;
+                            }
+                            Err(_) => {
+                                log::info!("notification_dispatcher: notification stream closed, exiting native listener");
+                                break;
+                            }
+                            _ => {}
                         }
                     }
-                    log::info!("notification_dispatcher: notification stream closed, exiting native listener");
                 });
             });
         }
@@ -100,21 +111,32 @@ impl NotificationDispatcher {
         {
             wasm_bindgen_futures::spawn_local(async move {
                 let mut notifications = client.notifications();
-                while let Ok(RelayPoolNotification::Event {
-                    subscription_id,
-                    event,
-                    ..
-                }) = notifications.recv().await
-                {
-                    let inner = inner.lock().unwrap_or_else(|e| e.into_inner());
-                    if let Some(senders) = inner.subscribers.get(&subscription_id) {
-                        let event = Arc::new(*event.clone());
-                        for (_, tx) in senders {
-                            let _ = tx.send(event.clone());
+                loop {
+                    match notifications.recv().await {
+                        Ok(RelayPoolNotification::Event {
+                            subscription_id,
+                            event,
+                            ..
+                        }) => {
+                            let inner = inner.lock().unwrap_or_else(|e| e.into_inner());
+                            if let Some(senders) = inner.subscribers.get(&subscription_id) {
+                                let event = Arc::new(*event.clone());
+                                for (_, tx) in senders {
+                                    let _ = tx.send(event.clone());
+                                }
+                            }
                         }
+                        Ok(RelayPoolNotification::Shutdown) => {
+                            log::info!("notification_dispatcher: relay pool shutdown, exiting wasm listener");
+                            break;
+                        }
+                        Err(_) => {
+                            log::info!("notification_dispatcher: notification stream closed, exiting wasm listener");
+                            break;
+                        }
+                        _ => {}
                     }
                 }
-                log::info!("notification_dispatcher: notification stream closed, exiting wasm listener");
             });
         }
     }

--- a/src/stores/notification_dispatcher.rs
+++ b/src/stores/notification_dispatcher.rs
@@ -71,43 +71,18 @@ impl NotificationDispatcher {
 
                 rt.block_on(async move {
                     let mut notifications = client.notifications();
-                    loop {
-                        if let Ok(RelayPoolNotification::Event {
-                            subscription_id,
-                            event,
-                            ..
-                        }) = notifications.recv().await
-                        {
-                            #[cfg(feature = "native")]
-                            {
-                                crate::stores::ndb::unknown_ids::queue_event((*event).clone());
-                                crate::stores::ndb::cache_event(&event);
-                                log::info!("notification_dispatcher: cached event {:?} in bridge cache", event.id.to_hex());
-                            }
-                            let inner = inner.lock().unwrap();
-                            if let Some(senders) = inner.subscribers.get(&subscription_id) {
-                                let event = Arc::new(*event.clone());
-                                for (_, tx) in senders {
-                                    let _ = tx.send(event.clone());
-                                }
-                            }
-                        }
-                    }
-                });
-            });
-        }
-
-        #[cfg(target_arch = "wasm32")]
-        {
-            wasm_bindgen_futures::spawn_local(async move {
-                let mut notifications = client.notifications();
-                loop {
-                    if let Ok(RelayPoolNotification::Event {
+                    while let Ok(RelayPoolNotification::Event {
                         subscription_id,
                         event,
                         ..
                     }) = notifications.recv().await
                     {
+                        #[cfg(feature = "native")]
+                        {
+                            crate::stores::ndb::unknown_ids::queue_event((*event).clone());
+                            crate::stores::ndb::cache_event(&event);
+                            log::info!("notification_dispatcher: cached event {:?} in bridge cache", event.id.to_hex());
+                        }
                         let inner = inner.lock().unwrap();
                         if let Some(senders) = inner.subscribers.get(&subscription_id) {
                             let event = Arc::new(*event.clone());
@@ -116,7 +91,30 @@ impl NotificationDispatcher {
                             }
                         }
                     }
+                    log::info!("notification_dispatcher: notification stream closed, exiting native listener");
+                });
+            });
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            wasm_bindgen_futures::spawn_local(async move {
+                let mut notifications = client.notifications();
+                while let Ok(RelayPoolNotification::Event {
+                    subscription_id,
+                    event,
+                    ..
+                }) = notifications.recv().await
+                {
+                    let inner = inner.lock().unwrap();
+                    if let Some(senders) = inner.subscribers.get(&subscription_id) {
+                        let event = Arc::new(*event.clone());
+                        for (_, tx) in senders {
+                            let _ = tx.send(event.clone());
+                        }
+                    }
                 }
+                log::info!("notification_dispatcher: notification stream closed, exiting wasm listener");
             });
         }
     }

--- a/src/stores/profiles.rs
+++ b/src/stores/profiles.rs
@@ -138,7 +138,7 @@ pub static PROFILE_CACHE: GlobalSignal<LruCache<String, Profile>> =
     Signal::global(|| LruCache::new(NonZeroUsize::new(5000).unwrap()));
 /// Cache TTL in seconds (24 hours)
 /// Increased from 5 minutes to reduce network requests for stable profile data
-const CACHE_TTL_SECONDS: i64 = 24 * 60 * 60;
+pub(crate) const CACHE_TTL_SECONDS: i64 = 24 * 60 * 60;
 /// Convert a Profile to nostr_sdk Metadata, populating all known fields.
 pub fn profile_to_metadata(profile: &Profile) -> nostr_sdk::Metadata {
     let mut metadata = nostr_sdk::Metadata::new();

--- a/src/stores/profiles.rs
+++ b/src/stores/profiles.rs
@@ -378,9 +378,10 @@ pub fn parse_profile_event(event: &Event) -> Result<Profile, String> {
         raw_metadata_json: Some(content.clone()),
     })
 }
-/// Convert a nostr_sdk `Metadata` into a `Profile`, skipping entries with no
-/// searchable data (empty placeholders from `get_contact_list_metadata`).
-pub fn metadata_to_profile(pubkey: String, metadata: &Metadata) -> Option<Profile> {
+/// Convert a nostr_sdk `Metadata` into a `Profile`.
+/// Always returns a Profile (even with no name/display_name) so it can be
+/// cached and avoid repeated fetch attempts.
+pub fn metadata_to_profile(pubkey: String, metadata: &Metadata) -> Profile {
     let name = metadata
         .name
         .as_ref()
@@ -391,9 +392,6 @@ pub fn metadata_to_profile(pubkey: String, metadata: &Metadata) -> Option<Profil
         .as_ref()
         .filter(|s| !s.is_empty())
         .cloned();
-    if name.is_none() && display_name.is_none() {
-        return None;
-    }
     let bot = metadata.custom.get("bot").and_then(|v| {
         if let Some(b) = v.as_bool() {
             Some(b)
@@ -421,7 +419,7 @@ pub fn metadata_to_profile(pubkey: String, metadata: &Metadata) -> Option<Profil
             None
         }
     });
-    Some(Profile {
+    Profile {
         pubkey,
         name,
         display_name,
@@ -464,7 +462,7 @@ pub fn metadata_to_profile(pubkey: String, metadata: &Metadata) -> Option<Profil
         birthday,
         fetched_at: Utc::now(),
         raw_metadata_json: None,
-    })
+    }
 }
 /// Get a profile from cache (if available)
 pub fn get_cached_profile(pubkey: &str) -> Option<Profile> {

--- a/src/stores/relay/nip65.rs
+++ b/src/stores/relay/nip65.rs
@@ -1336,12 +1336,16 @@ pub async fn init_nip51_relay_lists(client: Arc<Client>) -> Result<(), String> {
 /// Track the current real-time subscription ID for NIP-65 updates
 pub static RELAY_LIST_SUBSCRIPTION_ID: GlobalSignal<Option<SubscriptionId>> =
     Signal::global(|| None);
-/// Start real-time subscription for NIP-65 relay list updates
-/// Invalidates search relay cache when user's kind 10002 is updated
+static RELAY_LIST_LISTENER_TASK: GlobalSignal<Option<dioxus_core::Task>> =
+    Signal::global(|| None);
 pub async fn start_relay_list_subscription() {
     if RELAY_LIST_SUBSCRIPTION_ID.read().is_some() {
         log::debug!("Relay list subscription already active");
         return;
+    }
+    if let Some(old_task) = RELAY_LIST_LISTENER_TASK.write().take() {
+        log::info!("Cancelling old relay list listener task");
+        old_task.cancel();
     }
     let client = match crate::stores::nostr_client::get_client() {
         Some(c) => c,
@@ -1376,7 +1380,7 @@ pub async fn start_relay_list_subscription() {
         Ok(sub_id) => {
             RELAY_LIST_SUBSCRIPTION_ID.write().replace(sub_id.clone());
             log::info!("Started relay list subscription: {:?}", sub_id);
-            spawn(async move {
+            let task = spawn(async move {
                 let mut notifications = client.notifications();
                 while let Ok(notification) = notifications.recv().await {
                     if let nostr_sdk::RelayPoolNotification::Event {
@@ -1415,17 +1419,24 @@ pub async fn start_relay_list_subscription() {
                         }
                     }
                 }
-                log::warn!("Relay list subscription ended - clearing for reconnect");
-                *RELAY_LIST_SUBSCRIPTION_ID.write() = None;
+                let current_sub_id = RELAY_LIST_SUBSCRIPTION_ID.read().clone();
+                if current_sub_id.as_ref() == Some(&sub_id) {
+                    log::warn!("Relay list subscription ended - clearing for reconnect");
+                    *RELAY_LIST_SUBSCRIPTION_ID.write() = None;
+                }
             });
+            *RELAY_LIST_LISTENER_TASK.write() = Some(task);
         }
         Err(e) => {
             log::error!("Failed to start relay list subscription: {}", e);
         }
     }
 }
-/// Stop real-time relay list subscription
 pub async fn stop_relay_list_subscription() {
+    if let Some(task) = RELAY_LIST_LISTENER_TASK.write().take() {
+        log::info!("Cancelling relay list listener task");
+        task.cancel();
+    }
     let sub_id = RELAY_LIST_SUBSCRIPTION_ID.read().clone();
     if let Some(id) = sub_id {
         if let Some(client) = crate::stores::nostr_client::get_client() {

--- a/src/stores/social/pin_boards_store/fetch.rs
+++ b/src/stores/social/pin_boards_store/fetch.rs
@@ -488,7 +488,7 @@ fn extract_zap_amount(event: &NostrEvent) -> u64 {
     for tag in event.tags.iter() {
         if tag.kind() == TagKind::Custom("bolt11".into()) {
             if let Some(bolt11) = tag.content() {
-                if let Some(amount) = parse_bolt11_amount(bolt11) {
+                if let Some(amount) = crate::utils::bolt11::parse_bolt11_amount_msats(bolt11) {
                     return amount;
                 }
             }
@@ -504,44 +504,6 @@ fn extract_zap_amount(event: &NostrEvent) -> u64 {
         }
     }
     0
-}
-
-/// Parse amount from bolt11 invoice string (returns msats)
-fn parse_bolt11_amount(bolt11: &str) -> Option<u64> {
-    let lower = bolt11.to_lowercase();
-    if !lower.starts_with("lnbc") && !lower.starts_with("lntb") {
-        return None;
-    }
-    let prefix_len = 4;
-    let rest = &lower[prefix_len..];
-    let mut amount_end = 0;
-    let mut multiplier_char = None;
-    for (i, c) in rest.chars().enumerate() {
-        if c.is_ascii_digit() {
-            amount_end = i + 1;
-        } else if ['m', 'u', 'n', 'p'].contains(&c) {
-            multiplier_char = Some(c);
-            amount_end = i;
-            break;
-        } else {
-            amount_end = i;
-            break;
-        }
-    }
-    if amount_end == 0 {
-        return None;
-    }
-    let amount_str = &rest[..amount_end];
-    let amount: u64 = amount_str.parse().ok()?;
-    let msats = match multiplier_char {
-        Some('m') => amount * 100_000_000,
-        Some('u') => amount * 100_000,
-        Some('n') => amount * 100,
-        Some('p') => amount / 10,
-        Some(_) => return None,
-        None => amount * 100_000_000_000,
-    };
-    Some(msats)
 }
 
 /// Extract sender pubkey from zap receipt

--- a/src/stores/social/topic_store/fetch.rs
+++ b/src/stores/social/topic_store/fetch.rs
@@ -10,7 +10,7 @@ pub async fn fetch_topic_posts(
     *LOADING_TOPIC_POSTS.write() = true;
     let filter = topic_posts_filter(topic, limit, until);
     let result =
-        crate::stores::nostr_client::fetch_events_aggregated(filter, Duration::from_secs(15)).await;
+        crate::stores::nostr_client::fetch_topic_events(filter, Duration::from_secs(15)).await;
     *LOADING_TOPIC_POSTS.write() = false;
 
     match result {
@@ -36,7 +36,7 @@ pub async fn fetch_recent_posts(
     *LOADING_TOPIC_POSTS.write() = true;
     let filter = recent_topic_posts_filter(limit, until);
     let result =
-        crate::stores::nostr_client::fetch_events_aggregated(filter, Duration::from_secs(15)).await;
+        crate::stores::nostr_client::fetch_topic_events(filter, Duration::from_secs(15)).await;
     *LOADING_TOPIC_POSTS.write() = false;
 
     match result {
@@ -66,18 +66,21 @@ pub async fn fetch_subscribed_feed(
 
     *LOADING_TOPIC_POSTS.write() = true;
 
-    // Build filters for each topic and merge results
-    let topic_tags: Vec<String> = topics.iter().map(|t| format!("#{}", t)).collect();
+    let topic_urls: Vec<String> = topics
+        .iter()
+        .flat_map(|t| topic_to_filter_urls(t))
+        .collect();
     let mut filter = Filter::new()
         .kind(Kind::Comment)
-        .custom_tags(SingleLetterTag::uppercase(Alphabet::I), topic_tags)
+        .custom_tags(SingleLetterTag::uppercase(Alphabet::I), topic_urls)
+        .custom_tag(SingleLetterTag::uppercase(Alphabet::K), "web".to_string())
         .limit(limit);
     if let Some(ts) = until {
         filter = filter.until(Timestamp::from(ts));
     }
 
     let result =
-        crate::stores::nostr_client::fetch_events_aggregated(filter, Duration::from_secs(15)).await;
+        crate::stores::nostr_client::fetch_topic_events(filter, Duration::from_secs(15)).await;
     *LOADING_TOPIC_POSTS.write() = false;
 
     match result {
@@ -135,7 +138,7 @@ pub async fn fetch_votes_batch(
 
     let filter = votes_filter(event_ids.clone());
     let events =
-        crate::stores::nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10))
+        crate::stores::nostr_client::fetch_topic_events(filter, Duration::from_secs(10))
             .await?;
 
     // Aggregate votes, deduplicating by latest per pubkey per post
@@ -199,7 +202,7 @@ pub async fn fetch_post_by_id(event_id: &str) -> std::result::Result<Option<Topi
 
     let filter = Filter::new().id(id).limit(1);
     let events =
-        crate::stores::nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10))
+        crate::stores::nostr_client::fetch_topic_events(filter, Duration::from_secs(10))
             .await?;
 
     if let Some(event) = events.first() {
@@ -219,7 +222,7 @@ pub async fn fetch_post_replies(
 ) -> std::result::Result<Vec<TopicPost>, String> {
     let filter = post_replies_filter(post_id, limit);
     let events =
-        crate::stores::nostr_client::fetch_events_aggregated(filter, Duration::from_secs(10))
+        crate::stores::nostr_client::fetch_topic_events(filter, Duration::from_secs(10))
             .await?;
 
     let mut posts: Vec<TopicPost> = events
@@ -237,7 +240,7 @@ pub async fn fetch_post_replies(
 pub async fn discover_topics(limit: usize) -> std::result::Result<Vec<TopicInfo>, String> {
     let filter = recent_topic_posts_filter(500, None);
     let events =
-        crate::stores::nostr_client::fetch_events_aggregated(filter, Duration::from_secs(15))
+        crate::stores::nostr_client::fetch_topic_events(filter, Duration::from_secs(15))
             .await?;
 
     let mut topic_counts: HashMap<String, (usize, u64)> = HashMap::new();
@@ -273,4 +276,116 @@ pub async fn discover_topics(limit: usize) -> std::result::Result<Vec<TopicInfo>
 
     log::info!("Discovered {} topics", topics.len());
     Ok(topics)
+}
+
+pub async fn query_topic_posts_from_db(filter: Filter) -> Vec<TopicPost> {
+    let Some(client) = crate::stores::nostr_client::fetching::get_client() else {
+        return Vec::new();
+    };
+    match client.database().query(filter).await {
+        Ok(events) => {
+            let event_vec: Vec<NostrEvent> = events.into_iter().collect();
+            let mut posts: Vec<TopicPost> = event_vec.iter().filter_map(parse_topic_post).collect();
+            posts.sort_by_key(|b| std::cmp::Reverse(b.created_at));
+            log::info!("Topic DB-only: {} posts instantly", posts.len());
+            posts
+        }
+        Err(e) => {
+            log::warn!("Topic DB query failed: {}", e);
+            Vec::new()
+        }
+    }
+}
+
+pub async fn query_votes_from_db(
+    event_ids: Vec<EventId>,
+    user_pubkey: Option<PublicKey>,
+) -> HashMap<String, VoteCounts> {
+    if event_ids.is_empty() {
+        return HashMap::new();
+    }
+    let Some(client) = crate::stores::nostr_client::fetching::get_client() else {
+        return HashMap::new();
+    };
+    let filter = votes_filter(event_ids.clone());
+    let events = match client.database().query(filter).await {
+        Ok(e) => e,
+        Err(e) => {
+            log::warn!("Topic votes DB query failed: {}", e);
+            return HashMap::new();
+        }
+    };
+    let event_vec: Vec<NostrEvent> = events.into_iter().collect();
+
+    let mut vote_map: HashMap<String, HashMap<String, (VoteDirection, u64)>> = HashMap::new();
+    for event in &event_vec {
+        if let Some((target_id, direction)) = parse_vote(event) {
+            let pubkey = event.pubkey.to_hex();
+            let created_at = event.created_at.as_secs();
+            let post_votes = vote_map.entry(target_id).or_default();
+            let entry = post_votes.entry(pubkey).or_insert((direction, created_at));
+            if created_at > entry.1 {
+                *entry = (direction, created_at);
+            }
+        }
+    }
+
+    let user_hex = user_pubkey.map(|pk| pk.to_hex());
+    let mut result = HashMap::new();
+    for id in &event_ids {
+        let id_hex = id.to_hex();
+        let mut counts = VoteCounts::default();
+        if let Some(post_votes) = vote_map.get(&id_hex) {
+            for (pubkey, (direction, _)) in post_votes {
+                match direction {
+                    VoteDirection::Up => counts.upvotes += 1,
+                    VoteDirection::Down => counts.downvotes += 1,
+                }
+                if user_hex.as_ref() == Some(pubkey) {
+                    counts.user_vote = Some(*direction);
+                }
+            }
+        }
+        result.insert(id_hex, counts);
+    }
+    result
+}
+
+pub async fn query_discover_topics_from_db(limit: usize) -> Vec<TopicInfo> {
+    let Some(client) = crate::stores::nostr_client::fetching::get_client() else {
+        return Vec::new();
+    };
+    let filter = recent_topic_posts_filter(500, None);
+    match client.database().query(filter).await {
+        Ok(events) => {
+            let event_vec: Vec<NostrEvent> = events.into_iter().collect();
+            let mut topic_counts: HashMap<String, (usize, u64)> = HashMap::new();
+            for event in &event_vec {
+                if let Some(topic_name) = extract_topic_name(event) {
+                    let entry = topic_counts.entry(topic_name).or_insert((0, 0));
+                    entry.0 += 1;
+                    let ts = event.created_at.as_secs();
+                    if ts > entry.1 {
+                        entry.1 = ts;
+                    }
+                }
+            }
+            let mut topics: Vec<TopicInfo> = topic_counts
+                .into_iter()
+                .map(|(name, (count, latest))| TopicInfo {
+                    name,
+                    post_count: count,
+                    latest_post_at: Some(latest),
+                })
+                .collect();
+            topics.sort_by_key(|b| std::cmp::Reverse(b.post_count));
+            topics.truncate(limit);
+            log::info!("Topic DB-only: discovered {} topics instantly", topics.len());
+            topics
+        }
+        Err(e) => {
+            log::warn!("Topic discover DB query failed: {}", e);
+            Vec::new()
+        }
+    }
 }

--- a/src/stores/social/topic_store/mod.rs
+++ b/src/stores/social/topic_store/mod.rs
@@ -25,7 +25,7 @@ use dioxus::prelude::*;
 use lru::LruCache;
 use nostr::Event as NostrEvent;
 use nostr_sdk::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::rc::Rc;
 
@@ -73,6 +73,24 @@ pub struct TopicPost {
     pub is_root: bool,
     pub created_at: u64,
     pub event: NostrEvent,
+}
+
+pub fn merge_pending_posts(
+    mut posts: Signal<Vec<TopicPost>>,
+    pending: Vec<TopicPost>,
+) {
+    if pending.is_empty() {
+        return;
+    }
+    let mut current = posts.read().clone();
+    let existing: HashSet<String> = current.iter().map(|p| p.id.clone()).collect();
+    for p in pending {
+        if !existing.contains(&p.id) {
+            current.push(p);
+        }
+    }
+    current.sort_by_key(|b| std::cmp::Reverse(b.created_at));
+    posts.set(current);
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/src/stores/social/topic_store/mod.rs
+++ b/src/stores/social/topic_store/mod.rs
@@ -1,8 +1,11 @@
 //! Topic Store
-//! Handles hashtag-based topical communities (Damus DIP "Topical Communities")
+//! Handles NIP-73 web URL topical communities (NIP-22 comments on external content)
+//!
+//! Reads from both nostr.blue and clawstr.com URL namespaces.
+//! Publishes with nostr.blue URLs.
 //!
 //! Event Kinds:
-//! - 1111 (Kind::Comment): Topic posts & replies (NIP-22 with NIP-73 external hashtag)
+//! - 1111 (Kind::Comment): Topic posts & replies (NIP-22 with NIP-73 web URL)
 //! - 10073: User subscriptions (replaceable, `I` tags for subscribed topics)
 //! - 7 (Kind::Reaction): Voting - "+" upvote, "-" downvote
 //!
@@ -27,6 +30,30 @@ use std::num::NonZeroUsize;
 use std::rc::Rc;
 
 pub const KIND_TOPIC_SUBSCRIPTION: u16 = 10073;
+
+const TOPIC_URL_BASE: &str = "https://nostr.blue/topics/t/";
+const TOPIC_URL_CLAWSTR: &str = "https://clawstr.com/c/";
+
+pub fn topic_to_publish_url(topic: &str) -> String {
+    format!("{}{}", TOPIC_URL_BASE, topic)
+}
+
+pub fn topic_to_filter_urls(topic: &str) -> Vec<String> {
+    vec![
+        format!("{}{}", TOPIC_URL_BASE, topic),
+        format!("{}{}", TOPIC_URL_CLAWSTR, topic),
+    ]
+}
+
+fn url_to_topic(url: &str) -> Option<String> {
+    url.strip_prefix(TOPIC_URL_BASE)
+        .or_else(|| url.strip_prefix(TOPIC_URL_CLAWSTR))
+        .map(String::from)
+}
+
+fn is_topic_url(url: &str) -> bool {
+    url.starts_with(TOPIC_URL_BASE) || url.starts_with(TOPIC_URL_CLAWSTR)
+}
 
 const TOPIC_POSTS_CACHE_SIZE: usize = 500;
 const TOPIC_VOTES_CACHE_SIZE: usize = 1000;
@@ -209,12 +236,16 @@ pub fn parse_subscriptions(event: &NostrEvent) -> Vec<String> {
         .iter()
         .filter_map(|tag| {
             if let Some(TagStandard::ExternalContent {
-                content: ExternalContentId::Hashtag(name),
+                content,
                 uppercase: true,
                 ..
             }) = tag.as_standardized()
             {
-                Some(name.clone())
+                match content {
+                    ExternalContentId::Url(url) => url_to_topic(url.as_str()),
+                    ExternalContentId::Hashtag(name) => Some(name.clone()),
+                    _ => None,
+                }
             } else {
                 None
             }
@@ -246,41 +277,43 @@ pub fn parse_vote(event: &NostrEvent) -> Option<(String, VoteDirection)> {
 
 // --- Helpers ---
 
-/// Check if a kind 1111 event is a topic post (has NIP-73 hashtag external content)
+/// Check if a kind 1111 event is a topic post (has NIP-73 web URL external content)
 pub fn is_topic_post(event: &NostrEvent) -> bool {
     event.kind == Kind::Comment
         && event.tags.iter().any(|tag| {
-            matches!(
-                tag.as_standardized(),
+            match tag.as_standardized() {
                 Some(TagStandard::ExternalContent {
-                    content: ExternalContentId::Hashtag(_),
+                    content: ExternalContentId::Url(url),
                     ..
-                })
-            )
+                }) => is_topic_url(url.as_str()),
+                _ => false,
+            }
         })
 }
 
 /// Extract topic name from a topic post event (prefer uppercase I tag = root)
 pub fn extract_topic_name(event: &NostrEvent) -> Option<String> {
-    // First try uppercase I tag (root reference)
     for tag in event.tags.iter() {
         if let Some(TagStandard::ExternalContent {
-            content: ExternalContentId::Hashtag(name),
+            content: ExternalContentId::Url(url),
             uppercase: true,
             ..
         }) = tag.as_standardized()
         {
-            return Some(name.clone());
+            if let Some(name) = url_to_topic(url.as_str()) {
+                return Some(name);
+            }
         }
     }
-    // Fallback to lowercase i tag
     for tag in event.tags.iter() {
         if let Some(TagStandard::ExternalContent {
-            content: ExternalContentId::Hashtag(name),
+            content: ExternalContentId::Url(url),
             ..
         }) = tag.as_standardized()
         {
-            return Some(name.clone());
+            if let Some(name) = url_to_topic(url.as_str()) {
+                return Some(name);
+            }
         }
     }
     None
@@ -288,12 +321,13 @@ pub fn extract_topic_name(event: &NostrEvent) -> Option<String> {
 
 // --- Filter Builders ---
 
-/// Filter for topic posts in a specific topic
+/// Filter for topic posts in a specific topic (queries both nostr.blue and clawstr URLs)
 pub fn topic_posts_filter(topic: &str, limit: usize, until: Option<u64>) -> Filter {
-    let topic_tag = format!("#{}", topic);
+    let urls = topic_to_filter_urls(topic);
     let mut filter = Filter::new()
         .kind(Kind::Comment)
-        .custom_tag(SingleLetterTag::uppercase(Alphabet::I), topic_tag)
+        .custom_tags(SingleLetterTag::uppercase(Alphabet::I), urls)
+        .custom_tag(SingleLetterTag::uppercase(Alphabet::K), "web".to_string())
         .limit(limit);
     if let Some(ts) = until {
         filter = filter.until(Timestamp::from(ts));
@@ -301,11 +335,11 @@ pub fn topic_posts_filter(topic: &str, limit: usize, until: Option<u64>) -> Filt
     filter
 }
 
-/// Filter for recent topic posts across all topics (global feed)
+/// Filter for recent topic posts across all topics (global feed via #K web)
 pub fn recent_topic_posts_filter(limit: usize, until: Option<u64>) -> Filter {
     let mut filter = Filter::new()
         .kind(Kind::Comment)
-        .custom_tag(SingleLetterTag::uppercase(Alphabet::K), "#")
+        .custom_tag(SingleLetterTag::uppercase(Alphabet::K), "web".to_string())
         .limit(limit);
     if let Some(ts) = until {
         filter = filter.until(Timestamp::from(ts));
@@ -335,6 +369,26 @@ pub fn post_replies_filter(post_id: &str, limit: usize) -> Filter {
 }
 
 // --- Thread Tree ---
+
+/// Extract the root external content ID (uppercase I tag) from an event.
+/// Used when replying to preserve the original root for thread consistency.
+pub fn extract_root_external_content(event: &NostrEvent) -> Option<ExternalContentId> {
+    event.tags.iter().find_map(|tag| {
+        if let Some(TagStandard::ExternalContent {
+            content,
+            uppercase: true,
+            ..
+        }) = tag.as_standardized()
+        {
+            if let ExternalContentId::Url(url) = content {
+                if is_topic_url(url.as_str()) {
+                    return Some(content.clone());
+                }
+            }
+        }
+        None
+    })
+}
 
 /// Build a thread tree from flat posts list
 pub fn build_topic_thread_tree(posts: Vec<TopicPost>) -> Vec<Rc<TopicThread>> {

--- a/src/stores/social/topic_store/publish.rs
+++ b/src/stores/social/topic_store/publish.rs
@@ -5,10 +5,16 @@ use nostr::nips::nip73::ExternalContentId;
 use std::borrow::Cow;
 
 pub async fn create_topic_post(topic: &str, content: &str) -> std::result::Result<String, String> {
-    let hashtag = ExternalContentId::Hashtag(topic.to_string());
-    let target = CommentTarget::external(Cow::Owned(hashtag), None);
+    let url = Url::parse(&topic_to_publish_url(topic))
+        .map_err(|e| format!("Invalid topic URL: {}", e))?;
+    let content_id = ExternalContentId::Url(url);
+    let target = CommentTarget::external(Cow::Owned(content_id), None);
 
-    let builder = EventBuilder::comment(content, target, None);
+    let url2 = Url::parse(&topic_to_publish_url(topic)).unwrap();
+    let content_id2 = ExternalContentId::Url(url2);
+    let root = CommentTarget::external(Cow::Owned(content_id2), None);
+
+    let builder = EventBuilder::comment(content, target, Some(root));
 
     let event = crate::stores::publish_queue::signing::sign_event_builder(builder)
         .await
@@ -41,10 +47,10 @@ pub async fn reply_to_topic_post(
 
     let comment_to = CommentTarget::event(parent_id, Kind::Comment, Some(parent_pk), None);
 
-    let hashtag = ExternalContentId::Hashtag(parent.topic.clone());
-    let root = CommentTarget::external(Cow::Owned(hashtag), None);
+    let root = extract_root_external_content(&parent.event)
+        .map(|cid| CommentTarget::external(Cow::Owned(cid), None));
 
-    let builder = EventBuilder::comment(content, comment_to, Some(root));
+    let builder = EventBuilder::comment(content, comment_to, root);
 
     let event = crate::stores::publish_queue::signing::sign_event_builder(builder)
         .await
@@ -140,8 +146,9 @@ pub async fn update_subscriptions(topics: &[String]) -> std::result::Result<(), 
     let tags: Vec<Tag> = topics
         .iter()
         .map(|topic| {
+            let url = Url::parse(&topic_to_publish_url(topic)).unwrap();
             Tag::from_standardized(TagStandard::ExternalContent {
-                content: ExternalContentId::Hashtag(topic.clone()),
+                content: ExternalContentId::Url(url),
                 hint: None,
                 uppercase: true,
             })

--- a/src/stores/ui/notifications.rs
+++ b/src/stores/ui/notifications.rs
@@ -13,6 +13,7 @@ const PUBLISH_THROTTLE_SECONDS: i64 = 10 * 60;
 pub static UNREAD_COUNT: GlobalSignal<usize> = Signal::global(|| 0);
 /// Track the current real-time subscription ID
 pub static SUBSCRIPTION_ID: GlobalSignal<Option<SubscriptionId>> = Signal::global(|| None);
+static LISTENER_TASK: GlobalSignal<Option<dioxus_core::Task>> = Signal::global(|| None);
 /// Global signal to track when notifications were last checked
 /// Timestamp in Unix seconds (i64)
 pub static NOTIFICATIONS_CHECKED_AT: GlobalSignal<i64> = Signal::global(|| 0);
@@ -196,6 +197,10 @@ pub async fn start_realtime_subscription() {
         );
         return;
     }
+    if let Some(old_task) = LISTENER_TASK.write().take() {
+        log::info!("Cancelling old notification listener task");
+        old_task.cancel();
+    }
     if SUBSCRIPTION_ID.read().is_some() {
         log::debug!("Real-time notification subscription already active");
         return;
@@ -257,7 +262,7 @@ pub async fn start_realtime_subscription() {
             log::info!("Real-time notification subscription started: {:?}", sub_id);
             let my_pubkey_clone = my_pubkey;
             let client_for_etag = client.clone();
-            spawn(async move {
+            let task = spawn(async move {
                 let mut notifications = client.notifications();
                 while let Ok(notification) = notifications.recv().await {
                     if let nostr_sdk::RelayPoolNotification::Event {
@@ -290,6 +295,7 @@ pub async fn start_realtime_subscription() {
                 );
                 *SUBSCRIPTION_ID.write() = None;
             });
+            *LISTENER_TASK.write() = Some(task);
 
             spawn(async move {
                 spawn_etag_qtag_subscriptions(client_for_etag, my_pubkey_clone).await;
@@ -302,6 +308,10 @@ pub async fn start_realtime_subscription() {
 }
 /// Stop real-time notification subscription
 pub async fn stop_realtime_subscription() {
+    if let Some(task) = LISTENER_TASK.write().take() {
+        log::info!("Cancelling notification listener task");
+        task.cancel();
+    }
     let sub_id = SUBSCRIPTION_ID.read().clone();
     if let Some(id) = sub_id {
         if let Some(client) = nostr_client::get_client() {

--- a/src/stores/ui/search_history.rs
+++ b/src/stores/ui/search_history.rs
@@ -42,7 +42,7 @@ pub fn add_query(query: String) {
         return;
     }
     let cache = get_cache();
-    let mut history = cache.lock().unwrap();
+    let mut history = cache.lock().unwrap_or_else(|e| e.into_inner());
     history.items.retain(|item| match item {
         RecentSearchItem::Query(q) => q != &query,
         _ => true,
@@ -56,7 +56,7 @@ pub fn add_query(query: String) {
 
 pub fn add_profile(pubkey: String, display_name: String) {
     let cache = get_cache();
-    let mut history = cache.lock().unwrap();
+    let mut history = cache.lock().unwrap_or_else(|e| e.into_inner());
     history.items.retain(|item| match item {
         RecentSearchItem::Profile { pubkey: pk, .. } => pk != &pubkey,
         _ => true,
@@ -75,7 +75,7 @@ pub fn add_profile(pubkey: String, display_name: String) {
 #[allow(dead_code)]
 pub fn remove_item(index: usize) {
     let cache = get_cache();
-    let mut history = cache.lock().unwrap();
+    let mut history = cache.lock().unwrap_or_else(|e| e.into_inner());
     if index < history.items.len() {
         history.items.remove(index);
         save_to_storage(&history);
@@ -84,12 +84,12 @@ pub fn remove_item(index: usize) {
 
 pub fn clear_all() {
     let cache = get_cache();
-    let mut history = cache.lock().unwrap();
+    let mut history = cache.lock().unwrap_or_else(|e| e.into_inner());
     history.items.clear();
     save_to_storage(&history);
 }
 
 pub fn get_items() -> Vec<RecentSearchItem> {
     let cache = get_cache();
-    cache.lock().unwrap().items.clone()
+    cache.lock().unwrap_or_else(|e| e.into_inner()).items.clone()
 }

--- a/src/utils/audio/v4v_payment.rs
+++ b/src/utils/audio/v4v_payment.rs
@@ -153,7 +153,7 @@ async fn resolve_lnurl_invoice(address: &str, amount_sats: u64) -> Result<String
         .and_then(|v| v.as_str())
         .ok_or_else(|| format!("No invoice in response for {}", address))?;
     let expected_msats = amount_sats * 1000;
-    match crate::utils::bolt11::parse_bolt11_amount(pr) {
+    match crate::utils::bolt11::parse_bolt11_amount_msats(pr) {
         Some(parsed) if parsed == expected_msats => Ok(pr.to_string()),
         Some(parsed) => Err(format!(
             "Bolt11 amount mismatch for {}: expected {} msats, got {} msats",

--- a/src/utils/bolt11.rs
+++ b/src/utils/bolt11.rs
@@ -15,14 +15,14 @@ pub fn parse_bolt11(invoice: &str) -> Result<ParsedBolt11, String> {
         .amount_milli_satoshis()
         .ok_or("Invoice has no amount")?;
     Ok(ParsedBolt11 {
-        amount_sats: amount_msats / 1000,
+        amount_sats: amount_msats.div_ceil(1000),
         payment_hash: *parsed.payment_hash(),
     })
 }
 
 pub fn parse_bolt11_amount(bolt11: &str) -> Option<u64> {
     let parsed: Bolt11Invoice = bolt11.parse().ok()?;
-    parsed.amount_milli_satoshis().map(|msats| msats / 1000)
+    parsed.amount_milli_satoshis().map(|msats| msats.div_ceil(1000))
 }
 
 pub fn parse_bolt11_amount_msats(bolt11: &str) -> Option<u64> {

--- a/src/utils/bolt11.rs
+++ b/src/utils/bolt11.rs
@@ -1,34 +1,31 @@
-/// Parse amount from bolt11 invoice string
+use lightning_invoice::Bolt11Invoice;
+
+#[allow(dead_code)]
+pub struct ParsedBolt11 {
+    pub amount_sats: u64,
+    pub payment_hash: bitcoin_hashes::sha256::Hash,
+}
+
+#[allow(dead_code)]
+pub fn parse_bolt11(invoice: &str) -> Result<ParsedBolt11, String> {
+    let parsed: Bolt11Invoice = invoice
+        .parse()
+        .map_err(|e| format!("Invalid bolt11 invoice: {}", e))?;
+    let amount_msats = parsed
+        .amount_milli_satoshis()
+        .ok_or("Invoice has no amount")?;
+    Ok(ParsedBolt11 {
+        amount_sats: amount_msats / 1000,
+        payment_hash: *parsed.payment_hash(),
+    })
+}
+
 pub fn parse_bolt11_amount(bolt11: &str) -> Option<u64> {
-    let lower = bolt11.to_lowercase();
-    let prefix_end = if lower.starts_with("lnbcrt") {
-        6
-    } else if lower.starts_with("lnbc") || lower.starts_with("lntb") {
-        4
-    } else {
-        return None;
-    };
-    let amount_part = &lower[prefix_end..];
-    let mut amount_str = String::new();
-    let mut multiplier_char = None;
-    for c in amount_part.chars() {
-        if c.is_ascii_digit() {
-            amount_str.push(c);
-        } else if c == 'p' || c == 'n' || c == 'u' || c == 'm' {
-            multiplier_char = Some(c);
-            break;
-        } else {
-            break;
-        }
-    }
-    let amount: u64 = amount_str.parse().ok()?;
-    let sats = match multiplier_char {
-        Some('m') => amount * 100_000,
-        Some('u') => amount * 100,
-        Some('n') => amount / 10,
-        Some('p') => amount / 10_000,
-        None => amount * 100_000_000,
-        _ => return None,
-    };
-    Some(sats)
+    let parsed: Bolt11Invoice = bolt11.parse().ok()?;
+    parsed.amount_milli_satoshis().map(|msats| msats / 1000)
+}
+
+pub fn parse_bolt11_amount_msats(bolt11: &str) -> Option<u64> {
+    let parsed: Bolt11Invoice = bolt11.parse().ok()?;
+    parsed.amount_milli_satoshis()
 }

--- a/src/utils/nips/nip53.rs
+++ b/src/utils/nips/nip53.rs
@@ -225,9 +225,6 @@ pub fn parse_meeting_space(event: &Event) -> Result<MeetingSpace, String> {
     let hashtags = get_all_tag_values(event, "t");
     let relays = get_relay_tag_values(event);
     let providers = parse_participants(event);
-    if providers.is_empty() {
-        return Err("Missing required provider (p tag)".to_string());
-    }
     Ok(MeetingSpace {
         d_tag,
         event_id: event.id.to_hex(),

--- a/src/utils/pagination.rs
+++ b/src/utils/pagination.rs
@@ -1,6 +1,6 @@
 use nostr_sdk::Timestamp;
 
-pub const GAP_THRESHOLD_SECS: u64 = 6 * 3600;
+pub const GAP_THRESHOLD_SECS: u64 = 3600;
 const MAX_FUTURE_SKEW_SECS: u64 = 120;
 
 pub fn is_likely_future(ts: Timestamp) -> bool {

--- a/src/utils/parsing/thread_tree.rs
+++ b/src/utils/parsing/thread_tree.rs
@@ -338,8 +338,16 @@ pub fn build_thread_tree(replies: Vec<Event>, root_event_id: &EventId) -> Vec<Th
     for node in &mut root_replies {
         node.children = attach_children(&node.event.id, &replies, &mut node_map);
     }
-    for (_, orphan) in node_map.drain() {
-        root_replies.push(orphan);
+    let orphan_count = node_map.len();
+    if orphan_count > 0 {
+        log::warn!(
+            "Thread tree: {} orphan reply(ies) with missing parent event appended at root level for root {}",
+            orphan_count,
+            root_id_hex
+        );
+        for (_, orphan) in node_map.drain() {
+            root_replies.push(orphan);
+        }
     }
     root_replies.sort_by_key(|a| a.event.created_at);
     {

--- a/src/utils/parsing/thread_tree.rs
+++ b/src/utils/parsing/thread_tree.rs
@@ -338,6 +338,9 @@ pub fn build_thread_tree(replies: Vec<Event>, root_event_id: &EventId) -> Vec<Th
     for node in &mut root_replies {
         node.children = attach_children(&node.event.id, &replies, &mut node_map);
     }
+    for (_, orphan) in node_map.drain() {
+        root_replies.push(orphan);
+    }
     root_replies.sort_by_key(|a| a.event.created_at);
     {
         let mut cache = get_thread_tree_cache().lock().unwrap_or_else(|poisoned| {

--- a/src/utils/path_validation.rs
+++ b/src/utils/path_validation.rs
@@ -1,14 +1,11 @@
-/// Check if a file path is safe (no traversal, no absolute paths).
+/// Check if a file path is safe (no traversal, no absolute paths, no NUL bytes).
 pub fn is_safe_path(path: &str) -> bool {
+    if path.contains('\0') {
+        return false;
+    }
     use std::path::{Component, Path};
     let p = Path::new(path);
-    for component in p.components() {
-        match component {
-            Component::ParentDir => return false,
-            Component::RootDir => return false,
-            Component::Prefix(_) => return false,
-            _ => {}
-        }
-    }
-    !p.to_string_lossy().starts_with('/')
+    !p.components()
+        .any(|c| matches!(c, Component::ParentDir | Component::RootDir | Component::Prefix(_)))
+        && !p.to_string_lossy().starts_with('/')
 }

--- a/src/utils/validation.rs
+++ b/src/utils/validation.rs
@@ -119,6 +119,82 @@ pub fn sanitize_lightning_invoice(invoice: &str) -> Option<String> {
     }
     Some(invoice.to_uppercase())
 }
+pub fn validate_blossom_server_url(input: &str) -> Result<String, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("URL cannot be empty".to_string());
+    }
+    let url_str = if !trimmed.starts_with("https://") {
+        if trimmed.starts_with("http://") {
+            return Err("Blossom servers must use HTTPS".to_string());
+        }
+        format!("https://{}", trimmed)
+    } else {
+        trimmed.to_string()
+    };
+    let url = url::Url::parse(&url_str).map_err(|e| format!("Invalid URL: {}", e))?;
+    if url.scheme() != "https" {
+        return Err("Blossom servers must use HTTPS".to_string());
+    }
+    if url_str.matches("://").count() > 1 {
+        return Err("URL must not contain multiple scheme separators".to_string());
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err("URL must not contain embedded credentials".to_string());
+    }
+    let host = url.host_str().ok_or("URL must have a host")?;
+    if host.is_empty() {
+        return Err("URL must have a host".to_string());
+    }
+    let host_lower = host.to_lowercase();
+    if host_lower == "localhost"
+        || host_lower.starts_with("127.")
+        || host_lower == "0.0.0.0"
+        || host_lower.starts_with("10.")
+        || host_lower.starts_with("192.168.")
+        || host_lower.starts_with("169.254.")
+    {
+        return Err("Private/local addresses not allowed".to_string());
+    }
+    if let Some(url::Host::Ipv4(addr)) = url.host() {
+        let octets = addr.octets();
+        if octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31 {
+            return Err("Private/local addresses not allowed".to_string());
+        }
+        if octets[0] == 100 && (octets[1] & 0xc0) == 64 {
+            return Err("Private/local addresses not allowed".to_string());
+        }
+    }
+    if let Some(url::Host::Ipv6(addr)) = url.host() {
+        if addr.is_loopback() {
+            return Err("Private/local addresses not allowed".to_string());
+        }
+        let segments = addr.segments();
+        if (segments[0] & 0xffc0) == 0xfe80 {
+            return Err("Private/local addresses not allowed".to_string());
+        }
+        if (segments[0] & 0xfe00) == 0xfc00 {
+            return Err("Private/local addresses not allowed".to_string());
+        }
+        if segments[0] == 0 && segments[1] == 0 && segments[2] == 0 && segments[3] == 0
+            && segments[4] == 0 && segments[5] == 0xffff
+        {
+            let v4_octets = (segments[6] as u32 >> 8, segments[6] as u32 & 0xff, segments[7] as u32 >> 8, segments[7] as u32 & 0xff);
+            if v4_octets.0 == 127 || v4_octets.0 == 10
+                || (v4_octets.0 == 172 && v4_octets.1 >= 16 && v4_octets.1 <= 31)
+                || (v4_octets.0 == 192 && v4_octets.1 == 168)
+            {
+                return Err("Private/local addresses not allowed".to_string());
+            }
+        }
+    }
+    let mut normalized = format!("{}://{}", url.scheme(), host);
+    if let Some(port) = url.port() {
+        normalized.push_str(&format!(":{}", port));
+    }
+    Ok(normalized)
+}
+
 static CSS_DIMENSION_PATTERN: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^-?[0-9]*\.?[0-9]+(px|%|vh|vw|em|rem|pt|vmin|vmax)?$")
         .expect("Failed to compile CSS dimension regex")

--- a/src/utils/validation.rs
+++ b/src/utils/validation.rs
@@ -142,6 +142,9 @@ pub fn validate_blossom_server_url(input: &str) -> Result<String, String> {
     if !url.username().is_empty() || url.password().is_some() {
         return Err("URL must not contain embedded credentials".to_string());
     }
+    if url.path() != "/" {
+        return Err("Blossom server URLs should not include a path component. Remove the path and try again.".to_string());
+    }
     let host = url.host_str().ok_or("URL must have a host")?;
     if host.is_empty() {
         return Err("URL must have a host".to_string());


### PR DESCRIPTION
- **Topics → NIP-73**: Migrate topic communities from hashtags to web URL namespaces with DB-first loading, real-time subscriptions, and live update banners
- **Followers/Following modal**: New `FollowersModal` component with pagination, profile resolution, follow/unfollow actions, backed by nostrarchives social graph API
- **Relay-aware live chat**: Refactor `LiveChat` to connect ephemeral relays for stream-specific chat messages

## Fixes
- **Nests audio**: Rewrite moq-nest.js with `@moq/net` library, fix WebTransport URL/auth, fix heartbeat loop
- **Feed stability**: Gap-aware pagination to prevent outlier cursor jumps; always apply `since` filter for partial caches
- **Notification busy-loop**: Replace `loop { if let Ok }` with `while let Ok` in dispatcher
- **Subscription leaks**: Add `AtomicBool` cancellation guards to relay/group subscription hooks
- **Memory safety**: LruCache for interaction store, stale profile eviction, wallet seed zeroization
- **Mutex poison resilience**: Recover from poisoned mutexes across 10 files instead of panicking
- **Bolt11 parsing**: Replace hand-rolled parsers with `lightning-invoice` crate; fix sub-satoshi truncation
- **Blossom validation**: HTTPS-only enforcement, private IP blocking, credential injection protection
- **Search reactivity**: Memo+effect chain so autocomplete updates on session restore
- **Note threads**: DB-first parent loading, NIP-22 comment support, orphaned node preservation
- **Cashu**: Remove broken DLEQ pre-check, defer draft saves, eliminate double-parses
- **NIP-78 double-fire**: Merge retry effects into single reactive gate
- **Path security**: Reject NUL bytes in `is_safe_path()`
- **Nest reactions**: Guard cleanup loop with `is_joined` check