### PR TITLE
Release 0.8.20: Routstr AI provider, Mostro trade durability, profile loading perf, cross-platform voice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "nostrblue"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "ammonia",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostrblue"
-version = "0.8.19"
+version = "0.8.20"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Patrick Ulrich"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A multi-platform Nostr client built using **Rust + Dioxus + rust-nostr** with integrated CDK wallet.
 
-![Version](https://img.shields.io/badge/version-0.8.19-blue)
+![Version](https://img.shields.io/badge/version-0.8.20-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Rust](https://img.shields.io/badge/rust-1.82+-orange)
 ![Platforms](https://img.shields.io/badge/platforms-Web%20%7C%20Android%20%7C%20Desktop-blue)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostrblue",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "description": "Nostr.blue Rust client",
   "scripts": {
     "dev": "npm run build:assets && dx serve",

--- a/public/docs/changelogs/0.8.20.md
+++ b/public/docs/changelogs/0.8.20.md
@@ -1,0 +1,8 @@
+- Routstr AI provider with Lightning and Cashu payments
+- Mostro durable trade recovery, orphan resilience, and self-healing trade list
+- Faster profile loading with multi-source streaming and indexer routing
+- Voice message playback on desktop and Android
+- Image-specific compression and configurable media upload limits
+- Relay coverage race and URL normalization fixes
+- Reply and comment mention dropdown positioning fix
+- Bug fixes and performance improvements

--- a/src/components/ai_settings_panel.rs
+++ b/src/components/ai_settings_panel.rs
@@ -1,7 +1,9 @@
 use crate::components::ppq_settings_panel::PpqSettingsPanel;
+use crate::components::routstr_settings_panel::RoutstrSettingsPanel;
 use crate::stores::ai_provider_store::{
-    self, normalize_base_url, ppq_provider, resolve_providers, sanitize_provider_input,
-    AiProviderKind, AiProviderState, CustomAiProvider, ProviderAuth, PROVIDER_STATE_SAVE_EVENT,
+    self, normalize_base_url, ppq_provider, resolve_providers, routstr_provider,
+    sanitize_provider_input, AiProviderKind, AiProviderState, CustomAiProvider, ProviderAuth,
+    PROVIDER_STATE_SAVE_EVENT,
 };
 use dioxus::prelude::*;
 use regex::Regex;
@@ -193,7 +195,7 @@ pub fn AiSettingsPanel(#[props(default = false)] headerless: bool) -> Element {
                                                     base_url.set(provider_clone.base_url.clone());
                                                     api_key.set(match &provider_clone.auth {
                                                         ProviderAuth::BearerToken(value) | ProviderAuth::XApiKey(value) => value.clone(),
-                                                        ProviderAuth::PpqManaged { .. } => String::new(),
+                                                        ProviderAuth::PpqManaged { .. } | ProviderAuth::Routstr { .. } => String::new(),
                                                     });
                                                     provider_kind.set(provider_clone.provider_kind.clone());
                                                     model_name.set(provider_clone.default_model.clone().unwrap_or_default());
@@ -241,6 +243,13 @@ pub fn AiSettingsPanel(#[props(default = false)] headerless: bool) -> Element {
             }
 
             PpqSettingsPanel {
+                state,
+                is_saving,
+                save_error,
+                provider_state_ready,
+            }
+
+            RoutstrSettingsPanel {
                 state,
                 is_saving,
                 save_error,
@@ -491,6 +500,9 @@ fn build_custom_provider(
     }
     if provider_id == ppq_provider(None).id {
         return Err("ID is reserved for the built-in PPQ provider".to_string());
+    }
+    if provider_id == routstr_provider(None).id {
+        return Err("ID is reserved for the built-in Routstr provider".to_string());
     }
     if base_url.is_empty() {
         return Err("Base URL is required".to_string());

--- a/src/components/article_cover_uploader.rs
+++ b/src/components/article_cover_uploader.rs
@@ -153,6 +153,7 @@ pub fn ArticleCoverUploader(props: ArticleCoverUploaderProps) -> Element {
                                 "Upload an image to use as your article cover. The URL will be filled in automatically."
                             }
                             MediaUploader {
+                                accept: "image/*".to_string(),
                                 on_upload: handle_upload,
                                 button_label: props.label.clone(),
                                 input_id: input_id.read().clone(),

--- a/src/components/image_upload_dialog.rs
+++ b/src/components/image_upload_dialog.rs
@@ -121,6 +121,7 @@ pub fn ImageUploadDialog(props: ImageUploadDialogProps) -> Element {
                             } else {
                                 div { class: "p-6",
                                     MediaUploader {
+                                        accept: "image/*".to_string(),
                                         on_upload: handle_upload,
                                         button_label: "Select Image".to_string(),
                                         input_id: "image-dialog-upload".to_string(),

--- a/src/components/media_uploader.rs
+++ b/src/components/media_uploader.rs
@@ -20,14 +20,13 @@ use wasm_bindgen::JsCast;
 #[cfg(feature = "web")]
 use web_sys::HtmlInputElement;
 
-const MEDIA_ACCEPT: &str = "image/*,video/*";
-const MAX_UPLOAD_BYTES: usize = 10 * 1024 * 1024;
+const DEFAULT_MAX_UPLOAD_BYTES: usize = 10 * 1024 * 1024;
 
-fn ensure_within_upload_limit(size: usize) -> Result<(), String> {
-    if size > MAX_UPLOAD_BYTES {
+fn ensure_within_upload_limit(size: usize, max_bytes: usize) -> Result<(), String> {
+    if size > max_bytes {
         Err(format!(
             "Selected file exceeds the {} MB upload limit",
-            MAX_UPLOAD_BYTES / (1024 * 1024)
+            max_bytes / (1024 * 1024)
         ))
     } else {
         Ok(())
@@ -46,6 +45,14 @@ pub struct MediaUploaderProps {
     /// Whether to show server selector (defaults to true)
     #[props(default = true)]
     pub show_server_selector: bool,
+    /// Accept filter for the file picker (defaults to all files). Use
+    /// "image/*" for image-only contexts, "video/*" for video, etc.
+    #[props(default = "*/*".to_string())]
+    pub accept: String,
+    /// Maximum upload size in bytes (defaults to 10 MB). Increase for contexts
+    /// that handle larger files (e.g., audio/music at 100 MB).
+    #[props(default = DEFAULT_MAX_UPLOAD_BYTES)]
+    pub max_bytes: usize,
 }
 #[component]
 pub fn MediaUploader(props: MediaUploaderProps) -> Element {
@@ -56,6 +63,8 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
     let upload_progress = blossom_store::UPLOAD_PROGRESS.read();
     let mut selected_server = use_signal(blossom_store::get_primary_server);
     let show_server_selector = props.show_server_selector;
+    let accept = props.accept.clone();
+    let max_bytes = props.max_bytes;
     let input_id = props.input_id.clone();
     let input_id_for_handler = input_id.clone();
     #[cfg(feature = "mobile_platform")]
@@ -64,8 +73,16 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
     let input_id_for_desktop_handler = input_id.clone();
     let input_id_for_upload = input_id.clone();
     let input_id_for_clear_handler = input_id.clone();
+    // `accept`/`max_bytes` are threaded into each platform picker. `accept` is a
+    // String so each `move` closure needs its own clone (mirroring `input_id`).
+    let accept_for_handler = accept.clone();
+    #[cfg(feature = "mobile_platform")]
+    let accept_for_mobile_handler = accept.clone();
+    #[cfg(feature = "desktop")]
+    let accept_for_desktop_handler = accept.clone();
     let handle_file_select = move |evt: Event<FormData>| {
         let input_id = input_id_for_handler.clone();
+        let accept = accept_for_handler.clone();
         spawn(async move {
             error.set(None);
             #[cfg(feature = "web")]
@@ -74,7 +91,7 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
                 if files.is_empty() {
                     return;
                 }
-                match read_file_as_bytes(&input_id, MEDIA_ACCEPT).await {
+                match read_file_as_bytes(&input_id, &accept, max_bytes).await {
                     Ok((file_name, data, mime_type)) => {
                         log::info!("File selected: {} ({} bytes)", file_name, data.len());
                         selected_file.set(Some((file_name, data, mime_type)));
@@ -87,12 +104,12 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
             }
             #[cfg(feature = "mobile_platform")]
             {
-                let _ = (evt, input_id);
+                let _ = (evt, input_id, accept);
                 // Mobile uses its dedicated picker button path.
             }
             #[cfg(feature = "desktop")]
             {
-                let _ = (evt, input_id);
+                let _ = (evt, input_id, accept);
                 // Desktop uses its dedicated picker button path.
             }
         });
@@ -100,9 +117,10 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
     #[cfg(feature = "mobile_platform")]
     let handle_mobile_pick = move |_| {
         let input_id = input_id_for_mobile_handler.clone();
+        let accept = accept_for_mobile_handler.clone();
         spawn(async move {
             error.set(None);
-            match read_file_as_bytes(&input_id, MEDIA_ACCEPT).await {
+            match read_file_as_bytes(&input_id, &accept, max_bytes).await {
                 Ok((file_name, data, mime_type)) => {
                     log::info!("File selected: {} ({} bytes)", file_name, data.len());
                     selected_file.set(Some((file_name, data, mime_type)));
@@ -119,9 +137,10 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
     #[cfg(feature = "desktop")]
     let handle_desktop_pick = move |_| {
         let input_id = input_id_for_desktop_handler.clone();
+        let accept = accept_for_desktop_handler.clone();
         spawn(async move {
             error.set(None);
-            match read_file_as_bytes(&input_id, MEDIA_ACCEPT).await {
+            match read_file_as_bytes(&input_id, &accept, max_bytes).await {
                 Ok((file_name, data, mime_type)) => {
                     log::info!("File selected: {} ({} bytes)", file_name, data.len());
                     selected_file.set(Some((file_name, data, mime_type)));
@@ -144,9 +163,13 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
             uploading.set(true);
             error.set(None);
             spawn(async move {
-                match blossom_store::upload_image(data, mime_type, quality_val, Some(server_url))
-                    .await
-                {
+                let result = if mime_type.starts_with("image/") {
+                    blossom_store::upload_image(data, mime_type, quality_val, Some(server_url))
+                        .await
+                } else {
+                    blossom_store::upload_file(data, mime_type, Some(server_url)).await
+                };
+                match result {
                     Ok(url) => {
                         log::info!("Upload successful: {}", url);
                         on_upload.call(url);
@@ -189,7 +212,7 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
                                     span { class: "font-semibold", "Tap to upload" }
                                 }
                                 p { class: "text-xs text-muted-foreground",
-                                    "Images (PNG, JPG) or Videos (MP4, MOV)"
+                                    "Any file type (images, video, audio, documents, etc.)"
                                 }
                             }
                         }
@@ -205,7 +228,7 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
                                     " from your device"
                                 }
                                 p { class: "text-xs text-muted-foreground",
-                                    "Images (PNG, JPG) or Videos (MP4, MOV)"
+                                    "Any file type (images, video, audio, documents, etc.)"
                                 }
                             }
                         }
@@ -218,21 +241,21 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
                                     " or drag and drop"
                                 }
                                 p { class: "text-xs text-muted-foreground",
-                                    "Images (PNG, JPG) or Videos (MP4, MOV)"
+                                    "Any file type (images, video, audio, documents, etc.)"
                                 }
                             }
                             input {
                                 id: "{props.input_id}",
                                 class: "hidden",
                                 r#type: "file",
-                                accept: "{MEDIA_ACCEPT}",
+                                accept: "{accept}",
                                 onchange: handle_file_select,
                             }
                         }
                     }
                 }
             } else {
-                if let Some((filename, data, _)) = selected_file.read().as_ref() {
+                if let Some((filename, data, mime_type)) = selected_file.read().as_ref() {
                     div { class: "p-4 bg-card border border-border rounded-lg space-y-3",
                         div { class: "flex items-center justify-between",
                             div {
@@ -250,26 +273,28 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
                                 "✕ Remove"
                             }
                         }
-                        div { class: "space-y-2",
-                            label { class: "block text-sm font-medium text-foreground",
-                                "Quality: {quality}% ({quality_label})"
-                            }
-                            input {
-                                class: "w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer",
-                                r#type: "range",
-                                min: "10",
-                                max: "100",
-                                step: "10",
-                                value: "{quality}",
-                                oninput: move |evt| {
-                                    if let Ok(val) = evt.value().parse::<u8>() {
-                                        quality.set(val);
-                                    }
-                                },
-                            }
-                            div { class: "flex justify-between text-xs text-muted-foreground",
-                                span { "Small" }
-                                span { "Original" }
+                        if blossom_store::is_image_compressible(mime_type) {
+                            div { class: "space-y-2",
+                                label { class: "block text-sm font-medium text-foreground",
+                                    "Quality: {quality}% ({quality_label})"
+                                }
+                                input {
+                                    class: "w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer",
+                                    r#type: "range",
+                                    min: "10",
+                                    max: "100",
+                                    step: "10",
+                                    value: "{quality}",
+                                    oninput: move |evt| {
+                                        if let Ok(val) = evt.value().parse::<u8>() {
+                                            quality.set(val);
+                                        }
+                                    },
+                                }
+                                div { class: "flex justify-between text-xs text-muted-foreground",
+                                    span { "Small" }
+                                    span { "Original" }
+                                }
                             }
                         }
                         if show_server_selector {
@@ -326,6 +351,7 @@ pub fn MediaUploader(props: MediaUploaderProps) -> Element {
 async fn read_file_as_bytes(
     input_id: &str,
     accept: &str,
+    max_bytes: usize,
 ) -> Result<(String, Vec<u8>, String), String> {
     use js_sys::{ArrayBuffer, Uint8Array};
     use wasm_bindgen_futures::JsFuture;
@@ -346,7 +372,7 @@ async fn read_file_as_bytes(
     }
     let promise = file.array_buffer();
     let file_size = file.size() as usize;
-    ensure_within_upload_limit(file_size)?;
+    ensure_within_upload_limit(file_size, max_bytes)?;
     let array_buffer = JsFuture::from(promise)
         .await
         .map_err(|_| "Failed to read file")?;
@@ -361,6 +387,7 @@ async fn read_file_as_bytes(
 async fn read_file_as_bytes(
     _input_id: &str,
     accept: &str,
+    max_bytes: usize,
 ) -> Result<(String, Vec<u8>, String), String> {
     let file_handle = rfd::FileDialog::new()
         .set_title("Select media file")
@@ -378,7 +405,7 @@ async fn read_file_as_bytes(
     let file_path = file_handle.as_path().to_path_buf();
     let metadata = std::fs::metadata(&file_path)
         .map_err(|e| format!("Failed to inspect selected file: {}", e))?;
-    ensure_within_upload_limit(metadata.len() as usize)?;
+    ensure_within_upload_limit(metadata.len() as usize, max_bytes)?;
     let data = tokio::task::spawn_blocking(move || std::fs::read(file_path))
         .await
         .map_err(|e| format!("Failed to read selected file: {}", e))?
@@ -391,9 +418,10 @@ async fn read_file_as_bytes(
 async fn read_file_as_bytes(
     _input_id: &str,
     accept: &str,
+    max_bytes: usize,
 ) -> Result<(String, Vec<u8>, String), String> {
     let (bytes, mime_type) = crate::platform::mobile::pick_file().await?;
-    ensure_within_upload_limit(bytes.len())?;
+    ensure_within_upload_limit(bytes.len(), max_bytes)?;
     let extension = mime_type
         .split('/')
         .nth(1)

--- a/src/components/mention_autocomplete.rs
+++ b/src/components/mention_autocomplete.rs
@@ -555,18 +555,23 @@ fn update_dropdown_position(
                     let bottom_space = viewport_height - rect.bottom();
                     let top_space = rect.top();
                     let dropdown_height = if is_mobile_view { 200.0 } else { 300.0 };
+                    // The dropdown is `position: fixed`, so its top/left are relative to the
+                    // viewport. `get_bounding_client_rect()` already returns viewport-relative
+                    // coordinates, so we must NOT add `window.scroll_y()`/`scroll_x()` here —
+                    // that double-counts the scroll offset and shoves the dropdown far below the
+                    // viewport when the body is scrolled (e.g. the reply/comment modal opened
+                    // after scrolling a feed).
                     if bottom_space >= dropdown_height {
                         show_below.set(true);
-                        dropdown_top.set(rect.bottom() + window.scroll_y().unwrap_or(0.0));
+                        dropdown_top.set(rect.bottom());
                     } else if top_space >= dropdown_height {
                         show_below.set(false);
-                        dropdown_top
-                            .set(rect.top() + window.scroll_y().unwrap_or(0.0) - dropdown_height);
+                        dropdown_top.set(rect.top() - dropdown_height);
                     } else {
                         show_below.set(true);
-                        dropdown_top.set(rect.bottom() + window.scroll_y().unwrap_or(0.0));
+                        dropdown_top.set(rect.bottom());
                     }
-                    dropdown_left.set(rect.left() + window.scroll_x().unwrap_or(0.0));
+                    dropdown_left.set(rect.left());
                 }
             }
         }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -58,6 +58,7 @@ pub mod radial_menu;
 pub mod reply_composer;
 pub mod link_preview;
 pub mod report_modal;
+pub mod routstr_settings_panel;
 pub mod rich_content;
 pub mod right_discovery_sidebar;
 pub mod search_input;

--- a/src/components/mostro/order_card.rs
+++ b/src/components/mostro/order_card.rs
@@ -96,6 +96,13 @@ pub fn P2POrderCard(order: P2POrder) -> Element {
                     if let Some(platform) = &order.platform {
                         span { class: "px-1.5 py-0.5 bg-accent rounded", "{platform}" }
                     }
+                    if !crate::stores::mostro::creation_ledger::entries_for_order(&order.order_id)
+                        .is_empty()
+                    {
+                        span { class: "px-1.5 py-0.5 bg-primary/15 text-primary rounded",
+                            "✓ Yours"
+                        }
+                    }
                 }
                 span { "{format_relative_time(Timestamp::from(order.created_at))}" }
             }

--- a/src/components/mostro/take_mostro_button.rs
+++ b/src/components/mostro/take_mostro_button.rs
@@ -18,8 +18,13 @@ pub fn TakeMostroButton(order: P2POrder) -> Element {
     // Disable taking if the current user already owns this order as maker.
     // `take_order` blocks self-takes server-side too, but disabling here is
     // better UX (no error toast) and avoids corrupting local state.
+    // We check both TRADES and the durable creation_ledger so the disable
+    // survives a TRADES cache wipe (e.g., orphan cleanup).
     let owns_order = crate::stores::mostro::find_by_order_id(&order.order_id)
-        .is_some_and(|t| t.role == crate::stores::mostro::TradeRole::Maker);
+        .is_some_and(|t| t.role == crate::stores::mostro::TradeRole::Maker)
+        || crate::stores::mostro::creation_ledger::entries_for_order(&order.order_id)
+            .iter()
+            .any(|e| e.role == crate::stores::mostro::TradeRole::Maker);
 
     rsx! {
         button {

--- a/src/components/profile_editor_modal.rs
+++ b/src/components/profile_editor_modal.rs
@@ -279,6 +279,7 @@ pub fn ProfileEditorModal(mut props: ProfileEditorModalProps) -> Element {
                         }
                         if *show_picture_uploader.read() || picture.read().is_empty() {
                             MediaUploader {
+                                accept: "image/*".to_string(),
                                 on_upload: handle_picture_uploaded,
                                 button_label: "Upload Profile Picture",
                             }
@@ -314,6 +315,7 @@ pub fn ProfileEditorModal(mut props: ProfileEditorModalProps) -> Element {
                         }
                         if *show_banner_uploader.read() || banner.read().is_empty() {
                             MediaUploader {
+                                accept: "image/*".to_string(),
                                 on_upload: handle_banner_uploaded,
                                 button_label: "Upload Banner",
                             }

--- a/src/components/recipe/add_to_cookbook_modal.rs
+++ b/src/components/recipe/add_to_cookbook_modal.rs
@@ -625,6 +625,7 @@ pub fn AddToCookbookModal(
                                         }
                                     }
                                     MediaUploader {
+                                        accept: "image/*".to_string(),
                                         on_upload: move |url: String| {
                                             if is_valid_http_url(&url) {
                                                 new_image_url.set(Some(url));

--- a/src/components/recipe/create_cookbook_modal.rs
+++ b/src/components/recipe/create_cookbook_modal.rs
@@ -158,6 +158,7 @@ pub fn CreateCookbookModal(on_close: EventHandler<()>) -> Element {
                             }
                         }
                         MediaUploader {
+                            accept: "image/*".to_string(),
                             on_upload: move |url: String| {
                                 let trimmed = url.trim();
                                 if is_valid_http_url(trimmed) {

--- a/src/components/recipe/form.rs
+++ b/src/components/recipe/form.rs
@@ -321,6 +321,7 @@ pub fn RecipeForm(
                 if *show_image_uploader.read() {
                     div { class: "space-y-2",
                         MediaUploader {
+                            accept: "image/*".to_string(),
                             on_upload: move |url: String| {
                                 let mut current = image_urls.read().clone();
                                 current.push(url);

--- a/src/components/routstr_settings_panel.rs
+++ b/src/components/routstr_settings_panel.rs
@@ -21,14 +21,14 @@ pub fn RoutstrSettingsPanel(
     let mut balance_error = use_signal(|| None::<String>);
     let mut topup_amount = use_signal(|| "1000".to_string());
     let mut topup_invoice = use_signal(|| None::<RoutstrLightningInvoice>);
-    let topup_loading = use_signal(|| false);
+    let mut topup_loading = use_signal(|| false);
     let mut topup_error = use_signal(|| None::<String>);
     let mut cashu_token_input = use_signal(String::new);
-    let cashu_loading = use_signal(|| false);
+    let mut cashu_loading = use_signal(|| false);
     let mut cashu_error = use_signal(|| None::<String>);
     let mut cashu_success = use_signal(|| None::<String>);
     let mut refund_result = use_signal(|| None::<RoutstrRefundResult>);
-    let refund_loading = use_signal(|| false);
+    let mut refund_loading = use_signal(|| false);
     let mut refund_error = use_signal(|| None::<String>);
     let mut last_loaded_key = use_signal(|| None::<String>);
     let mut request_generation = use_signal(|| 0u32);
@@ -89,10 +89,7 @@ pub fn RoutstrSettingsPanel(
 
     // Invoice payment polling loop (auto-cancels on unmount)
     {
-        let api_key_for_poll = state.read().routstr_api_key.clone();
-        use_future(move || {
-            let api_key_for_poll = api_key_for_poll.clone();
-            async move {
+        use_future(move || async move {
             let mut attempts = 0u32;
             loop {
                 crate::platform::timer::sleep_ms(5000).await;
@@ -114,7 +111,7 @@ pub fn RoutstrSettingsPanel(
                             topup_invoice.set(None);
                             topup_error.set(None);
                             attempts = 0;
-                            if let Some(key) = api_key_for_poll.as_ref() {
+                            if let Some(key) = state.read().routstr_api_key.as_ref() {
                                 if let Ok(result) = routstr::get_balance(key).await {
                                     balance.set(Some(result));
                                 }
@@ -128,7 +125,6 @@ pub fn RoutstrSettingsPanel(
                         }
                     }
             }
-        }
         });
     }
 
@@ -296,6 +292,7 @@ pub fn RoutstrSettingsPanel(
                                     };
                                     let api_key = state.read().routstr_api_key.clone().unwrap_or_default();
                                     topup_error.set(None);
+                                    topup_loading.set(true);
                                     spawn(async move {
                                         match routstr::create_lightning_invoice(amount, "topup", Some(&api_key)).await {
                                             Ok(invoice) => {
@@ -305,6 +302,7 @@ pub fn RoutstrSettingsPanel(
                                                 topup_error.set(Some(err));
                                             }
                                         }
+                                        topup_loading.set(false);
                                     });
                                 },
                                 if *topup_loading.read() { "Creating..." } else { "Create Invoice" }
@@ -380,6 +378,7 @@ pub fn RoutstrSettingsPanel(
                                     return;
                                 }
                                 let api_key = state.read().routstr_api_key.clone().unwrap_or_default();
+                                cashu_loading.set(true);
                                 spawn(async move {
                                     match routstr::topup_with_cashu(&api_key, &token).await {
                                         Ok(result) => {
@@ -401,6 +400,7 @@ pub fn RoutstrSettingsPanel(
                                             cashu_error.set(Some(err));
                                         }
                                     }
+                                    cashu_loading.set(false);
                                 });
                             },
                             if *cashu_loading.read() { "Processing..." } else { "Top Up" }
@@ -419,6 +419,7 @@ pub fn RoutstrSettingsPanel(
                             disabled: *refund_loading.read(),
                             onclick: move |_| {
                                 let api_key = state.read().routstr_api_key.clone().unwrap_or_default();
+                                refund_loading.set(true);
                                 spawn(async move {
                                     match routstr::refund(&api_key).await {
                                         Ok(result) => {
@@ -438,6 +439,7 @@ pub fn RoutstrSettingsPanel(
                                             refund_error.set(Some(err));
                                         }
                                     }
+                                    refund_loading.set(false);
                                 });
                             },
                             if *refund_loading.read() { "Processing..." } else { "Withdraw Remaining Balance" }
@@ -462,11 +464,8 @@ pub fn RoutstrSettingsPanel(
                                             },
                                             "Copy Token"
                                         }
-                                        if let Some(sats) = result.sats {
+                                        if let Some(sats) = result.sats.or_else(|| result.msats.map(|m| m / 1000)) {
                                             span { class: "text-xs text-muted-foreground", "{sats} sats" }
-                                        }
-                                        if let Some(msats) = result.msats {
-                                            span { class: "text-xs text-muted-foreground", "{msats} msats" }
                                         }
                                     }
                                 }

--- a/src/components/routstr_settings_panel.rs
+++ b/src/components/routstr_settings_panel.rs
@@ -1,0 +1,582 @@
+use crate::platform;
+use crate::services::routstr::{
+    self, RoutstrBalance, RoutstrLightningInvoice, RoutstrRefundResult,
+};
+use crate::stores::ai_provider_store::{self, AiProviderState, PROVIDER_STATE_SAVE_EVENT};
+use dioxus::prelude::*;
+use qrcode::{render::svg, QrCode};
+
+#[component]
+pub fn RoutstrSettingsPanel(
+    state: Signal<AiProviderState>,
+    is_saving: Signal<bool>,
+    save_error: Signal<Option<String>>,
+    provider_state_ready: bool,
+) -> Element {
+    let mut api_key_input = use_signal(String::new);
+    let mut key_saving = use_signal(|| false);
+    let mut key_error = use_signal(|| None::<String>);
+    let mut balance = use_signal(|| None::<RoutstrBalance>);
+    let balance_loading = use_signal(|| false);
+    let mut balance_error = use_signal(|| None::<String>);
+    let mut topup_amount = use_signal(|| "1000".to_string());
+    let mut topup_invoice = use_signal(|| None::<RoutstrLightningInvoice>);
+    let topup_loading = use_signal(|| false);
+    let mut topup_error = use_signal(|| None::<String>);
+    let mut cashu_token_input = use_signal(String::new);
+    let cashu_loading = use_signal(|| false);
+    let mut cashu_error = use_signal(|| None::<String>);
+    let mut cashu_success = use_signal(|| None::<String>);
+    let mut refund_result = use_signal(|| None::<RoutstrRefundResult>);
+    let refund_loading = use_signal(|| false);
+    let mut refund_error = use_signal(|| None::<String>);
+    let mut last_loaded_key = use_signal(|| None::<String>);
+    let mut request_generation = use_signal(|| 0u32);
+    let mut pending_save_snapshot = use_signal(|| None::<AiProviderState>);
+    let mut pending_save_min_event_id = use_signal(|| 0u64);
+
+    let current_api_key = state.read().routstr_api_key.clone();
+
+    // Balance loader: re-fetch when api_key changes
+    use_effect(move || {
+        if !provider_state_ready {
+            return;
+        }
+        let key = state.read().routstr_api_key.clone();
+        if last_loaded_key.read().as_ref() == key.as_ref() {
+            return;
+        }
+        last_loaded_key.set(key.clone());
+        balance.set(None);
+        balance_error.set(None);
+        let generation = request_generation.peek().wrapping_add(1);
+        request_generation.set(generation);
+
+        let Some(key) = key else {
+            return;
+        };
+        load_routstr_balance(
+            balance,
+            balance_loading,
+            balance_error,
+            key,
+            Some((request_generation, generation)),
+        );
+    });
+
+    // Save-completion listener (mirrors PPQ panel Effect B)
+    use_effect(move || {
+        let pending_snapshot = pending_save_snapshot.read().clone();
+        let Some(pending_snapshot) = pending_snapshot else {
+            return;
+        };
+        let Some(event) = PROVIDER_STATE_SAVE_EVENT.read().clone() else {
+            return;
+        };
+        if event.event_id <= *pending_save_min_event_id.read()
+            || event.snapshot != pending_snapshot
+        {
+            return;
+        }
+        pending_save_snapshot.set(None);
+        pending_save_min_event_id.set(event.event_id);
+        is_saving.set(false);
+        match event.result {
+            Ok(()) => save_error.set(None),
+            Err(err) => save_error.set(Some(err)),
+        }
+    });
+
+    // Invoice payment polling loop (auto-cancels on unmount)
+    {
+        let api_key_for_poll = state.read().routstr_api_key.clone();
+        use_future(move || {
+            let api_key_for_poll = api_key_for_poll.clone();
+            async move {
+            let mut attempts = 0u32;
+            loop {
+                crate::platform::timer::sleep_ms(5000).await;
+                let invoice = topup_invoice.read().clone();
+                let Some(invoice) = invoice else {
+                    attempts = 0;
+                    continue;
+                };
+                attempts += 1;
+                if attempts > 60 {
+                    topup_error
+                        .set(Some("Payment polling timed out. Please check manually.".to_string()));
+                    topup_invoice.set(None);
+                    attempts = 0;
+                    continue;
+                }
+                if let Ok(status) = routstr::get_lightning_invoice_status(&invoice.invoice_id).await {
+                        if status.status.as_deref() == Some("paid") {
+                            topup_invoice.set(None);
+                            topup_error.set(None);
+                            attempts = 0;
+                            if let Some(key) = api_key_for_poll.as_ref() {
+                                if let Ok(result) = routstr::get_balance(key).await {
+                                    balance.set(Some(result));
+                                }
+                            }
+                        }
+                        if status.status.as_deref() == Some("expired") {
+                            topup_error
+                                .set(Some("Invoice expired. Please try again.".to_string()));
+                            topup_invoice.set(None);
+                            attempts = 0;
+                        }
+                    }
+            }
+        }
+        });
+    }
+
+    let active_key = current_api_key.clone();
+    let active_balance = balance.read().clone();
+    let display_balance_sats = active_balance
+        .as_ref()
+        .and_then(|b| b.balance_msats.map(|m| m / 1000))
+        .unwrap_or(0);
+    let display_total_spent_sats = active_balance
+        .as_ref()
+        .and_then(|b| b.total_spent_msats.map(|m| m / 1000))
+        .unwrap_or(0);
+    let display_total_requests = active_balance
+        .as_ref()
+        .and_then(|b| b.total_requests)
+        .unwrap_or(0);
+
+    let topup_invoice_display = topup_invoice.read().clone();
+    let topup_qr_svg = topup_invoice_display
+        .as_ref()
+        .and_then(|inv| inv.bolt11.as_ref())
+        .map(|b| generate_invoice_qr_svg(b))
+        .unwrap_or_default();
+    let refund_display = refund_result.read().clone();
+
+    rsx! {
+        div { class: "rounded-xl border border-border bg-card p-6 space-y-6",
+            div {
+                h3 { class: "text-lg font-semibold text-foreground", "Routstr" }
+                p { class: "mt-1 text-sm text-muted-foreground",
+                    "Decentralized AI inference marketplace powered by Bitcoin. Pay per request with Lightning or Cashu."
+                }
+            }
+
+            if active_key.is_none() {
+                // API Key entry section
+                div { class: "space-y-3",
+                    label { class: "text-sm font-medium text-foreground", "API Key or Cashu Token" }
+                    input {
+                        r#type: "text",
+                        class: "w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary",
+                        placeholder: "sk-... or cashuA...",
+                        value: "{api_key_input}",
+                        oninput: move |e| {
+                            api_key_input.set(e.value());
+                            key_error.set(None);
+                        },
+                    }
+                    if let Some(err) = key_error.read().as_ref() {
+                        p { class: "text-xs text-red-600 dark:text-red-400", "{err}" }
+                    }
+                    button {
+                        r#type: "button",
+                        class: "rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-60",
+                        disabled: *key_saving.read() || api_key_input.read().trim().is_empty(),
+                        onclick: move |_| {
+                            let input = api_key_input.read().trim().to_string();
+                            if input.is_empty() {
+                                key_error.set(Some("Please enter an API key or Cashu token".to_string()));
+                                return;
+                            }
+                            key_saving.set(true);
+                            key_error.set(None);
+                            let input_clone = input.clone();
+                            spawn(async move {
+                                let final_key = if input_clone.starts_with("cashu") {
+                                    match routstr::create_key_from_cashu(&input_clone).await {
+                                        Ok(key) => key,
+                                        Err(err) => {
+                                            key_error.set(Some(err));
+                                            key_saving.set(false);
+                                            return;
+                                        }
+                                    }
+                                } else {
+                                    input_clone
+                                };
+                                let mut next_state = state.read().clone();
+                                next_state.routstr_api_key = Some(final_key);
+                                persist_routstr_state(
+                                    next_state,
+                                    state,
+                                    is_saving,
+                                    save_error,
+                                    pending_save_snapshot,
+                                    pending_save_min_event_id,
+                                );
+                                api_key_input.set(String::new());
+                                key_saving.set(false);
+                            });
+                        },
+                        if *key_saving.read() { "Saving..." } else { "Save Key" }
+                    }
+                    a {
+                        href: "https://api.routstr.com",
+                        target: "_blank",
+                        class: "block text-xs text-primary hover:underline",
+                        "Create a key at routstr.com →"
+                    }
+                }
+            } else {
+                // Balance + Topup + Refund section
+                div { class: "space-y-4",
+                    // Balance card
+                    div { class: "rounded-lg border border-border p-4",
+                        div { class: "flex items-center justify-between",
+                            div {
+                                p { class: "text-sm text-muted-foreground", "Balance" }
+                                p { class: "text-2xl font-bold text-foreground",
+                                    "{display_balance_sats}"
+                                    span { class: "ml-1 text-sm font-normal text-muted-foreground", "sats" }
+                                }
+                            }
+                            button {
+                                r#type: "button",
+                                class: "rounded-lg border border-border px-3 py-1.5 text-xs transition hover:bg-accent disabled:opacity-60",
+                                disabled: *balance_loading.read(),
+                                onclick: move |_| {
+                                    let key = state.read().routstr_api_key.clone().unwrap_or_default();
+                                    load_routstr_balance(
+                                        balance,
+                                        balance_loading,
+                                        balance_error,
+                                        key,
+                                        None,
+                                    );
+                                },
+                                if *balance_loading.read() { "Loading..." } else { "Refresh" }
+                            }
+                        }
+                        if display_total_requests > 0 || display_total_spent_sats > 0 {
+                            div { class: "mt-2 flex gap-4 text-xs text-muted-foreground",
+                                span { "{display_total_requests} requests" }
+                                span { "{display_total_spent_sats} sats spent" }
+                            }
+                        }
+                        if let Some(err) = balance_error.read().as_ref() {
+                            p { class: "mt-2 text-xs text-red-600 dark:text-red-400", "{err}" }
+                        }
+                    }
+
+                    // Top up via Lightning
+                    div { class: "rounded-lg border border-border p-4 space-y-3",
+                        p { class: "text-sm font-medium text-foreground", "Top Up via Lightning" }
+                        div { class: "flex gap-2",
+                            input {
+                                r#type: "number",
+                                class: "w-32 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary",
+                                placeholder: "sats",
+                                value: "{topup_amount}",
+                                oninput: move |e| { topup_amount.set(e.value()); },
+                            }
+                            button {
+                                r#type: "button",
+                                class: "rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-60",
+                                disabled: *topup_loading.read(),
+                                onclick: move |_| {
+                                    let amount = match topup_amount.read().trim().parse::<u64>() {
+                                        Ok(a) if a > 0 => a,
+                                        _ => {
+                                            topup_error.set(Some("Enter a valid amount in sats".to_string()));
+                                            return;
+                                        }
+                                    };
+                                    let api_key = state.read().routstr_api_key.clone().unwrap_or_default();
+                                    topup_error.set(None);
+                                    spawn(async move {
+                                        match routstr::create_lightning_invoice(amount, "topup", Some(&api_key)).await {
+                                            Ok(invoice) => {
+                                                topup_invoice.set(Some(invoice));
+                                            }
+                                            Err(err) => {
+                                                topup_error.set(Some(err));
+                                            }
+                                        }
+                                    });
+                                },
+                                if *topup_loading.read() { "Creating..." } else { "Create Invoice" }
+                            }
+                        }
+                        if let Some(err) = topup_error.read().as_ref() {
+                            p { class: "text-xs text-red-600 dark:text-red-400", "{err}" }
+                        }
+                        if let Some(invoice) = topup_invoice_display.as_ref() {
+                            if invoice.bolt11.is_some() {
+                                div { class: "flex flex-col items-center gap-2 pt-2",
+                                    div {
+                                        class: "flex justify-center rounded-lg bg-white p-4",
+                                        dangerous_inner_html: "{topup_qr_svg}",
+                                    }
+                                    p { class: "text-xs text-muted-foreground", "Pay the invoice to add funds" }
+                                    div { class: "flex gap-2",
+                                        button {
+                                            r#type: "button",
+                                            class: "rounded-lg border border-border px-3 py-1.5 text-xs transition hover:bg-accent",
+                                            onclick: move |_| {
+                                                let bolt11 = topup_invoice.read().as_ref().and_then(|inv| inv.bolt11.clone()).unwrap_or_default();
+                                                spawn(async move {
+                                                    let _ = platform::clipboard::copy_to_clipboard(&bolt11).await;
+                                                });
+                                            },
+                                            "Copy"
+                                        }
+                                        button {
+                                            r#type: "button",
+                                            class: "rounded-lg border border-border px-3 py-1.5 text-xs transition hover:bg-accent",
+                                            onclick: move |_| {
+                                                let bolt11 = topup_invoice.read().as_ref().and_then(|inv| inv.bolt11.clone()).unwrap_or_default();
+                                                spawn(async move {
+                                                    let _ = platform::open_lightning_invoice(&bolt11).await;
+                                                });
+                                            },
+                                            "Open Wallet"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Top up via Cashu
+                    div { class: "rounded-lg border border-border p-4 space-y-3",
+                        p { class: "text-sm font-medium text-foreground", "Top Up via Cashu Token" }
+                        textarea {
+                            class: "w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary resize-y",
+                            rows: "2",
+                            placeholder: "cashuA...",
+                            value: "{cashu_token_input}",
+                            oninput: move |e| {
+                                cashu_token_input.set(e.value());
+                                cashu_error.set(None);
+                                cashu_success.set(None);
+                            },
+                        }
+                        if let Some(err) = cashu_error.read().as_ref() {
+                            p { class: "text-xs text-red-600 dark:text-red-400", "{err}" }
+                        }
+                        if let Some(msg) = cashu_success.read().as_ref() {
+                            p { class: "text-xs text-green-600 dark:text-green-400", "{msg}" }
+                        }
+                        button {
+                            r#type: "button",
+                            class: "rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-60",
+                            disabled: *cashu_loading.read() || cashu_token_input.read().trim().is_empty(),
+                            onclick: move |_| {
+                                let token = cashu_token_input.read().trim().to_string();
+                                if token.is_empty() {
+                                    return;
+                                }
+                                let api_key = state.read().routstr_api_key.clone().unwrap_or_default();
+                                spawn(async move {
+                                    match routstr::topup_with_cashu(&api_key, &token).await {
+                                        Ok(result) => {
+                                            let sats = result.msats.map(|m| m / 1000).unwrap_or(0);
+                                            cashu_success.set(Some(format!("Added {} sats", sats)));
+                                            cashu_error.set(None);
+                                            cashu_token_input.set(String::new());
+                                            // Refresh balance
+                                            let key = state.read().routstr_api_key.clone().unwrap_or_default();
+                                            load_routstr_balance(
+                                                balance,
+                                                balance_loading,
+                                                balance_error,
+                                                key,
+                                                None,
+                                            );
+                                        }
+                                        Err(err) => {
+                                            cashu_error.set(Some(err));
+                                        }
+                                    }
+                                });
+                            },
+                            if *cashu_loading.read() { "Processing..." } else { "Top Up" }
+                        }
+                    }
+
+                    // Refund / Withdraw
+                    div { class: "rounded-lg border border-border p-4 space-y-3",
+                        p { class: "text-sm font-medium text-foreground", "Withdraw" }
+                        p { class: "text-xs text-muted-foreground",
+                            "Withdraw your remaining balance as a Cashu token. The token can be claimed in any Cashu wallet."
+                        }
+                        button {
+                            r#type: "button",
+                            class: "rounded-lg border border-red-500/20 px-4 py-2 text-sm text-red-600 transition hover:bg-red-500/10 dark:text-red-400 disabled:opacity-60",
+                            disabled: *refund_loading.read(),
+                            onclick: move |_| {
+                                let api_key = state.read().routstr_api_key.clone().unwrap_or_default();
+                                spawn(async move {
+                                    match routstr::refund(&api_key).await {
+                                        Ok(result) => {
+                                            refund_result.set(Some(result));
+                                            refund_error.set(None);
+                                            // Refresh balance
+                                            let key = state.read().routstr_api_key.clone().unwrap_or_default();
+                                            load_routstr_balance(
+                                                balance,
+                                                balance_loading,
+                                                balance_error,
+                                                key,
+                                                None,
+                                            );
+                                        }
+                                        Err(err) => {
+                                            refund_error.set(Some(err));
+                                        }
+                                    }
+                                });
+                            },
+                            if *refund_loading.read() { "Processing..." } else { "Withdraw Remaining Balance" }
+                        }
+                        if let Some(err) = refund_error.read().as_ref() {
+                            p { class: "text-xs text-red-600 dark:text-red-400", "{err}" }
+                        }
+                        if let Some(result) = refund_display.as_ref() {
+                            if let Some(token) = result.token.as_ref() {
+                                div { class: "rounded-lg bg-background border border-border p-3 space-y-2",
+                                    p { class: "text-xs font-medium text-foreground", "Cashu Token" }
+                                    p { class: "break-all text-xs text-muted-foreground", "{token}" }
+                                    div { class: "flex items-center gap-2",
+                                        button {
+                                            r#type: "button",
+                                            class: "rounded-lg border border-border px-3 py-1.5 text-xs transition hover:bg-accent",
+                                            onclick: move |_| {
+                                                let token = refund_result.read().as_ref().and_then(|r| r.token.clone()).unwrap_or_default();
+                                                spawn(async move {
+                                                    let _ = platform::clipboard::copy_to_clipboard(&token).await;
+                                                });
+                                            },
+                                            "Copy Token"
+                                        }
+                                        if let Some(sats) = result.sats {
+                                            span { class: "text-xs text-muted-foreground", "{sats} sats" }
+                                        }
+                                        if let Some(msats) = result.msats {
+                                            span { class: "text-xs text-muted-foreground", "{msats} msats" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Replace key
+                    div { class: "pt-2",
+                        button {
+                            r#type: "button",
+                            class: "text-xs text-muted-foreground hover:text-foreground transition",
+                            onclick: move |_| {
+                                let mut next_state = state.read().clone();
+                                next_state.routstr_api_key = None;
+                                persist_routstr_state(
+                                    next_state,
+                                    state,
+                                    is_saving,
+                                    save_error,
+                                    pending_save_snapshot,
+                                    pending_save_min_event_id,
+                                );
+                                balance.set(None);
+                                balance_error.set(None);
+                                topup_invoice.set(None);
+                                topup_error.set(None);
+                                refund_result.set(None);
+                                cashu_success.set(None);
+                                cashu_error.set(None);
+                            },
+                            "Replace Key"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn generate_invoice_qr_svg(invoice: &str) -> String {
+    match QrCode::new(invoice.trim().to_uppercase()) {
+        Ok(code) => code
+            .render::<svg::Color>()
+            .min_dimensions(220, 220)
+            .dark_color(svg::Color("#000000"))
+            .light_color(svg::Color("#ffffff"))
+            .build(),
+        Err(_) => "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"220\" height=\"220\" viewBox=\"0 0 220 220\"><rect width=\"220\" height=\"220\" fill=\"#ffffff\"/><text x=\"110\" y=\"110\" text-anchor=\"middle\" fill=\"#666666\" font-size=\"14\">QR Error</text></svg>".to_string(),
+    }
+}
+
+fn load_routstr_balance(
+    mut balance: Signal<Option<RoutstrBalance>>,
+    mut balance_loading: Signal<bool>,
+    mut balance_error: Signal<Option<String>>,
+    api_key: String,
+    request_generation: Option<(Signal<u32>, u32)>,
+) {
+    balance_loading.set(true);
+    balance_error.set(None);
+    spawn(async move {
+        let current = || {
+            request_generation
+                .as_ref()
+                .is_none_or(|(signal, generation)| *signal.peek() == *generation)
+        };
+        match routstr::get_balance(&api_key).await {
+            Ok(result) => {
+                if current() {
+                    balance.set(Some(result));
+                }
+            }
+            Err(err) => {
+                if current() {
+                    balance_error.set(Some(err));
+                }
+            }
+        }
+        if current() {
+            balance_loading.set(false);
+        }
+    });
+}
+
+fn persist_routstr_state(
+    next_state: AiProviderState,
+    mut state: Signal<AiProviderState>,
+    mut is_saving: Signal<bool>,
+    mut save_error: Signal<Option<String>>,
+    mut pending_save_snapshot: Signal<Option<AiProviderState>>,
+    mut pending_save_min_event_id: Signal<u64>,
+) {
+    is_saving.set(true);
+    save_error.set(None);
+    if let Err(err) = ai_provider_store::cache_provider_state(&next_state) {
+        save_error.set(Some(err));
+        is_saving.set(false);
+        return;
+    }
+    state.set(next_state.clone());
+    pending_save_snapshot.set(Some(next_state.clone()));
+    pending_save_min_event_id.set(
+        PROVIDER_STATE_SAVE_EVENT
+            .read()
+            .as_ref()
+            .map(|event| event.event_id)
+            .unwrap_or(0),
+    );
+    if let Some(snapshot) = ai_provider_store::queue_provider_state_save(next_state) {
+        ai_provider_store::process_queued_provider_state_saves(snapshot);
+    }
+}

--- a/src/components/video_card.rs
+++ b/src/components/video_card.rs
@@ -436,7 +436,7 @@ pub fn VideoCard(event: Event) -> Element {
         .duration
         .map(|d| format_duration_timecode_padded(d as u64));
     let video_src = if first_video.thumbnail.is_none() {
-        format!("{}#t=0.1", &first_video.url)
+        format!("{}#t=0.1", first_video.url)
     } else {
         first_video.url.clone()
     };

--- a/src/components/viewers/profile_viewer.rs
+++ b/src/components/viewers/profile_viewer.rs
@@ -152,14 +152,48 @@ pub fn ProfileViewer(pubkey: String) -> Element {
         pinned_events.set(Vec::new());
         pinned_loading.set(true);
         user_write_relays.set(Vec::new());
+        // Clean up ephemeral relays from the previous profile view.
+        // The metadata + tab-events fetches share these connections and
+        // don't clean up per-call (to avoid races). They idle-timeout after
+        // 5 min, but we remove them promptly on profile change.
+        if let Some(client) = nostr_client::get_client() {
+            spawn(async move {
+                let all = client.pool().all_relays().await;
+                let to_remove: Vec<String> = all
+                    .iter()
+                    .filter(|(_, r)| {
+                        let flags = r.flags();
+                        flags.has_read() && flags.has_write() && !flags.has_discovery()
+                    })
+                    .filter_map(|(url, _)| {
+                        // Only remove ephemeral relays (tracked in EPHEMERAL_IN_USE)
+                        if crate::stores::relay::coverage::is_ephemeral_relay(url.as_str()) {
+                            Some(url.to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                if !to_remove.is_empty() {
+                    crate::stores::relay::coverage::cleanup_ephemeral_relays(&client, &to_remove)
+                        .await;
+                }
+            });
+        }
     }));
     use_effect(use_reactive(
         (
             &pubkey_for_pinned,
             &*nostr_client::CLIENT_INITIALIZED.read(),
+            &*nostr_client::HAS_SIGNER.read(),
         ),
-        move |(pubkey_str, client_initialized)| {
+        move |(pubkey_str, client_initialized, has_signer)| {
             if !client_initialized {
+                return;
+            }
+            // For authenticated users whose signer hasn't attached yet, defer.
+            // The effect re-runs when HAS_SIGNER flips true.
+            if auth_store::is_authenticated() && !has_signer {
                 return;
             }
             pinned_loading.set(true);
@@ -198,9 +232,15 @@ pub fn ProfileViewer(pubkey: String) -> Element {
             &pubkey,
             &*nostr_client::CLIENT_INITIALIZED.read(),
             &*retry_count.read(),
+            &*nostr_client::HAS_SIGNER.read(),
         ),
-        move |(pubkey_str, client_initialized, _retry)| {
+        move |(pubkey_str, client_initialized, _retry, has_signer)| {
             if !client_initialized {
+                return;
+            }
+            // For authenticated users whose signer hasn't attached yet, defer.
+            // The effect re-runs when HAS_SIGNER flips true.
+            if auth_store::is_authenticated() && !has_signer {
                 return;
             }
             let current_id = *request_id.peek();
@@ -282,40 +322,67 @@ pub fn ProfileViewer(pubkey: String) -> Element {
                     return;
                 }
 
-                let write_relays = crate::stores::relay::coverage::resolve_user_relays(
+                // Resolve write relays in the background (non-blocking) so the
+                // metadata race isn't gated on a 5s kind-10002 network fetch.
+                // `fetch_metadata_targeted` resolves these internally too, but
+                // resolving here ensures `user_write_relays` is populated
+                // promptly for the tab-events effect (Effect 4).
+                {
+                    let hex_bg = hex_pubkey.clone();
+                    let mut uwr = user_write_relays;
+                    let rid_bg = rid;
+                    let cid_bg = current_id;
+                    spawn(async move {
+                        let write_relays = crate::stores::relay::coverage::resolve_user_relays(
+                            &hex_bg,
+                            crate::stores::relay::coverage::RelayPurpose::Write,
+                        )
+                        .await;
+                        if *rid_bg.peek() == cid_bg && !write_relays.is_empty() {
+                            uwr.set(write_relays);
+                        }
+                    });
+                }
+
+                // Race indexers (fast path) vs outbox. Indexers are connected at
+                // boot and purpose-built for kind 0 discovery — typically
+                // <500ms. The outbox path resolves the user's write relays +
+                // ephemeral-connects + fetches. First Ok(Some) wins; if the
+                // winner returns None/Err we fall back to the remaining future.
+                use futures::future::{select, Either};
+                use futures::pin_mut;
+                let indexer_fut = nostr_client::fetch_metadata_from_indexers(
                     &hex_pubkey,
-                    crate::stores::relay::coverage::RelayPurpose::Write,
-                )
-                .await;
+                    Duration::from_secs(5),
+                );
+                let outbox_fut =
+                    nostr_client::fetch_metadata_targeted(&hex_pubkey, Duration::from_secs(8));
+                pin_mut!(indexer_fut, outbox_fut);
+                let metadata_result = match select(indexer_fut, outbox_fut).await {
+                    Either::Left((indexer_res, remaining_outbox)) => match indexer_res {
+                        Ok(m @ Some(_)) => Ok(m),
+                        _ => remaining_outbox.await,
+                    },
+                    Either::Right((outbox_res, remaining_indexer)) => match outbox_res {
+                        Ok(m @ Some(_)) => Ok(m),
+                        _ => remaining_indexer.await,
+                    },
+                };
+
                 if *rid.peek() != current_id {
                     return;
                 }
-                if !write_relays.is_empty() {
-                    user_write_relays.set(write_relays);
-                }
-
-                match nostr_client::fetch_metadata_targeted(&hex_pubkey, Duration::from_secs(5))
-                    .await
-                {
+                match metadata_result {
                     Ok(Some(metadata)) => {
-                        if *rid.peek() != current_id {
-                            return;
-                        }
-                        log::debug!("Fetched profile metadata from relays");
+                        log::debug!("Fetched profile metadata from race winner");
                         profile_data.set(Some(metadata));
                     }
                     Ok(None) => {
-                        if *rid.peek() != current_id {
-                            return;
-                        }
-                        log::debug!("No metadata found, using empty profile");
+                        log::debug!("No metadata found from any source");
                         metadata_error.set(Some("No profile data found".to_string()));
                         profile_data.set(Some(nostr_sdk::Metadata::new()));
                     }
                     Err(e) => {
-                        if *rid.peek() != current_id {
-                            return;
-                        }
                         log::error!("Failed to fetch profile metadata: {}", e);
                         metadata_error.set(Some(format!("Failed to load: {}", e)));
                         profile_data.set(Some(nostr_sdk::Metadata::new()));
@@ -332,9 +399,15 @@ pub fn ProfileViewer(pubkey: String) -> Element {
             &pubkey,
             &*active_tab.read(),
             &*nostr_client::CLIENT_INITIALIZED.read(),
+            &*nostr_client::HAS_SIGNER.read(),
         ),
-        move |(pubkey_str, tab, client_initialized)| {
+        move |(pubkey_str, tab, client_initialized, has_signer)| {
             if !client_initialized {
+                return;
+            }
+            // For authenticated users whose signer hasn't attached yet, defer.
+            // The effect re-runs when HAS_SIGNER flips true.
+            if auth_store::is_authenticated() && !has_signer {
                 return;
             }
             let already_loaded = tab_data.read().get(&tab).map(|d| d.loaded).unwrap_or(false);
@@ -406,6 +479,18 @@ pub fn ProfileViewer(pubkey: String) -> Element {
                         loading_events.set(false);
                         return;
                     }
+                    // Wait for user relay lists to be applied (no-op if
+                    // logged out or already applied). Ensures the user's
+                    // NIP-65 read relays are in the pool before streaming.
+                    crate::stores::relay::wait_for_user_relays(
+                        Duration::from_millis(500),
+                        "profile_tab_events",
+                    )
+                    .await;
+                    if *rid.peek() != current_id {
+                        loading_events.set(false);
+                        return;
+                    }
                     let public_key_for_relay = match crate::utils::nip19_urls::parse_profile_id(&pubkey_for_relay) {
                         Some(pk) => pk,
                         None => {
@@ -414,13 +499,14 @@ pub fn ProfileViewer(pubkey: String) -> Element {
                         }
                     };
                     let known_relays = user_write_relays.read().clone();
-                    let client = match nostr_client::get_client() {
-                        Some(c) => c,
-                        None => {
-                            loading_events.set(false);
-                            return;
-                        }
-                    };
+                    // Guard: ensure the client is initialized before proceeding.
+                    // `stream_profile_events_from_relays` obtains the client
+                    // internally, but we bail early here to avoid building a
+                    // filter + collector for a client that doesn't exist.
+                    if nostr_client::get_client().is_none() {
+                        loading_events.set(false);
+                        return;
+                    }
                     let filter = build_tab_filter(public_key_for_relay, &tab_for_relay, None, 100);
 
                     if matches!(tab_for_relay, ProfileTab::Likes) {
@@ -516,118 +602,188 @@ pub fn ProfileViewer(pubkey: String) -> Element {
                         return;
                     }
 
-                    let targeted_future = nostr_client::fetch_profile_events_from_relays_direct(
-                        &client, filter.clone(), &known_relays, Duration::from_secs(5),
-                    );
-                    let safety_future = nostr_client::fetch_events_from_connected_relays(
-                        filter, Duration::from_secs(5),
-                    );
+                    // Stream events from the author's outbox relays for
+                    // progressive UI updates — posts paint as they arrive
+                    // instead of blocking for the full EOSE window. Mirrors
+                    // the home Following feed's `load_following_feed_streaming`
+                    // pattern: per-event callback + `DebouncedCollector` for
+                    // coalesced signal writes.
+                    let collector =
+                        crate::utils::debounced_collector::DebouncedCollector::<NostrEvent>::new(
+                            50,
+                        );
+                    let all_streamed: std::rc::Rc<std::cell::RefCell<Vec<NostrEvent>>> =
+                        std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+                    let td_stream = tab_data;
+                    let tfr_stream = tab_for_relay.clone();
+                    let pc_stream = post_count;
+                    let rid_stream = rid;
+                    let cid_stream = current_id;
 
-                    let (targeted_result, safety_result) = futures::join!(targeted_future, safety_future);
+                    let stream_result = nostr_client::stream_profile_events_from_relays(
+                        filter,
+                        &known_relays,
+                        Duration::from_secs(8),
+                        {
+                            let collector = collector.clone();
+                            let all_streamed = all_streamed.clone();
+                            move |event| {
+                                if *rid_stream.peek() != cid_stream {
+                                    return;
+                                }
+                                if is_likely_future(event.created_at) {
+                                    return;
+                                }
+                                all_streamed.borrow_mut().push(event.clone());
+                                collector.extend(std::iter::once(event), {
+                                    let mut td = td_stream;
+                                    let tfr = tfr_stream.clone();
+                                    let mut pc = pc_stream;
+                                    move |batch| {
+                                        if *rid_stream.peek() != cid_stream {
+                                            return;
+                                        }
+                                        let processed = process_tab_events(batch, &tfr);
+                                        if processed.is_empty() {
+                                            return;
+                                        }
+                                        let mut data_map = td.read().clone();
+                                        let existing =
+                                            data_map.get(&tfr).cloned().unwrap_or_default();
+                                        let existing_ids: std::collections::HashSet<_> =
+                                            existing.events.iter().map(|e| e.id).collect();
+                                        let new: Vec<_> = processed
+                                            .into_iter()
+                                            .filter(|e| !existing_ids.contains(&e.id))
+                                            .collect();
+                                        if new.is_empty() {
+                                            return;
+                                        }
+                                        let mut merged = existing.events;
+                                        merged.extend(new);
+                                        if matches!(tfr, ProfileTab::Articles) {
+                                            merged = dedupe_articles_by_address(merged);
+                                            merged.sort_by_key(|e| {
+                                                std::cmp::Reverse(get_published_at(e))
+                                            });
+                                        } else {
+                                            merged
+                                                .sort_by_key(|e| std::cmp::Reverse(e.created_at));
+                                        }
+                                        let oldest_ts = if matches!(tfr, ProfileTab::Articles) {
+                                            safe_cursor_from_timestamps(
+                                                &merged.iter().map(get_published_at).collect::<Vec<u64>>(),
+                                            )
+                                        } else {
+                                            safe_cursor_from_timestamps(
+                                                &merged.iter().map(|e| e.created_at.as_secs()).collect::<Vec<u64>>(),
+                                            )
+                                        };
+                                        let merged_len = merged.len();
+                                        data_map.insert(
+                                            tfr.clone(),
+                                            TabData {
+                                                events: merged,
+                                                oldest_timestamp: oldest_ts,
+                                                has_more: true,
+                                                loaded: true,
+                                            },
+                                        );
+                                        td.set(data_map);
+                                        if matches!(tfr, ProfileTab::Posts) {
+                                            pc.set(merged_len);
+                                        }
+                                    }
+                                });
+                            }
+                        },
+                    )
+                    .await;
+
+                    if let Err(e) = &stream_result {
+                        log::warn!("Profile tab stream error for {:?}: {}", tab_for_relay, e);
+                    }
 
                     if *rid.peek() != current_id {
                         loading_events.set(false);
                         return;
                     }
 
-                    let mut all_events = Vec::new();
-                    let mut seen_ids = std::collections::HashSet::new();
-                    for events in [&targeted_result, &safety_result]
-                        .into_iter()
-                        .filter_map(|r| r.as_ref().ok())
-                    {
-                        for event in events {
-                            if is_likely_future(event.created_at) { continue; }
-                            if seen_ids.insert(event.id) {
-                                all_events.push(event.clone());
+                    // Flush any events buffered after the last debounce window.
+                    let tail = collector.drain();
+                    if !tail.is_empty() {
+                        let processed = process_tab_events(tail, &tab_for_relay);
+                        let mut data_map = tab_data.read().clone();
+                        let existing = data_map.get(&tab_for_relay).cloned().unwrap_or_default();
+                        let existing_ids: std::collections::HashSet<_> =
+                            existing.events.iter().map(|e| e.id).collect();
+                        let new: Vec<_> = processed
+                            .into_iter()
+                            .filter(|e| !existing_ids.contains(&e.id))
+                            .collect();
+                        if !new.is_empty() {
+                            let mut merged = existing.events;
+                            merged.extend(new);
+                            if matches!(tab_for_relay, ProfileTab::Articles) {
+                                merged = dedupe_articles_by_address(merged);
+                                merged.sort_by_key(|e| std::cmp::Reverse(get_published_at(e)));
+                            } else {
+                                merged.sort_by_key(|e| std::cmp::Reverse(e.created_at));
+                            }
+                            let oldest_ts = if matches!(tab_for_relay, ProfileTab::Articles) {
+                                safe_cursor_from_timestamps(
+                                    &merged.iter().map(get_published_at).collect::<Vec<u64>>(),
+                                )
+                            } else {
+                                safe_cursor_from_timestamps(
+                                    &merged.iter().map(|e| e.created_at.as_secs()).collect::<Vec<u64>>(),
+                                )
+                            };
+                            let merged_len = merged.len();
+                            data_map.insert(
+                                tab_for_relay.clone(),
+                                TabData {
+                                    events: merged,
+                                    oldest_timestamp: oldest_ts,
+                                    has_more: true,
+                                    loaded: true,
+                                },
+                            );
+                            tab_data.set(data_map);
+                            if matches!(tab_for_relay, ProfileTab::Posts) {
+                                post_count.set(merged_len);
                             }
                         }
                     }
 
-                    let mut processed = process_tab_events(all_events, &tab_for_relay);
-                    if matches!(tab_for_relay, ProfileTab::Articles) {
-                        processed.sort_by_key(|e| std::cmp::Reverse(get_published_at(e)));
-                    } else {
-                        processed.sort_by_key(|e| std::cmp::Reverse(e.created_at));
-                    }
-                    let mut seen_ids = std::collections::HashSet::new();
-                    processed.retain(|e| seen_ids.insert(e.id));
-                    let relay_count = processed.len();
-
-                    let mut data_map = tab_data.read().clone();
-                    let existing_data = data_map.get(&tab_for_relay).cloned().unwrap_or_default();
-                    let existing_ids: std::collections::HashSet<_> =
-                        existing_data.events.iter().map(|e| e.id).collect();
-                    let new_events: Vec<_> = processed
-                        .into_iter()
-                        .filter(|e| !existing_ids.contains(&e.id))
-                        .collect();
-                    let has_more = relay_count >= 100;
-                    if !new_events.is_empty() {
-                        log::info!(
-                            "Phase 2: found {} new events from relays (has_more: {})",
-                            new_events.len(),
-                            has_more
-                        );
-                        let mut merged = existing_data.events;
-                        merged.extend(new_events.clone());
-                        if matches!(tab_for_relay, ProfileTab::Articles) {
-                            merged = dedupe_articles_by_address(merged);
+                    // Finalize has_more based on total events received.
+                    let total = all_streamed.borrow().len();
+                    let has_more = total >= 100;
+                    {
+                        let mut data_map = tab_data.read().clone();
+                        if let Some(data) = data_map.get_mut(&tab_for_relay) {
+                            data.has_more = has_more;
+                            data.loaded = true;
                         }
-                        if matches!(tab_for_relay, ProfileTab::Articles) {
-                            merged.sort_by_key(|e| std::cmp::Reverse(get_published_at(e)));
-                        } else {
-                            merged.sort_by_key(|e| std::cmp::Reverse(e.created_at));
-                        }
-                        let oldest_ts = if matches!(tab_for_relay, ProfileTab::Articles) {
-                            safe_cursor_from_timestamps(&merged.iter().map(get_published_at).collect::<Vec<u64>>())
-                        } else {
-                            safe_cursor_from_timestamps(&merged.iter().map(|e| e.created_at.as_secs()).collect::<Vec<u64>>())
-                        };
-                        if *rid.peek() != current_id {
-                            loading_events.set(false);
-                            return;
-                        }
-                        data_map.insert(
-                            tab_for_relay.clone(),
-                            TabData {
-                                events: merged.clone(),
-                                oldest_timestamp: oldest_ts,
-                                has_more,
-                                loaded: true,
-                            },
-                        );
                         tab_data.set(data_map);
-                        current_tab_has_more.set(has_more);
-                        if matches!(tab_for_relay, ProfileTab::Posts) {
-                            post_count.set(merged.len());
-                        }
-                        let events_for_prefetch = expand_events_for_prefetch(&new_events);
+                    }
+                    current_tab_has_more.set(has_more);
+                    log::info!(
+                        "Phase 2 stream: received {} events for {:?} (has_more: {})",
+                        total,
+                        tab_for_relay,
+                        has_more
+                    );
+
+                    // Prefetch author metadata for all streamed events.
+                    let events_for_prefetch =
+                        expand_events_for_prefetch(&all_streamed.borrow());
+                    if !events_for_prefetch.is_empty() {
                         spawn(async move {
                             prefetch_author_metadata(&events_for_prefetch).await;
                         });
-                    } else {
-                        log::info!(
-                            "Phase 2: no new events from relays (all already in DB, has_more: {})",
-                            has_more
-                        );
-                        if *rid.peek() != current_id {
-                            loading_events.set(false);
-                            return;
-                        }
-                        let mut data_map = tab_data.read().clone();
-                        data_map.insert(
-                            tab_for_relay.clone(),
-                            TabData {
-                                events: existing_data.events,
-                                oldest_timestamp: existing_data.oldest_timestamp,
-                                has_more,
-                                loaded: true,
-                            },
-                        );
-                        tab_data.set(data_map);
-                        current_tab_has_more.set(has_more);
                     }
+
                     if *rid.peek() == current_id {
                         loading_events.set(false);
                     }
@@ -681,6 +837,91 @@ pub fn ProfileViewer(pubkey: String) -> Element {
             }
         });
     }));
+    // Live-tail subscription: after the initial page streams in, subscribe to
+    // new events for realtime updates (amethyst/wisp pattern). Uses
+    // `use_relay_subscription_to` which is reactive to relay_urls changes —
+    // it auto-re-subscribes when user_write_relays are discovered
+    // mid-session (the wisp "re-subscribe on discovery" pattern).
+    //
+    // `since` is derived from the newest loaded event so only genuinely-new
+    // events arrive. As new events merge, the filter advances and the hook
+    // re-subscribes with the updated `since` (duplicates are deduped).
+    // Disabled for Likes/Zaps tabs (multi-stage fetch logic).
+    {
+        let live_tab = active_tab.read().clone();
+        let live_td = tab_data.read();
+        let live_loaded = live_td.get(&live_tab).map(|d| d.loaded).unwrap_or(false);
+        let live_since = live_td
+            .get(&live_tab)
+            .and_then(|d| d.events.first())
+            .map(|e| e.created_at);
+        drop(live_td);
+        let is_simple_tab = !matches!(live_tab, ProfileTab::Likes | ProfileTab::Zaps(_));
+        let live_filter: Option<Filter> =
+            if live_loaded && *nostr_client::CLIENT_INITIALIZED.read() && is_simple_tab {
+                live_since.and_then(|since| {
+                    crate::utils::nip19_urls::parse_profile_id(&pubkey)
+                        .map(|pk| build_tab_filter(pk, &live_tab, None, 10).since(since))
+                })
+            } else {
+                None
+            };
+        let live_relays = if live_filter.is_some() {
+            user_write_relays.read().clone()
+        } else {
+            Vec::new()
+        };
+        let mut td_live = tab_data;
+        let tab_live = live_tab;
+        let mut pc_live = post_count;
+        crate::hooks::use_relay_subscription_to(
+            live_filter,
+            None,
+            live_relays,
+            move |event: &nostr::Event| {
+                if is_likely_future(event.created_at) {
+                    return;
+                }
+                let processed = process_tab_events(vec![event.clone()], &tab_live);
+                if processed.is_empty() {
+                    return;
+                }
+                let mut data_map = td_live.read().clone();
+                let existing = data_map.get(&tab_live).cloned().unwrap_or_default();
+                let existing_ids: std::collections::HashSet<_> =
+                    existing.events.iter().map(|e| e.id).collect();
+                let new: Vec<_> = processed
+                    .into_iter()
+                    .filter(|e| !existing_ids.contains(&e.id))
+                    .collect();
+                if new.is_empty() {
+                    return;
+                }
+                let mut merged = existing.events;
+                merged.extend(new);
+                if matches!(tab_live, ProfileTab::Articles) {
+                    merged = dedupe_articles_by_address(merged);
+                    merged.sort_by_key(|e| std::cmp::Reverse(get_published_at(e)));
+                } else {
+                    merged.sort_by_key(|e| std::cmp::Reverse(e.created_at));
+                }
+                let merged_len = merged.len();
+                data_map.insert(
+                    tab_live.clone(),
+                    TabData {
+                        events: merged,
+                        oldest_timestamp: existing.oldest_timestamp,
+                        has_more: existing.has_more,
+                        loaded: true,
+                    },
+                );
+                td_live.set(data_map);
+                if matches!(tab_live, ProfileTab::Posts) {
+                    pc_live.set(merged_len);
+                }
+            },
+        );
+    }
     let load_more = move || {
         let tab = active_tab.read().clone();
         log::info!("load_more called for tab {:?}", tab);

--- a/src/components/voice/message_card.rs
+++ b/src/components/voice/message_card.rs
@@ -238,49 +238,19 @@ pub fn VoiceMessageCard(
     };
     let audio_id_for_effect = audio_id.clone();
     use_effect(move || {
-        let global_state = voice_messages_store::VOICE_PLAYBACK.read();
-        let _is_playing = global_state.currently_playing == Some(event_id);
-        let _audio_id_clone = audio_id_for_effect.clone();
-        #[cfg(feature = "web")]
-        {
-            let is_playing = _is_playing;
-            let audio_id_clone = _audio_id_clone;
-            let window = match web_sys::window() {
-                Some(w) => w,
-                None => {
-                    log::error!("Failed to get window object");
-                    return;
-                }
-            };
-            let document = match window.document() {
-                Some(d) => d,
-                None => {
-                    log::error!("Failed to get document object");
-                    return;
-                }
-            };
-            let element = match document.get_element_by_id(&audio_id_clone) {
-                Some(e) => e,
-                None => {
-                    log::debug!("Audio element {} not found yet", audio_id_clone);
-                    return;
-                }
-            };
-            let audio: web_sys::HtmlAudioElement = match element.dyn_into() {
-                Ok(a) => a,
-                Err(e) => {
-                    log::error!("Element is not an HtmlAudioElement: {:?}", e);
-                    return;
-                }
-            };
-            if is_playing {
-                let _ = audio.play().map_err(|e| {
-                    log::debug!("Play failed: {:?}", e);
-                });
-            } else if let Err(e) = audio.pause() {
-                log::debug!("Pause failed: {:?}", e);
-            }
-        }
+        let is_playing =
+            voice_messages_store::VOICE_PLAYBACK.read().currently_playing == Some(event_id);
+        let audio_id_clone = audio_id_for_effect.clone();
+        spawn(async move {
+            let id = serde_json::to_string(&audio_id_clone).unwrap_or_default();
+            let play_lit = if is_playing { "true" } else { "false" };
+            let js = format!(
+                "(function(){{var a=document.getElementById({id});if(!a)return;if({p}){{a.play().catch(function(){{}});}}else{{a.pause();}}}})();",
+                id = id,
+                p = play_lit,
+            );
+            let _ = document::eval(&js).await;
+        });
     });
     #[cfg(feature = "web")]
     let _handle_timeupdate = move |_evt: Event<MediaData>| {
@@ -319,6 +289,48 @@ pub fn VoiceMessageCard(
         voice_messages_store::pause_voice_message();
         current_time.set(0.0);
     };
+    #[cfg(not(feature = "web"))]
+    {
+        let audio_id_poll = audio_id.clone();
+        use_future(move || {
+            let audio_id_poll = audio_id_poll.clone();
+            async move {
+                loop {
+                    crate::platform::timer::sleep_ms(200).await;
+                    if voice_messages_store::VOICE_PLAYBACK.read().currently_playing
+                        != Some(event_id)
+                    {
+                        continue;
+                    }
+                    let id = serde_json::to_string(&audio_id_poll).unwrap_or_default();
+                    let js = format!(
+                        "(function(){{var a=document.getElementById({id});if(!a)return null;return [a.currentTime||0,a.duration||0,a.ended];}})();",
+                        id = id,
+                    );
+                    if let Ok(v) = document::eval(&js).await {
+                        if let Some(arr) = v.as_array() {
+                            let t = arr.first().and_then(|x| x.as_f64()).unwrap_or(0.0);
+                            let d = arr.get(1).and_then(|x| x.as_f64()).unwrap_or(0.0);
+                            let ended = arr.get(2).and_then(|x| x.as_bool()).unwrap_or(false);
+                            if !t.is_nan() {
+                                current_time.set(t);
+                                voice_messages_store::set_current_time(t);
+                            }
+                            if d.is_finite() && d > 0.0 {
+                                duration.set(d);
+                                is_loading.set(false);
+                                voice_messages_store::set_duration(d);
+                            }
+                            if ended {
+                                voice_messages_store::pause_voice_message();
+                                current_time.set(0.0);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
     let event_id_for_repost = event_id_str.clone();
     let handle_repost = move |e: MouseEvent| {
         e.stop_propagation();
@@ -373,59 +385,30 @@ pub fn VoiceMessageCard(
             format!("{}d", (diff / 86400.0) as u32)
         }
     };
-    let navigator: Option<std::rc::Rc<dyn Fn()>> = {
-        #[cfg(feature = "web")]
-        {
-            let nav = use_navigator();
-            let voice_id = event_id_str.clone();
-            let author_pubkey_nav = author_pubkey.clone();
-            Some(std::rc::Rc::new(move || {
-                let _ = nav.push(Route::AddressViewer {
-                    address: crate::utils::nip19_urls::note_route_id(&voice_id, Some(&author_pubkey_nav)),
-                });
-            }))
-        }
-        #[cfg(not(feature = "web"))]
-        {
-            None
-        }
-    };
-    #[cfg(feature = "web")]
-    let is_clickable = true;
-    #[cfg(not(feature = "web"))]
-    let is_clickable = false;
-    let card_class = if is_clickable {
-        "p-4 hover:bg-accent/50 transition cursor-pointer border-b border-border"
-    } else {
-        "p-4 border-b border-border opacity-60"
-    };
-    let tooltip_text = if !is_clickable {
-        "Not supported on this platform"
-    } else {
-        ""
-    };
-    let navigator_for_click = navigator.clone();
-    let navigator_for_keydown = navigator.clone();
-    let handle_click = move |_evt: Event<MouseData>| {
-        #[cfg(feature = "web")]
-        {
-            if let Some(target) = _evt.data.as_web_event().target() {
-                if let Some(element) = target.dyn_ref::<web_sys::Element>() {
-                    if element
-                        .closest(INTERACTIVE_ELEMENT_SELECTOR)
-                        .ok()
-                        .flatten()
-                        .is_some()
-                    {
-                        return;
+    let nav = use_navigator();
+    let card_class = "p-4 hover:bg-accent/50 transition cursor-pointer border-b border-border";
+    let handle_click = {
+        let voice_id = event_id_str.clone();
+        let author_pk = author_pubkey.clone();
+        move |_evt: Event<MouseData>| {
+            #[cfg(feature = "web")]
+            {
+                if let Some(target) = _evt.data.as_web_event().target() {
+                    if let Some(element) = target.dyn_ref::<web_sys::Element>() {
+                        if element
+                            .closest(INTERACTIVE_ELEMENT_SELECTOR)
+                            .ok()
+                            .flatten()
+                            .is_some()
+                        {
+                            return;
+                        }
                     }
                 }
             }
-        }
-        if is_clickable {
-            if let Some(nav) = navigator_for_click.as_ref() {
-                nav();
-            }
+            nav.push(Route::AddressViewer {
+                address: crate::utils::nip19_urls::note_route_id(&voice_id, Some(&author_pk)),
+            });
         }
     };
     let content_warning = nip36::get_content_warning(&event.tags);
@@ -440,58 +423,47 @@ pub fn VoiceMessageCard(
                 onloadedmetadata: _handle_loadedmetadata,
                 onended: _handle_ended,
             }
-            if cfg!(feature = "web") {
-                div { class: "flex items-center gap-4 bg-muted/30 rounded-lg p-3",
-                    button {
-                        class: "shrink-0 w-10 h-10 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 transition flex items-center justify-center",
-                        onclick: toggle_play,
-                        if voice_messages_store::VOICE_PLAYBACK.read().currently_playing == Some(event_id) {
-                            svg {
-                                class: "w-5 h-5",
-                                view_box: "0 0 24 24",
-                                fill: "currentColor",
-                                rect {
-                                    x: "6",
-                                    y: "4",
-                                    width: "4",
-                                    height: "16",
-                                }
-                                rect {
-                                    x: "14",
-                                    y: "4",
-                                    width: "4",
-                                    height: "16",
-                                }
+            div { class: "flex items-center gap-4 bg-muted/30 rounded-lg p-3",
+                button {
+                    class: "shrink-0 w-10 h-10 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 transition flex items-center justify-center",
+                    onclick: toggle_play,
+                    if voice_messages_store::VOICE_PLAYBACK.read().currently_playing == Some(event_id) {
+                        svg {
+                            class: "w-5 h-5",
+                            view_box: "0 0 24 24",
+                            fill: "currentColor",
+                            rect {
+                                x: "6",
+                                y: "4",
+                                width: "4",
+                                height: "16",
                             }
-                        } else {
-                            svg {
-                                class: "w-5 h-5 ml-0.5",
-                                view_box: "0 0 24 24",
-                                fill: "currentColor",
-                                polygon { points: "8,5 19,12 8,19" }
+                            rect {
+                                x: "14",
+                                y: "4",
+                                width: "4",
+                                height: "16",
                             }
                         }
-                    }
-                    div { class: "flex-1",
-                        div { class: "w-full h-1 bg-muted rounded-full overflow-hidden mb-1",
-                            div {
-                                class: "h-full bg-primary transition-all",
-                                style: "width: {progress_percent}%",
-                            }
-                        }
-                        div { class: "flex justify-between text-xs text-muted-foreground",
-                            span { "{current_time_str}" }
-                            span { "{duration_str}" }
+                    } else {
+                        svg {
+                            class: "w-5 h-5 ml-0.5",
+                            view_box: "0 0 24 24",
+                            fill: "currentColor",
+                            polygon { points: "8,5 19,12 8,19" }
                         }
                     }
                 }
-            } else {
-                div { class: "flex items-center gap-4 bg-muted/30 rounded-lg p-3",
-                    div { class: "shrink-0 w-10 h-10 rounded-full bg-muted flex items-center justify-center",
-                        span { class: "text-muted-foreground text-xs", "N/A" }
+                div { class: "flex-1",
+                    div { class: "w-full h-1 bg-muted rounded-full overflow-hidden mb-1",
+                        div {
+                            class: "h-full bg-primary transition-all",
+                            style: "width: {progress_percent}%",
+                        }
                     }
-                    div { class: "flex-1 text-sm text-muted-foreground",
-                        "Playback not supported on this platform"
+                    div { class: "flex justify-between text-xs text-muted-foreground",
+                        span { "{current_time_str}" }
+                        span { "{duration_str}" }
                     }
                 }
             }
@@ -500,40 +472,40 @@ pub fn VoiceMessageCard(
     rsx! {
         div {
             class: "{card_class}",
-            title: "{tooltip_text}",
-            role: if is_clickable { "button" } else { "article" },
-            tabindex: if is_clickable { "0" } else { "-1" },
+            role: "button",
+            tabindex: "0",
             onclick: handle_click,
-            onkeydown: move |evt: KeyboardEvent| {
-                if !is_clickable {
-                    return;
-                }
-                let activate = match evt.key() {
-                    Key::Enter => true,
-                    Key::Character(c) => c == " ",
-                    _ => false,
-                };
-                if !activate {
-                    return;
-                }
-                #[cfg(feature = "web")]
-                {
-                    if let Some(target) = evt.data.as_web_event().target() {
-                        if let Some(element) = target.dyn_ref::<web_sys::Element>() {
-                            if element
-                                .closest(INTERACTIVE_ELEMENT_SELECTOR)
-                                .ok()
-                                .flatten()
-                                .is_some()
-                            {
-                                return;
+            onkeydown: {
+                let voice_id = event_id_str.clone();
+                let author_pk = author_pubkey.clone();
+                move |evt: KeyboardEvent| {
+                    let activate = match evt.key() {
+                        Key::Enter => true,
+                        Key::Character(c) => c == " ",
+                        _ => false,
+                    };
+                    if !activate {
+                        return;
+                    }
+                    #[cfg(feature = "web")]
+                    {
+                        if let Some(target) = evt.data.as_web_event().target() {
+                            if let Some(element) = target.dyn_ref::<web_sys::Element>() {
+                                if element
+                                    .closest(INTERACTIVE_ELEMENT_SELECTOR)
+                                    .ok()
+                                    .flatten()
+                                    .is_some()
+                                {
+                                    return;
+                                }
                             }
                         }
                     }
-                }
-                evt.prevent_default();
-                if let Some(nav) = navigator_for_keydown.as_ref() {
-                    nav();
+                    evt.prevent_default();
+                    nav.push(Route::AddressViewer {
+                        address: crate::utils::nip19_urls::note_route_id(&voice_id, Some(&author_pk)),
+                    });
                 }
             },
             div { class: "flex items-start gap-3 mb-3",

--- a/src/routes/address_viewer.rs
+++ b/src/routes/address_viewer.rs
@@ -19,10 +19,10 @@ pub fn AddressViewer(address: String) -> Element {
             &*retry_nonce.read(),
         ),
         move |(addr, client_initialized, _retry)| {
-            state.set(AddressState::Loading);
             if !client_initialized {
                 return;
             }
+            state.set(AddressState::Loading);
             spawn(async move {
                 match resolve_address(&addr).await {
                     Ok(resolved) => state.set(resolved),

--- a/src/routes/ai_chat/mod.rs
+++ b/src/routes/ai_chat/mod.rs
@@ -12,13 +12,14 @@ use crate::services::ai_chat::{
     get_available_models, ChatModel, ChatModelKind,
 };
 use crate::services::ppq;
+use crate::services::routstr;
 use crate::stores::ai_chat_seed_store;
 use crate::stores::ai_chat_store::{
     self, PersistedChatMessage, PersistedChatState,
     PersistedConversation,
 };
 use crate::stores::ai_provider_store::{
-    self, ppq_provider, resolve_providers, AiProviderState, PpqAccountState,
+    self, ppq_provider, resolve_providers, routstr_provider, AiProviderState, PpqAccountState,
     PROVIDER_STATE_SAVE_EVENT,
 };
 use crate::stores::nostr_client;
@@ -578,7 +579,7 @@ pub fn AIChat() -> Element {
     }
 
     let active_provider = current_provider(&providers.read(), &provider_state.read());
-    let ppq_blocked = active_provider.requires_setup();
+    let needs_setup = active_provider.requires_setup();
     let active_model = current_model(&models.read(), selected_model.read().as_str());
     let supports_image_attachments = active_model
         .as_ref()
@@ -860,7 +861,7 @@ pub fn AIChat() -> Element {
                             key: "{active_provider.id}:{models.read().len()}:{selected_model}",
                             class: "h-10 min-w-0 flex-1 rounded-lg border border-border bg-card px-3 text-sm text-foreground focus:outline-hidden sm:w-[18rem] sm:flex-none",
                             value: "{selected_model}",
-                            disabled: models.read().is_empty() || *loading.read() || ppq_blocked,
+                            disabled: models.read().is_empty() || *loading.read() || needs_setup,
                             onchange: move |evt| {
                                 let value = evt.value();
                                 selected_model.set(value.clone());
@@ -879,7 +880,7 @@ pub fn AIChat() -> Element {
                                 option {
                                     value: "",
                                     selected: selected_model.read().is_empty(),
-                                    if ppq_blocked { "Set up PPQ or switch providers" } else { "Loading models..." }
+                                    if needs_setup { "Set up provider or switch in AI settings" } else { "Loading models..." }
                                 }
                             } else {
                                 for model in models.read().iter() {
@@ -941,61 +942,95 @@ pub fn AIChat() -> Element {
                 id: "{messages_container_id}",
                 class: "flex-1 overflow-y-auto",
                 div { class: "mx-auto flex max-w-5xl flex-col gap-6 overflow-hidden px-4 py-6",
-                    if ppq_blocked {
-                        PpqSetupGate {
-                            loading: ppq_bootstrap_loading,
-                            on_create_account: move |_| {
-                                if *ppq_bootstrap_loading.read() {
-                                    return;
-                                }
-                                ppq_bootstrap_loading.set(true);
-                                error.set(None);
-                                spawn(async move {
-                                    match ppq::create_account().await {
-                                        Ok(account) => {
-                                            let mut next_state = provider_state.read().clone();
-                                            next_state.selected_provider_id = ppq_provider(None).id;
-                                            next_state.ppq_account = Some(PpqAccountState {
-                                                credit_id: account.credit_id,
-                                                api_key: account.api_key,
-                                                managed_api_key: None,
-                                                active_api_key_id: None,
-                                            });
-                                            if let Err(err) =
-                                                ai_provider_store::cache_provider_state(&next_state)
-                                            {
+                    if needs_setup {
+                        if active_provider.id == ppq_provider(None).id {
+                            PpqSetupGate {
+                                loading: ppq_bootstrap_loading,
+                                on_create_account: move |_| {
+                                    if *ppq_bootstrap_loading.read() {
+                                        return;
+                                    }
+                                    ppq_bootstrap_loading.set(true);
+                                    error.set(None);
+                                    spawn(async move {
+                                        match ppq::create_account().await {
+                                            Ok(account) => {
+                                                let mut next_state = provider_state.read().clone();
+                                                next_state.selected_provider_id = ppq_provider(None).id;
+                                                next_state.ppq_account = Some(PpqAccountState {
+                                                    credit_id: account.credit_id,
+                                                    api_key: account.api_key,
+                                                    managed_api_key: None,
+                                                    active_api_key_id: None,
+                                                });
+                                                if let Err(err) =
+                                                    ai_provider_store::cache_provider_state(&next_state)
+                                                {
+                                                    error.set(Some(err));
+                                                    ppq_bootstrap_loading.set(false);
+                                                    return;
+                                                }
+                                                providers.set(resolve_providers(&next_state));
+                                                provider_state.set(next_state.clone());
+                                                pending_provider_save_snapshot
+                                                    .set(Some(next_state.clone()));
+                                                pending_provider_save_min_event_id.set(
+                                                    PROVIDER_STATE_SAVE_EVENT
+                                                        .read()
+                                                        .as_ref()
+                                                        .map(|event| event.event_id)
+                                                        .unwrap_or(0),
+                                                );
+                                                pending_provider_save_action
+                                                    .set(PendingProviderSaveAction::BootstrapPpq);
+                                                if let Some(snapshot) =
+                                                    ai_provider_store::queue_provider_state_save(
+                                                        next_state,
+                                                    )
+                                                {
+                                                    ai_provider_store::process_queued_provider_state_saves(snapshot);
+                                                }
+                                            }
+                                            Err(err) => {
                                                 error.set(Some(err));
                                                 ppq_bootstrap_loading.set(false);
-                                                return;
-                                            }
-                                            providers.set(resolve_providers(&next_state));
-                                            provider_state.set(next_state.clone());
-                                            pending_provider_save_snapshot
-                                                .set(Some(next_state.clone()));
-                                            pending_provider_save_min_event_id.set(
-                                                PROVIDER_STATE_SAVE_EVENT
-                                                    .read()
-                                                    .as_ref()
-                                                    .map(|event| event.event_id)
-                                                    .unwrap_or(0),
-                                            );
-                                            pending_provider_save_action
-                                                .set(PendingProviderSaveAction::BootstrapPpq);
-                                            if let Some(snapshot) =
-                                                ai_provider_store::queue_provider_state_save(
-                                                    next_state,
-                                                )
-                                            {
-                                                ai_provider_store::process_queued_provider_state_saves(snapshot);
                                             }
                                         }
-                                        Err(err) => {
-                                            error.set(Some(err));
-                                            ppq_bootstrap_loading.set(false);
-                                        }
-                                    }
-                                });
+                                    });
+                                }
                             }
+                        } else if active_provider.id == routstr_provider(None).id {
+                            RoutstrSetupGate {
+                                on_key_received: move |api_key: String| {
+                                    let mut next_state = provider_state.read().clone();
+                                    next_state.selected_provider_id = routstr_provider(None).id;
+                                    next_state.routstr_api_key = Some(api_key);
+                                    if let Err(err) =
+                                        ai_provider_store::cache_provider_state(&next_state)
+                                    {
+                                        error.set(Some(err));
+                                        return;
+                                    }
+                                    providers.set(resolve_providers(&next_state));
+                                    provider_state.set(next_state.clone());
+                                    pending_provider_save_snapshot
+                                        .set(Some(next_state.clone()));
+                                    pending_provider_save_min_event_id.set(
+                                        PROVIDER_STATE_SAVE_EVENT
+                                            .read()
+                                            .as_ref()
+                                            .map(|event| event.event_id)
+                                            .unwrap_or(0),
+                                    );
+                                    if let Some(snapshot) =
+                                        ai_provider_store::queue_provider_state_save(next_state)
+                                    {
+                                        ai_provider_store::process_queued_provider_state_saves(snapshot);
+                                    }
+                                },
+                            }
+                        } else {
+                            ProviderSetupGate { provider_name: active_provider.name.clone() }
                         }
                     } else if messages.read().is_empty() {
                         EmptyState { provider_name: active_provider.name.clone() }
@@ -1059,8 +1094,8 @@ pub fn AIChat() -> Element {
                         }
                         textarea {
                             class: "min-h-[96px] w-full resize-none bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-60",
-                            placeholder: if ppq_blocked {
-                                "Create a PPQ account here or open AI settings to switch to a custom provider..."
+                            placeholder: if needs_setup {
+                                "Complete provider setup or open AI settings to switch..."
                             } else if active_model.as_ref().is_some_and(|model| model.kind == ChatModelKind::Image) {
                                 "Describe the image you want to generate..."
                             } else if selected_model.read().is_empty() {
@@ -1069,7 +1104,7 @@ pub fn AIChat() -> Element {
                                 "Send a message..."
                             },
                             value: "{input}",
-                            disabled: selected_model.read().is_empty() || *loading.read() || ppq_blocked,
+                            disabled: selected_model.read().is_empty() || *loading.read() || needs_setup,
                             oninput: move |evt| {
                                 compose_notice.set(None);
                                 input.set(evt.value());
@@ -1098,13 +1133,13 @@ pub fn AIChat() -> Element {
                             div { class: "flex items-center gap-3",
                                 if supports_image_attachments {
                                     button {
-                                        class: if selected_model.read().is_empty() || *loading.read() || ppq_blocked {
+                                        class: if selected_model.read().is_empty() || *loading.read() || needs_setup {
                                             "inline-flex h-11 w-11 items-center justify-center rounded-xl border border-border text-muted-foreground opacity-50"
                                         } else {
                                             "inline-flex h-11 w-11 items-center justify-center rounded-xl border border-border text-muted-foreground transition hover:bg-accent"
                                         },
                                         title: "Attach image",
-                                        disabled: selected_model.read().is_empty() || *loading.read() || ppq_blocked,
+                                        disabled: selected_model.read().is_empty() || *loading.read() || needs_setup,
                                         onclick: move |_| show_image_upload.set(true),
                                         CameraIcon { class: "w-4 h-4".to_string() }
                                     }
@@ -1118,12 +1153,12 @@ pub fn AIChat() -> Element {
                                 }
                             }
                             button {
-                                class: if !can_submit || selected_model.read().is_empty() || *loading.read() || ppq_blocked {
+                                class: if !can_submit || selected_model.read().is_empty() || *loading.read() || needs_setup {
                                     "inline-flex h-11 w-11 items-center justify-center rounded-xl bg-muted text-muted-foreground cursor-not-allowed"
                                 } else {
                                     "inline-flex h-11 w-11 items-center justify-center rounded-xl bg-primary text-primary-foreground transition hover:bg-primary/90"
                                 },
-                                disabled: !can_submit || selected_model.read().is_empty() || *loading.read() || ppq_blocked,
+                                disabled: !can_submit || selected_model.read().is_empty() || *loading.read() || needs_setup,
                                 onclick: move |_| {
                                     submit_message(
                                         input,
@@ -1182,6 +1217,197 @@ fn PpqSetupGate(loading: Signal<bool>, on_create_account: EventHandler<MouseEven
                             navigator().push(Route::SettingsAi {});
                         },
                         "Use Custom Provider Instead"
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn RoutstrSetupGate(on_key_received: EventHandler<String>) -> Element {
+    use crate::services::routstr::RoutstrLightningInvoice;
+    use crate::platform;
+    use qrcode::{render::svg, QrCode};
+
+    let mut amount_input = use_signal(|| "1000".to_string());
+    let mut invoice = use_signal(|| None::<RoutstrLightningInvoice>);
+    let mut creating = use_signal(|| false);
+    let mut gate_error = use_signal(|| None::<String>);
+    let qr_svg = invoice
+        .read()
+        .as_ref()
+        .and_then(|inv| inv.bolt11.as_ref())
+        .map(|b| match QrCode::new(b.trim().to_uppercase()) {
+            Ok(code) => code
+                .render::<svg::Color>()
+                .min_dimensions(220, 220)
+                .dark_color(svg::Color("#000000"))
+                .light_color(svg::Color("#ffffff"))
+                .build(),
+            Err(_) => "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"220\" height=\"220\" viewBox=\"0 0 220 220\"><rect width=\"220\" height=\"220\" fill=\"#ffffff\"/><text x=\"110\" y=\"110\" text-anchor=\"middle\" fill=\"#666666\" font-size=\"14\">QR Error</text></svg>".to_string(),
+        })
+        .unwrap_or_default();
+
+    // Auto-poll for payment
+    {
+        let on_key = on_key_received;
+        use_future(move || {
+            let on_key = on_key;
+            async move {
+                let mut attempts = 0u32;
+                loop {
+                    crate::platform::timer::sleep_ms(5000).await;
+                    let current = invoice.read().clone();
+                    let Some(inv) = current else {
+                        attempts = 0;
+                        continue;
+                    };
+                    attempts += 1;
+                    if attempts > 60 {
+                        gate_error.set(Some("Payment polling timed out.".to_string()));
+                        invoice.set(None);
+                        attempts = 0;
+                        continue;
+                    }
+                    if let Ok(status) = routstr::get_lightning_invoice_status(&inv.invoice_id).await {
+                            if status.status.as_deref() == Some("paid") {
+                                invoice.set(None);
+                                if let Some(api_key) = status.api_key {
+                                    on_key.call(api_key);
+                                }
+                                attempts = 0;
+                            }
+                            if status.status.as_deref() == Some("expired") {
+                                gate_error.set(Some("Invoice expired.".to_string()));
+                                invoice.set(None);
+                                attempts = 0;
+                            }
+                        }
+                }
+            }
+        });
+    }
+
+    let invoice_display = invoice.read().clone();
+
+    rsx! {
+        div { class: "flex min-h-[50vh] items-center justify-center p-6",
+            div { class: "max-w-md w-full rounded-2xl border border-border bg-card p-8 text-center shadow-sm",
+                div { class: "mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 text-primary",
+                    SparklesIcon { class: "w-7 h-7".to_string() }
+                }
+                h2 { class: "text-2xl font-semibold", "Set Up Routstr" }
+                p { class: "mt-2 text-sm text-muted-foreground",
+                    "Decentralized AI inference paid with Bitcoin via Lightning. Fund a session below or open AI settings to paste an existing key."
+                }
+                if invoice_display.is_none() {
+                    div { class: "mt-5 space-y-3",
+                        div { class: "flex justify-center gap-2",
+                            input {
+                                r#type: "number",
+                                class: "w-32 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary",
+                                placeholder: "sats",
+                                value: "{amount_input}",
+                                oninput: move |e| { amount_input.set(e.value()); },
+                            }
+                            button {
+                                class: "rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-60",
+                                disabled: *creating.read(),
+                                onclick: move |_| {
+                                    let amount = match amount_input.read().trim().parse::<u64>() {
+                                        Ok(a) if a > 0 => a,
+                                        _ => {
+                                            gate_error.set(Some("Enter a valid amount in sats".to_string()));
+                                            return;
+                                        }
+                                    };
+                                    creating.set(true);
+                                    gate_error.set(None);
+                                    spawn(async move {
+                                        match routstr::create_lightning_invoice(amount, "create", None).await {
+                                            Ok(inv) => { invoice.set(Some(inv)); }
+                                            Err(err) => { gate_error.set(Some(err)); }
+                                        }
+                                        creating.set(false);
+                                    });
+                                },
+                                if *creating.read() { "Creating..." } else { "Create Session" }
+                            }
+                        }
+                        p { class: "text-xs text-muted-foreground", "Minimum 1000 sats recommended" }
+                    }
+                }
+                if let Some(err) = gate_error.read().as_ref() {
+                    p { class: "mt-3 text-xs text-red-600 dark:text-red-400", "{err}" }
+                }
+                if invoice_display.is_some() {
+                    if !qr_svg.is_empty() {
+                        div { class: "mt-5 space-y-3",
+                            p { class: "text-sm font-medium text-foreground", "Pay to Activate" }
+                            div {
+                                class: "flex justify-center rounded-lg bg-white p-4",
+                                dangerous_inner_html: "{qr_svg}",
+                            }
+                            div { class: "flex justify-center gap-2",
+                                button {
+                                    class: "rounded-lg border border-border px-3 py-1.5 text-xs transition hover:bg-accent",
+                                    onclick: move |_| {
+                                        let bolt11 = invoice.read().as_ref().and_then(|inv| inv.bolt11.clone()).unwrap_or_default();
+                                        spawn(async move {
+                                            let _ = platform::clipboard::copy_to_clipboard(&bolt11).await;
+                                        });
+                                    },
+                                    "Copy Invoice"
+                                }
+                                button {
+                                    class: "rounded-lg border border-border px-3 py-1.5 text-xs transition hover:bg-accent",
+                                    onclick: move |_| {
+                                        let bolt11 = invoice.read().as_ref().and_then(|inv| inv.bolt11.clone()).unwrap_or_default();
+                                        spawn(async move {
+                                            let _ = platform::open_lightning_invoice(&bolt11).await;
+                                        });
+                                    },
+                                    "Open Wallet"
+                                }
+                            }
+                            p { class: "text-xs text-muted-foreground", "Waiting for payment..." }
+                        }
+                    }
+                }
+                div { class: "mt-5",
+                    button {
+                        class: "rounded-lg border border-border px-4 py-2 text-sm transition hover:bg-accent",
+                        onclick: move |_| {
+                            navigator().push(Route::SettingsAi {});
+                        },
+                        "Open AI Settings"
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn ProviderSetupGate(provider_name: String) -> Element {
+    rsx! {
+        div { class: "flex min-h-[50vh] items-center justify-center p-6",
+            div { class: "max-w-md w-full rounded-2xl border border-border bg-card p-8 text-center shadow-sm",
+                div { class: "mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 text-primary",
+                    SparklesIcon { class: "w-7 h-7".to_string() }
+                }
+                h2 { class: "text-2xl font-semibold", "Configure {provider_name}" }
+                p { class: "mt-2 text-sm text-muted-foreground",
+                    "This provider needs configuration. Open AI settings to enter your API key."
+                }
+                div { class: "mt-5",
+                    button {
+                        class: "rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90",
+                        onclick: move |_| {
+                            navigator().push(Route::SettingsAi {});
+                        },
+                        "Open AI Settings"
                     }
                 }
             }

--- a/src/routes/blossom/blossom_home.rs
+++ b/src/routes/blossom/blossom_home.rs
@@ -768,7 +768,7 @@ fn UploadModal(on_close: EventHandler<()>, on_upload_complete: EventHandler<()>)
                     return;
                 };
                 input.set_type("file");
-                input.set_accept("image/*,video/*,audio/*");
+                input.set_accept("*/*");
                 input.set_attribute("style", "display: none").ok();
                 body.append_child(&input).ok();
                 let (tx, rx) = futures::channel::oneshot::channel::<Option<web_sys::File>>();
@@ -827,10 +827,8 @@ fn UploadModal(on_close: EventHandler<()>, on_upload_complete: EventHandler<()>)
             spawn(async move {
                 let result = if mime_type.starts_with("image/") {
                     blossom_store::upload_image(data, mime_type, q, None).await
-                } else if mime_type.starts_with("audio/") {
-                    blossom_store::upload_audio(data, mime_type, None).await
                 } else {
-                    blossom_store::upload_image(data, mime_type, 100, None).await
+                    blossom_store::upload_file(data, mime_type, None).await
                 };
                 match result {
                     Ok(url) => {
@@ -932,7 +930,7 @@ fn UploadModal(on_close: EventHandler<()>, on_upload_complete: EventHandler<()>)
                                 }
                             }
                         }
-                        if mime_type.starts_with("image/") {
+                        if blossom_store::is_image_compressible(mime_type) {
                             div {
                                 label { class: "block text-sm font-medium mb-2", "Quality: {quality()}%" }
                                 input {
@@ -969,7 +967,7 @@ fn UploadModal(on_close: EventHandler<()>, on_upload_complete: EventHandler<()>)
                                 }
                                 p { class: "font-medium", "Click to select a file" }
                                 p { class: "text-sm text-muted-foreground",
-                                    "Images, videos, or audio"
+                                    "Any file type"
                                 }
                             }
                         }

--- a/src/routes/code/code_repo_upload.rs
+++ b/src/routes/code/code_repo_upload.rs
@@ -147,12 +147,10 @@ pub fn CodeRepoUpload(naddr: String) -> Element {
 
             for (i, file) in files_to_upload.into_iter().enumerate() {
                 current_file_index.set(i);
-                let quality = 100u8; // quality=100 bypasses image compression, safe for all file types
                 let file_size = file.data.len();
-                match blossom_store::upload_image(
+                match blossom_store::upload_file(
                     file.data,
                     file.mime_type,
-                    quality,
                     Some(server_url.clone()),
                 )
                 .await

--- a/src/routes/events/calendar_event_new.rs
+++ b/src/routes/events/calendar_event_new.rs
@@ -914,6 +914,7 @@ pub fn CalendarEventNew(edit_naddr: Option<String>) -> Element {
                     div { class: "mb-4",
                         label { class: "block text-sm font-medium mb-2", "Cover Image" }
                         MediaUploader {
+                            accept: "image/*".to_string(),
                             on_upload: move |url: String| {
                                 image_url.set(url);
                             },

--- a/src/routes/mostro/create_order.rs
+++ b/src/routes/mostro/create_order.rs
@@ -22,6 +22,7 @@ use nostr::prelude::*;
 use nostr_relay_pool::relay::ReqExitPolicy;
 use nostr_relay_pool::SubscribeAutoCloseOptions;
 use std::time::Duration;
+use tokio::sync::broadcast::error::RecvError;
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum OrderKind {
@@ -262,6 +263,48 @@ pub fn MostroCreateOrder() -> Element {
                 }
             };
 
+            // Fix B: Build and upsert the placeholder trade BEFORE sending the
+            // message. This puts the trade pubkey into TRADES so the always-
+            // mounted `use_mostro_session` hook's reactive subscription
+            // includes it during the ACK wait — providing a fallback listener
+            // even if this function's own `listen_fut` fails (e.g., broadcast
+            // channel Lagged during feed backfill). The `upsert` function's
+            // placeholder→UUID migration (trade_index / my_trade_pubkey match)
+            // ensures a single record when the ACK later updates the order_id.
+            let fiat_display = if *is_range.read() {
+                format!(
+                    "{}-{}",
+                    range_min.read().clone(),
+                    range_max.read().clone()
+                )
+            } else {
+                fiat_amount.read().clone()
+            };
+            let placeholder_order_id = format!("maker-{trade_index_used}");
+            let payment_methods_vec: Vec<String> = pm
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            let mut placeholder_trade = Trade::new_pending(
+                placeholder_order_id.clone(),
+                String::new(),
+                String::new(),
+                TradeRole::Maker,
+                format!("{kind}"),
+                fiat_display.clone(),
+                fc.clone(),
+                if sats > 0 { Some(sats) } else { None },
+                prem as f64,
+                payment_methods_vec.clone(),
+                trade_index_opt,
+            );
+            placeholder_trade.my_trade_pubkey = Some(trade_pubkey_hex.clone());
+            placeholder_trade.expires_at = expires_at;
+            placeholder_trade.daemon_pubkey = node.pubkey.clone();
+            mostro::upsert_trade(placeholder_trade);
+            let _ = mostro::publish_trades().await;
+
             ensure_node_relays_connected().await;
 
             let client = match crate::stores::nostr_client::get_client() {
@@ -317,6 +360,8 @@ pub fn MostroCreateOrder() -> Element {
             .await
             {
                 let _ = client.unsubscribe(&sub_id).await;
+                mostro::remove_trade(&placeholder_order_id);
+                let _ = mostro::publish_trades().await;
                 error.set(Some(format!("Send failed: {e}")));
                 submitting.set(false);
                 return;
@@ -362,7 +407,13 @@ pub fn MostroCreateOrder() -> Element {
                             return Ok::<_, ()>(Some((action, unwrapped)));
                         }
                         Ok(_) => continue,
-                        Err(_) => return Ok::<_, ()>(None),
+                        Err(RecvError::Lagged(skipped)) => {
+                            log::warn!(
+                                "mostro create_order listener lagged, skipped {skipped} events, continuing"
+                            );
+                            continue;
+                        }
+                        Err(RecvError::Closed) => return Ok::<_, ()>(None),
                     }
                 }
             };
@@ -401,6 +452,10 @@ pub fn MostroCreateOrder() -> Element {
                                 } else {
                                     "Order rejected".to_string()
                                 };
+                            // Remove the pre-send placeholder trade since the
+                            // daemon rejected the order.
+                            mostro::remove_trade(&placeholder_order_id);
+                            let _ = mostro::publish_trades().await;
                             let toast = consume_toast();
                             toast.error(
                                 "Cannot proceed".to_string(),
@@ -457,20 +512,14 @@ pub fn MostroCreateOrder() -> Element {
                 }
             }
 
-            let fiat_display = if *is_range.read() {
-                format!(
-                    "{}-{}",
-                    range_min.read().clone(),
-                    range_max.read().clone()
-                )
-            } else {
-                fiat_amount.read().clone()
-            };
-
             let order_id_for_nav = real_order_id
                 .clone()
                 .unwrap_or_else(|| format!("maker-{trade_index_used}"));
 
+            // Upsert the trade with the real order_id (if ACK'd) or keep the
+            // placeholder. The upsert's placeholder→UUID migration via
+            // trade_index / my_trade_pubkey ensures the pre-send placeholder
+            // is replaced in-place rather than creating a duplicate record.
             let mut trade = Trade::new_pending(
                 order_id_for_nav.clone(),
                 String::new(),
@@ -478,17 +527,15 @@ pub fn MostroCreateOrder() -> Element {
                 TradeRole::Maker,
                 format!("{kind}"),
                 fiat_display,
-                fc,
+                fc.clone(),
                 if sats > 0 { Some(sats) } else { None },
                 prem as f64,
-                pm.split(',')
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect(),
+                payment_methods_vec,
                 trade_index_opt,
             );
             trade.my_trade_pubkey = Some(trade_pubkey_hex.clone());
             trade.expires_at = expires_at;
+            trade.daemon_pubkey = node.pubkey.clone();
             mostro::upsert_trade(trade);
             // Record in the durable creation ledger so this order is
             // recoverable even if the rich TRADES cache is later wiped.

--- a/src/routes/mostro/mostro_order_detail.rs
+++ b/src/routes/mostro/mostro_order_detail.rs
@@ -117,9 +117,16 @@ fn render_order_detail(order: &P2POrder, mut recovering: Signal<bool>) -> Elemen
     // Check if the current user owns this order (as maker or taker) via
     // the local TRADES cache or the durable creation_ledger.
     let owned_order_id = order.order_id.clone();
-    let is_owned = crate::stores::mostro::find_by_order_id(&owned_order_id).is_some()
-        || !crate::stores::mostro::creation_ledger::entries_for_order(&owned_order_id)
-            .is_empty();
+    let trade = crate::stores::mostro::find_by_order_id(&owned_order_id);
+    let ledger_entries = crate::stores::mostro::creation_ledger::entries_for_order(&owned_order_id);
+    let is_owned = trade.is_some() || !ledger_entries.is_empty();
+    // Determine if the user is the Maker specifically (for the label).
+    let is_maker = trade
+        .as_ref()
+        .is_some_and(|t| t.role == crate::stores::mostro::TradeRole::Maker)
+        || ledger_entries
+            .iter()
+            .any(|e| e.role == crate::stores::mostro::TradeRole::Maker);
     let sats_display = if order.amount_sats > 0 {
         format_sats_with_unit(order.amount_sats)
     } else if let Some(btc_price) = btc_price::get_btc_price(&order.currency) {
@@ -237,7 +244,7 @@ fn render_order_detail(order: &P2POrder, mut recovering: Signal<bool>) -> Elemen
                 rsx! {
                     div { class: "bg-primary/10 border border-primary/30 rounded-lg p-4 flex items-center justify-between",
                         p { class: "text-sm font-medium text-primary",
-                            "You own this order"
+                            { if is_maker { "You own this order" } else { "You have a trade on this order" } }
                         }
                         button {
                             class: "px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition",

--- a/src/routes/mostro/mostro_order_detail.rs
+++ b/src/routes/mostro/mostro_order_detail.rs
@@ -114,6 +114,12 @@ fn render_order_detail(order: &P2POrder, mut recovering: Signal<bool>) -> Elemen
     // Bound before the rsx so the recover button's 'static onclick can
     // capture an owned order_id (the borrowed `order` can't escape).
     let recover_oid = order.order_id.clone();
+    // Check if the current user owns this order (as maker or taker) via
+    // the local TRADES cache or the durable creation_ledger.
+    let owned_order_id = order.order_id.clone();
+    let is_owned = crate::stores::mostro::find_by_order_id(&owned_order_id).is_some()
+        || !crate::stores::mostro::creation_ledger::entries_for_order(&owned_order_id)
+            .is_empty();
     let sats_display = if order.amount_sats > 0 {
         format_sats_with_unit(order.amount_sats)
     } else if let Some(btc_price) = btc_price::get_btc_price(&order.currency) {
@@ -224,6 +230,26 @@ fn render_order_detail(order: &P2POrder, mut recovering: Signal<bool>) -> Elemen
                         p { class: "text-xs font-mono text-muted-foreground break-all", "{source}" }
                     }
                 }
+            }
+
+            if is_mostro && is_owned {
+                {let owned_oid = order.order_id.clone();
+                rsx! {
+                    div { class: "bg-primary/10 border border-primary/30 rounded-lg p-4 flex items-center justify-between",
+                        p { class: "text-sm font-medium text-primary",
+                            "You own this order"
+                        }
+                        button {
+                            class: "px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition",
+                            onclick: move |_| {
+                                let _ = navigator().push(Route::MostroTradeDetail {
+                                    order_id: owned_oid.clone(),
+                                });
+                            },
+                            "Open Trade →"
+                        }
+                    }
+                }}
             }
 
             if is_mostro && is_pending {

--- a/src/routes/mostro/my_trades.rs
+++ b/src/routes/mostro/my_trades.rs
@@ -6,6 +6,8 @@ use dioxus::prelude::*;
 
 #[component]
 pub fn MostroMyTrades() -> Element {
+    let heal_done = use_signal(|| false);
+
     // Reactive: `all_trades_for_daemon` reads the `TRADES` GlobalSignal, so
     // wrapping it in `use_memo` makes My Trades update live (new trade,
     // status change, recovery) without a manual reload. Previously this was
@@ -17,6 +19,72 @@ pub fn MostroMyTrades() -> Element {
         v
     };
     let has_trades = !sorted.is_empty();
+
+    // Self-heal: if My Trades is empty and we haven't attempted healing yet,
+    // try to recover trades from the NIP-78 blob, the creation ledger, and
+    // the daemon's RestoreSession. This catches the case where the local
+    // TRADES cache was wiped (orphan cleanup, fresh login, etc.) but the
+    // trades still exist on the daemon.
+    use_effect(move || {
+        if *heal_done.read() {
+            return;
+        }
+        if !*crate::stores::nostr_client::CLIENT_INITIALIZED.read() {
+            return;
+        }
+        if crate::stores::mostro::try_get().is_none() {
+            return;
+        }
+        if crate::stores::mostro::try_get_node_config().is_none() {
+            return;
+        }
+        if has_trades {
+            return;
+        }
+        let mut heal_done = heal_done;
+        heal_done.set(true);
+        spawn(async move {
+            log::info!("My Trades is empty — attempting self-heal");
+            // 1. Refresh from NIP-78 trades blob
+            let _ = trade_store::refresh_from_relays().await;
+            // 2. Recover individual orders from the creation ledger
+            let ledger = crate::stores::mostro::creation_ledger::CREATION_LEDGER.read().clone();
+            for entry in &ledger {
+                if trade_store::find_by_order_id(&entry.order_id).is_some() {
+                    continue;
+                }
+                if let Ok(uuid) = uuid::Uuid::parse_str(&entry.order_id) {
+                    log::info!(
+                        "My Trades self-heal: recovering order {} from daemon",
+                        entry.order_id
+                    );
+                    match crate::stores::mostro::recover_order_by_id(uuid).await {
+                        Ok(1) => {
+                            log::info!("My Trades self-heal: recovered {}", entry.order_id);
+                        }
+                        Ok(_) => {
+                            log::debug!(
+                                "My Trades self-heal: daemon has no record of {}",
+                                entry.order_id
+                            );
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "My Trades self-heal: failed to recover {}: {e}",
+                                entry.order_id
+                            );
+                        }
+                    }
+                }
+            }
+            // 3. RestoreSession for non-terminal gaps
+            if !crate::stores::mostro::is_restore_in_progress() {
+                if let Err(e) = crate::stores::mostro::request_restore().await {
+                    log::warn!("My Trades self-heal: restore failed: {e}");
+                }
+            }
+        });
+    });
 
     rsx! {
         div { class: "min-h-screen p-4 max-w-3xl mx-auto",

--- a/src/routes/mostro/trade_detail.rs
+++ b/src/routes/mostro/trade_detail.rs
@@ -44,6 +44,7 @@ pub fn MostroTradeDetail(order_id: String) -> Element {
     let mut action_busy = use_signal(|| false);
     let mut action_error = use_signal(|| Option::<String>::None);
     let countdown_tick = use_signal(|| 0u64);
+    let recovering = use_signal(|| false);
     let nav = navigator();
 
     let trade = trade_signal.read().clone();
@@ -154,55 +155,61 @@ pub fn MostroTradeDetail(order_id: String) -> Element {
                 }
                 let now = crate::platform::timestamp::now_secs();
                 if now >= deadline {
-                    let node_cfg = mostro::try_get_node_config();
-                    let node_pk_hex = node_cfg.as_ref().map(|c| c.pubkey.clone());
-                    let node_pow = node_cfg.as_ref().map(|c| c.pow).unwrap_or(0);
-                    let relay_urls = relays.clone();
-                    let order_id_for_remove = order_id_for_bf.clone();
-                    spawn(async move {
-                        if let Some(pk_hex) = node_pk_hex {
-                            if let Ok(npk_parsed) = nostr::PublicKey::from_hex(&pk_hex) {
-                                if let Some(required_pow) = mostro::client::fetch_daemon_pow(npk_parsed, &relay_urls).await {
-                                    if required_pow > node_pow {
-                                        let toast = consume_toast();
-                                        toast.error(
-                                            "PoW too low".to_string(),
-                                            ToastOptions::new()
-                                                .description(format!(
-                                                    "Daemon requires PoW of {required_pow}, we sent {node_pow}. Update daemon settings."
-                                                ))
-                                                .duration(Duration::from_secs(10)),
-                                        );
+                    let is_placeholder = current_trade
+                        .as_ref()
+                        .map(|t| t.is_placeholder())
+                        .unwrap_or(true);
+                    if is_placeholder {
+                        let node_cfg = mostro::try_get_node_config();
+                        let node_pk_hex = node_cfg.as_ref().map(|c| c.pubkey.clone());
+                        let node_pow = node_cfg.as_ref().map(|c| c.pow).unwrap_or(0);
+                        let relay_urls = relays.clone();
+                        let order_id_for_remove = order_id_for_bf.clone();
+                        spawn(async move {
+                            if let Some(pk_hex) = node_pk_hex {
+                                if let Ok(npk_parsed) = nostr::PublicKey::from_hex(&pk_hex) {
+                                    if let Some(required_pow) = mostro::client::fetch_daemon_pow(npk_parsed, &relay_urls).await {
+                                        if required_pow > node_pow {
+                                            let toast = consume_toast();
+                                            toast.error(
+                                                "PoW too low".to_string(),
+                                                ToastOptions::new()
+                                                    .description(format!(
+                                                        "Daemon requires PoW of {required_pow}, we sent {node_pow}. Update daemon settings."
+                                                    ))
+                                                    .duration(Duration::from_secs(10)),
+                                            );
+                                        }
                                     }
                                 }
                             }
-                        }
-                    });
+                        });
 
-                    // E4: 30s elapsed with no NewOrder ACK — treat the
-                    // trade as orphaned (matches mostro/mobile's 10s
-                    // cleanup timer pattern, with a longer threshold to
-                    // be polite to slow relays). Remove the local trade
-                    // record so it doesn't sit forever as a stuck
-                    // placeholder, then bounce the user back to the
-                    // order book. Without this, a confused user might
-                    // retry the take and double-increment their trade
-                    // index (the daemon would reject with `NotFound`,
-                    // but the local orphan persists).
-                    let toast = consume_toast();
-                    toast.error(
-                        "Trade did not confirm".to_string(),
-                        ToastOptions::new()
-                            .description(
-                                "The daemon did not acknowledge this trade within 30 seconds. \
-                                 It may have been rejected or the relays may be slow. \
-                                 Please try again.".to_string(),
-                            )
-                            .duration(Duration::from_secs(8)),
-                    );
-                    mostro::remove_trade(&order_id_for_remove);
-                    nav_for_bf.replace(Route::MostroHome {});
-                    return;
+                        let toast = consume_toast();
+                        toast.error(
+                            "Trade did not confirm".to_string(),
+                            ToastOptions::new()
+                                .description(
+                                    "The daemon did not acknowledge this trade within 30 seconds. \
+                                     It may have been rejected or the relays may be slow. \
+                                     Please try again.".to_string(),
+                                )
+                                .duration(Duration::from_secs(8)),
+                        );
+                        mostro::remove_trade(&order_id_for_remove);
+                        nav_for_bf.replace(Route::MostroHome {});
+                        return;
+                    } else {
+                        // Real-UUID Pending trade: stop aggressive polling but
+                        // keep the trade. The always-mounted use_mostro_session
+                        // hook and the periodic reconciler (every 300s) will
+                        // continue catching daemon events at a slower cadence.
+                        log::info!(
+                            "Trade {} still Pending after 30s with real UUID — transitioning to slow reconcile",
+                            order_id_for_bf
+                        );
+                        return;
+                    }
                 }
 
                 let client = match crate::stores::nostr_client::get_client() {
@@ -1734,20 +1741,84 @@ pub fn MostroTradeDetail(order_id: String) -> Element {
                             }}
                         }
                     } else {
-                        div { class: "p-8 text-center",
-                            div { class: "text-4xl mb-4", "?" }
-                            h3 { class: "text-lg font-medium mb-2", "Trade not found" }
-                            p { class: "text-muted-foreground mb-4",
-                                "No local record exists for this trade."
+                        {let mut recovering = recovering;
+                        let oid_recover = order_id.clone();
+                        rsx! {
+                            div { class: "p-8 text-center",
+                                div { class: "text-4xl mb-4", "?" }
+                                h3 { class: "text-lg font-medium mb-2", "Trade not found" }
+                                p { class: "text-muted-foreground mb-4",
+                                    "No local record exists for this trade."
+                                }
+                                div { class: "flex flex-col gap-2 items-center",
+                                    button {
+                                        class: "px-4 py-2 border border-border rounded-lg hover:bg-accent transition disabled:opacity-50 text-sm",
+                                        disabled: *recovering.read()
+                                            || crate::stores::mostro::is_restore_in_progress(),
+                                        title: "Fetch this order from the daemon and rebuild your local trade record",
+                                        onclick: move |_| {
+                                            let oid = oid_recover.clone();
+                                            let mut ts = trade_signal;
+                                            spawn(async move {
+                                                let uuid = match uuid::Uuid::parse_str(&oid) {
+                                                    Ok(u) => u,
+                                                    Err(_) => {
+                                                        let toast = consume_toast();
+                                                        toast.error(
+                                                            "Cannot recover".to_string(),
+                                                            ToastOptions::new()
+                                                                .description("Order id is not a valid UUID.")
+                                                                .duration(Duration::from_secs(4)),
+                                                        );
+                                                        return;
+                                                    }
+                                                };
+                                                recovering.set(true);
+                                                match mostro::recover_order_by_id(uuid).await {
+                                                    Ok(1) => {
+                                                        let toast = consume_toast();
+                                                        toast.success(
+                                                            "Order recovered".to_string(),
+                                                            ToastOptions::new()
+                                                                .description("Restored your trade record from the daemon.")
+                                                                .duration(Duration::from_secs(3)),
+                                                        );
+                                                        ts.set(mostro::find_by_order_id(&oid));
+                                                    }
+                                                    Ok(_) => {
+                                                        let toast = consume_toast();
+                                                        toast.error(
+                                                            "Not found".to_string(),
+                                                            ToastOptions::new()
+                                                                .description("The daemon has no record of you owning this order.")
+                                                                .duration(Duration::from_secs(5)),
+                                                        );
+                                                    }
+                                                    Err(e) => {
+                                                        let toast = consume_toast();
+                                                        toast.error(
+                                                            "Recovery failed".to_string(),
+                                                            ToastOptions::new()
+                                                                .description(e)
+                                                                .duration(Duration::from_secs(6)),
+                                                        );
+                                                    }
+                                                }
+                                                recovering.set(false);
+                                            });
+                                        },
+                                        { if *recovering.read() { "Recovering…" } else { "Recover from daemon" } }
+                                    }
+                                    button {
+                                        class: "px-4 py-2 bg-primary text-primary-foreground rounded-lg",
+                                        onclick: move |_| {
+                                            let _ = nav.push(Route::MostroHome {});
+                                        },
+                                        "Back to orders"
+                                    }
+                                }
                             }
-                            button {
-                                class: "px-4 py-2 bg-primary text-primary-foreground rounded-lg",
-                                onclick: move |_| {
-                                    let _ = nav.push(Route::MostroHome {});
-                                },
-                                "Back to orders"
-                            }
-                        }
+                        }}
                     }
                 }
             }

--- a/src/routes/music/artist.rs
+++ b/src/routes/music/artist.rs
@@ -263,7 +263,7 @@ fn NostrArtistSection(pubkey: String) -> Element {
         .unwrap_or_else(|| {
             format!(
                 "https://api.dicebear.com/7.x/identicon/svg?seed={}",
-                &pubkey
+                pubkey
             )
         });
     let artist_bio = profile.read().as_ref().and_then(|p| p.about.clone());

--- a/src/routes/music/music_search.rs
+++ b/src/routes/music/music_search.rs
@@ -461,7 +461,7 @@ fn NostrArtistCard(pubkey: String, profile: profiles::Profile) -> Element {
     let artist_image = profile.picture.clone().unwrap_or_else(|| {
         format!(
             "https://api.dicebear.com/7.x/identicon/svg?seed={}",
-            &pubkey
+            pubkey
         )
     });
     rsx! {

--- a/src/routes/music/track_new.rs
+++ b/src/routes/music/track_new.rs
@@ -1,3 +1,4 @@
+use crate::components::MediaUploader;
 use crate::routes::Route;
 use crate::stores::{auth_store, nostr_music};
 use crate::utils::slugify;
@@ -126,26 +127,34 @@ pub fn MusicTrackNew() -> Element {
                     }
                 }
                 div {
-                    label { class: "block text-sm font-medium mb-2", "Audio URL *" }
-                    input {
-                        r#type: "url",
-                        placeholder: "https://example.com/track.mp3",
-                        class: "w-full px-4 py-3 border border-border rounded-lg bg-background focus:outline-hidden focus:ring-2 focus:ring-primary",
-                        value: "{audio_url}",
-                        oninput: move |e| audio_url.set(e.value()),
+                    label { class: "block text-sm font-medium mb-2", "Audio File *" }
+                    MediaUploader {
+                        accept: "audio/*".to_string(),
+                        max_bytes: 100 * 1024 * 1024,
+                        button_label: "Upload Audio".to_string(),
+                        on_upload: move |url: String| audio_url.set(url),
                     }
-                    p { class: "text-xs text-muted-foreground mt-1",
-                        "Direct link to your audio file (MP3, WAV, etc.)"
+                    if !audio_url.read().is_empty() {
+                        p { class: "text-xs text-muted-foreground mt-1 truncate",
+                            "Uploaded: {audio_url}"
+                        }
+                    } else {
+                        p { class: "text-xs text-muted-foreground mt-1",
+                            "Upload an audio file (MP3, WAV, OGG, FLAC, etc.) to Blossom"
+                        }
                     }
                 }
                 div {
-                    label { class: "block text-sm font-medium mb-2", "Cover Image URL" }
-                    input {
-                        r#type: "url",
-                        placeholder: "https://example.com/cover.jpg",
-                        class: "w-full px-4 py-3 border border-border rounded-lg bg-background focus:outline-hidden focus:ring-2 focus:ring-primary",
-                        value: "{image_url}",
-                        oninput: move |e| image_url.set(e.value()),
+                    label { class: "block text-sm font-medium mb-2", "Cover Image" }
+                    MediaUploader {
+                        accept: "image/*".to_string(),
+                        button_label: "Upload Cover".to_string(),
+                        on_upload: move |url: String| image_url.set(url),
+                    }
+                    if !image_url.read().is_empty() {
+                        p { class: "text-xs text-muted-foreground mt-1 truncate",
+                            "Uploaded: {image_url}"
+                        }
                     }
                 }
                 div {

--- a/src/routes/photo_new.rs
+++ b/src/routes/photo_new.rs
@@ -145,7 +145,10 @@ pub fn PhotoNew() -> Element {
                             }
                         }
                         if *show_image_uploader.read() {
-                            MediaUploader { on_upload: handle_image_uploaded }
+                            MediaUploader {
+                                accept: "image/*".to_string(),
+                                on_upload: handle_image_uploaded
+                            }
                         }
                         if !*show_image_uploader.read() {
                             button {

--- a/src/routes/pin/pin_board_new.rs
+++ b/src/routes/pin/pin_board_new.rs
@@ -140,6 +140,7 @@ pub fn PinBoardNew() -> Element {
                                 }
                             }
                             MediaUploader {
+                                accept: "image/*".to_string(),
                                 on_upload: move |url: String| image_url.set(Some(url)),
                                 button_label: "Upload cover image".to_string(),
                             }
@@ -385,6 +386,7 @@ pub fn PinBoardEdit(naddr: String) -> Element {
                                 }
                             }
                             MediaUploader {
+                                accept: "image/*".to_string(),
                                 on_upload: move |url: String| image_url.set(Some(url)),
                                 button_label: "Upload cover image".to_string(),
                             }

--- a/src/routes/pin/pin_new.rs
+++ b/src/routes/pin/pin_new.rs
@@ -576,6 +576,7 @@ pub fn PinNew() -> Element {
                                 }
                             }
                             MediaUploader {
+                                accept: "image/*".to_string(),
                                 on_upload: move |url: String| custom_image_url.set(Some(url)),
                                 button_label: if custom_image_url.read().is_some() || fetched_metadata.read().image.is_some() { "Replace image".to_string() } else { "Upload image".to_string() },
                             }

--- a/src/routes/shop/shop_product_edit.rs
+++ b/src/routes/shop/shop_product_edit.rs
@@ -154,6 +154,7 @@ pub fn ShopProductEdit(naddr: String) -> Element {
                         div {
                             label { class: "block text-sm font-medium mb-2", "Product Images" }
                             MediaUploader {
+                                accept: "image/*".to_string(),
                                 on_upload: move |url: String| images.write().push(url),
                                 button_label: if images.read().is_empty() {
                                     "Upload image".to_string()

--- a/src/routes/shop/shop_product_new.rs
+++ b/src/routes/shop/shop_product_new.rs
@@ -117,6 +117,7 @@ pub fn ShopProductNew() -> Element {
                         div {
                             label { class: "block text-sm font-medium mb-2", "Product Images" }
                             MediaUploader {
+                                accept: "image/*".to_string(),
                                 on_upload: move |url: String| images.write().push(url),
                                 button_label: if images.read().is_empty() {
                                     "Upload image".to_string()

--- a/src/routes/video_new_landscape.rs
+++ b/src/routes/video_new_landscape.rs
@@ -131,7 +131,10 @@ pub fn VideoNewLandscape() -> Element {
                                 }
                             }
                         } else if *show_video_uploader.read() {
-                            MediaUploader { on_upload: handle_video_uploaded }
+                            MediaUploader {
+                                accept: "video/*".to_string(),
+                                on_upload: handle_video_uploaded
+                            }
                         }
                     }
                     div {
@@ -152,7 +155,10 @@ pub fn VideoNewLandscape() -> Element {
                                 }
                             }
                         } else if *show_thumbnail_uploader.read() {
-                            MediaUploader { on_upload: handle_thumbnail_uploaded }
+                            MediaUploader {
+                                accept: "image/*".to_string(),
+                                on_upload: handle_thumbnail_uploaded
+                            }
                         } else {
                             button {
                                 class: "px-4 py-2 bg-accent hover:bg-accent/80 text-foreground rounded-lg transition",

--- a/src/routes/video_new_portrait.rs
+++ b/src/routes/video_new_portrait.rs
@@ -133,7 +133,10 @@ pub fn VideoNewPortrait() -> Element {
                                 "Remove video"
                             }
                         } else if *show_video_uploader.read() {
-                            MediaUploader { on_upload: handle_video_uploaded }
+                            MediaUploader {
+                                accept: "video/*".to_string(),
+                                on_upload: handle_video_uploaded
+                            }
                         }
                         p { class: "mt-2 text-xs text-muted-foreground",
                             "Upload a vertical/portrait video (9:16 aspect ratio recommended)"
@@ -157,7 +160,10 @@ pub fn VideoNewPortrait() -> Element {
                                 "Remove thumbnail"
                             }
                         } else if *show_thumbnail_uploader.read() {
-                            MediaUploader { on_upload: handle_thumbnail_uploaded }
+                            MediaUploader {
+                                accept: "image/*".to_string(),
+                                on_upload: handle_thumbnail_uploaded
+                            }
                         } else {
                             button {
                                 class: "px-4 py-2 bg-accent hover:bg-accent/80 text-foreground rounded-lg transition",

--- a/src/services/ai_chat.rs
+++ b/src/services/ai_chat.rs
@@ -886,6 +886,26 @@ async fn send_provider_request(
                 .await
                 .map_err(|e| format!("Failed to send request: {}", e))
         }
+        ProviderAuth::Routstr { api_key } => {
+            let Some(api_key) = api_key
+                .as_deref()
+                .map(str::trim)
+                .filter(|key| !key.is_empty())
+            else {
+                return Err("Routstr account is not set up yet".to_string());
+            };
+            let mut request = client.request(method, url);
+            request = request.header("Authorization", format!("Bearer {api_key}"));
+            if let Some(body_bytes) = body {
+                request = request
+                    .header("Content-Type", "application/json")
+                    .body(body_bytes);
+            }
+            request
+                .send()
+                .await
+                .map_err(|e| format!("Failed to send request: {}", e))
+        }
         ProviderAuth::BearerToken(api_key) => {
             let mut request = client.request(method, url);
             request = request.header("Authorization", format!("Bearer {}", api_key));

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -17,6 +17,7 @@ pub use payments::btc_price;
 pub use payments::lnurl;
 pub use payments::mempool;
 pub mod ppq;
+pub mod routstr;
 
 #[cfg(all(feature = "web", feature = "desktop"))]
 compile_error!("Cannot enable both 'web' and 'desktop' features");

--- a/src/services/pages.rs
+++ b/src/services/pages.rs
@@ -94,7 +94,7 @@ pub async fn publish_pages_manifest(
             .clone()
             .or_else(|| Some(blossom_store::get_primary_server()));
 
-        match blossom_store::upload_image(bytes, content_type, 100u8, server).await {
+        match blossom_store::upload_file(bytes, content_type, server).await {
             Ok(_) => {}
             Err(e) => {
                 log::warn!("Failed to upload {}: {}", file_path, e);

--- a/src/services/routstr.rs
+++ b/src/services/routstr.rs
@@ -114,6 +114,12 @@ pub async fn topup_with_cashu(
 pub async fn create_key_from_cashu(cashu_token: &str) -> Result<String, String> {
     let base = format!("{}/balance/create", ROUTSTR_BASE_URL);
     let mut url = Url::parse(&base).map_err(|e| format!("Invalid Routstr URL: {}", e))?;
+    // NOTE: The Cashu token travels as a GET query parameter because the Routstr
+    // `/balance/create` endpoint is GET-only (@router.get in routstr-core's
+    // balance.py). The POST alternative (`/v1/wallet/create`) is an unimplemented
+    // TODO upstream. The token may appear in server/proxy access logs — this is
+    // an upstream API design constraint, not fixable client-side. Switch to POST
+    // when the upstream endpoint ships. (topup and refund already use POST.)
     url.query_pairs_mut()
         .append_pair("initial_balance_token", cashu_token);
     let url = url.to_string();

--- a/src/services/routstr.rs
+++ b/src/services/routstr.rs
@@ -1,0 +1,311 @@
+use crate::platform::http::http_client;
+use reqwest::{Method, Response};
+use serde_json::{json, Value};
+use url::Url;
+
+pub const ROUTSTR_BASE_URL: &str = "https://api.routstr.com/v1";
+const ROUTSTR_LIGHTNING_ROOT: &str = "https://api.routstr.com/lightning";
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RoutstrBalance {
+    pub balance_msats: Option<u64>,
+    pub total_spent_msats: Option<u64>,
+    pub total_requests: Option<u64>,
+    pub raw_json: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RoutstrLightningInvoice {
+    pub invoice_id: String,
+    pub bolt11: Option<String>,
+    pub amount_sats: Option<u64>,
+    pub expires_at: Option<u64>,
+    pub payment_hash: Option<String>,
+    pub raw_json: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RoutstrInvoiceStatus {
+    pub status: Option<String>,
+    pub api_key: Option<String>,
+    pub amount_sats: Option<u64>,
+    pub paid_at: Option<u64>,
+    pub raw_json: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RoutstrTopupResult {
+    pub msats: Option<u64>,
+    pub raw_json: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RoutstrRefundResult {
+    pub token: Option<String>,
+    pub sats: Option<u64>,
+    pub msats: Option<u64>,
+    pub raw_json: String,
+}
+
+pub async fn get_balance(api_key: &str) -> Result<RoutstrBalance, String> {
+    let url = format!("{}/balance/info", ROUTSTR_BASE_URL);
+    let headers = vec![("Authorization".to_string(), format!("Bearer {}", api_key))];
+    let value = send_request(Method::GET, &url, Some(headers), None).await?;
+    Ok(RoutstrBalance {
+        balance_msats: number_field(&value, &["balance"]).map(|n| n as u64),
+        total_spent_msats: number_field(&value, &["total_spent"]).map(|n| n as u64),
+        total_requests: number_field(&value, &["total_requests"]).map(|n| n as u64),
+        raw_json: pretty_json(&value),
+    })
+}
+
+pub async fn create_lightning_invoice(
+    amount_sats: u64,
+    purpose: &str,
+    api_key: Option<&str>,
+) -> Result<RoutstrLightningInvoice, String> {
+    let url = format!("{}/invoice", ROUTSTR_LIGHTNING_ROOT);
+    let mut headers = Vec::new();
+    if let Some(key) = api_key {
+        headers.push(("Authorization".to_string(), format!("Bearer {}", key)));
+    }
+    let body = json!({ "amount_sats": amount_sats, "purpose": purpose });
+    let value = send_request(Method::POST, &url, Some(headers), Some(body)).await?;
+    let invoice_id = string_field(&value, &["invoice_id"])
+        .ok_or_else(|| "Routstr invoice response missing invoice_id (<redacted response>)".to_string())?;
+    Ok(RoutstrLightningInvoice {
+        invoice_id,
+        bolt11: string_field(&value, &["bolt11", "payment_request"]),
+        amount_sats: number_field(&value, &["amount_sats"]).map(|n| n as u64),
+        expires_at: number_field(&value, &["expires_at"]).map(|n| n as u64),
+        payment_hash: string_field(&value, &["payment_hash"]),
+        raw_json: pretty_json(&value),
+    })
+}
+
+pub async fn get_lightning_invoice_status(
+    invoice_id: &str,
+) -> Result<RoutstrInvoiceStatus, String> {
+    let url = format!("{}/invoice/{}/status", ROUTSTR_LIGHTNING_ROOT, invoice_id);
+    let value = send_request(Method::GET, &url, None, None).await?;
+    Ok(RoutstrInvoiceStatus {
+        status: string_field(&value, &["status"]),
+        api_key: string_field(&value, &["api_key"]),
+        amount_sats: number_field(&value, &["amount_sats"]).map(|n| n as u64),
+        paid_at: number_field(&value, &["paid_at"]).map(|n| n as u64),
+        raw_json: pretty_json(&value),
+    })
+}
+
+pub async fn topup_with_cashu(
+    api_key: &str,
+    cashu_token: &str,
+) -> Result<RoutstrTopupResult, String> {
+    let url = format!("{}/balance/topup", ROUTSTR_BASE_URL);
+    let headers = vec![("Authorization".to_string(), format!("Bearer {}", api_key))];
+    let body = json!({ "cashu_token": cashu_token });
+    let value = send_request(Method::POST, &url, Some(headers), Some(body)).await?;
+    Ok(RoutstrTopupResult {
+        msats: number_field(&value, &["msats"]).map(|n| n as u64),
+        raw_json: pretty_json(&value),
+    })
+}
+
+pub async fn create_key_from_cashu(cashu_token: &str) -> Result<String, String> {
+    let base = format!("{}/balance/create", ROUTSTR_BASE_URL);
+    let mut url = Url::parse(&base).map_err(|e| format!("Invalid Routstr URL: {}", e))?;
+    url.query_pairs_mut()
+        .append_pair("initial_balance_token", cashu_token);
+    let url = url.to_string();
+    let value = send_request(Method::GET, &url, None, None).await?;
+    string_field(&value, &["api_key"])
+        .ok_or_else(|| "Routstr balance/create response missing api_key (<redacted response>)".to_string())
+}
+
+pub async fn refund(api_key: &str) -> Result<RoutstrRefundResult, String> {
+    let url = format!("{}/balance/refund", ROUTSTR_BASE_URL);
+    let headers = vec![("Authorization".to_string(), format!("Bearer {}", api_key))];
+    let value = send_request(Method::POST, &url, Some(headers), None).await?;
+    Ok(RoutstrRefundResult {
+        token: string_field(&value, &["token", "cashu_token"]),
+        sats: number_field(&value, &["sats"]).map(|n| n as u64),
+        msats: number_field(&value, &["msats"]).map(|n| n as u64),
+        raw_json: pretty_json(&value),
+    })
+}
+
+fn string_field(value: &Value, keys: &[&str]) -> Option<String> {
+    for key in keys {
+        if let Some(found) = value.get(*key) {
+            if let Some(as_str) = found.as_str() {
+                let trimmed = as_str.trim();
+                if !trimmed.is_empty() {
+                    return Some(trimmed.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn number_field(value: &Value, keys: &[&str]) -> Option<f64> {
+    for key in keys {
+        if let Some(found) = value.get(*key) {
+            if let Some(number) = found.as_f64() {
+                return Some(number);
+            }
+            if let Some(as_str) = found.as_str() {
+                if let Ok(number) = as_str.parse::<f64>() {
+                    return Some(number);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn pretty_json(value: &Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}
+
+async fn send_request(
+    method: Method,
+    url: &str,
+    headers: Option<Vec<(String, String)>>,
+    body: Option<Value>,
+) -> Result<Value, String> {
+    let client = http_client().map_err(|e| format!("HTTP client init failed: {}", e))?;
+    let mut request = client.request(method, url);
+    if let Some(headers) = headers {
+        for (name, value) in headers {
+            request = request.header(name, value);
+        }
+    }
+    if let Some(body) = body {
+        request = request
+            .header("Content-Type", "application/json")
+            .json(&body);
+    }
+
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("Failed to send Routstr request: {}", e))?;
+    parse_response(response).await
+}
+
+async fn parse_response(response: Response) -> Result<Value, String> {
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read Routstr response: {}", e))?;
+    if !status.is_success() {
+        return Err(format!(
+            "Routstr request failed ({}). {}",
+            status,
+            redacted_response_body(body.as_str())
+        ));
+    }
+    if body.trim().is_empty() {
+        return Ok(Value::Null);
+    }
+    serde_json::from_str(&body).map_err(|e| {
+        format!(
+            "Failed to parse Routstr response: {}. {}",
+            e,
+            redacted_response_body(body.as_str())
+        )
+    })
+}
+
+fn redacted_response_body(body: &str) -> String {
+    format!("Response body redacted ({} bytes).", body.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_balance_msats() {
+        let value: Value = serde_json::from_str(
+            r#"{"api_key":"sk-abc","balance":8500000,"reserved":0,"total_requests":42,"total_spent":1500000}"#,
+        ).unwrap();
+        let balance = RoutstrBalance {
+            balance_msats: number_field(&value, &["balance"]).map(|n| n as u64),
+            total_spent_msats: number_field(&value, &["total_spent"]).map(|n| n as u64),
+            total_requests: number_field(&value, &["total_requests"]).map(|n| n as u64),
+            raw_json: pretty_json(&value),
+        };
+        assert_eq!(balance.balance_msats, Some(8500000));
+        assert_eq!(balance.total_spent_msats, Some(1500000));
+        assert_eq!(balance.total_requests, Some(42));
+    }
+
+    #[test]
+    fn parses_invoice_status_with_api_key() {
+        let value: Value = serde_json::from_str(
+            r#"{"status":"paid","api_key":"sk-paid-key","amount_sats":1000,"paid_at":1750000500}"#,
+        ).unwrap();
+        let status = RoutstrInvoiceStatus {
+            status: string_field(&value, &["status"]),
+            api_key: string_field(&value, &["api_key"]),
+            amount_sats: number_field(&value, &["amount_sats"]).map(|n| n as u64),
+            paid_at: number_field(&value, &["paid_at"]).map(|n| n as u64),
+            raw_json: pretty_json(&value),
+        };
+        assert_eq!(status.status.as_deref(), Some("paid"));
+        assert_eq!(status.api_key.as_deref(), Some("sk-paid-key"));
+    }
+
+    #[test]
+    fn parses_invoice_status_pending() {
+        let value: Value = serde_json::from_str(
+            r#"{"status":"pending","api_key":null,"amount_sats":1000,"paid_at":null}"#,
+        ).unwrap();
+        let status = RoutstrInvoiceStatus {
+            status: string_field(&value, &["status"]),
+            api_key: string_field(&value, &["api_key"]),
+            amount_sats: number_field(&value, &["amount_sats"]).map(|n| n as u64),
+            paid_at: number_field(&value, &["paid_at"]).map(|n| n as u64),
+            raw_json: pretty_json(&value),
+        };
+        assert_eq!(status.status.as_deref(), Some("pending"));
+        assert!(status.api_key.is_none());
+    }
+
+    #[test]
+    fn parses_refund_with_string_sats() {
+        let value: Value = serde_json::from_str(
+            r#"{"token":"cashuAeyJ0b2tlbiI6...","sats":"1000"}"#,
+        ).unwrap();
+        let refund = RoutstrRefundResult {
+            token: string_field(&value, &["token", "cashu_token"]),
+            sats: number_field(&value, &["sats"]).map(|n| n as u64),
+            msats: number_field(&value, &["msats"]).map(|n| n as u64),
+            raw_json: pretty_json(&value),
+        };
+        assert_eq!(refund.token.as_deref(), Some("cashuAeyJ0b2tlbiI6..."));
+        assert_eq!(refund.sats, Some(1000));
+        assert!(refund.msats.is_none());
+    }
+
+    #[test]
+    fn parses_topup_result() {
+        let value: Value = serde_json::from_str(r#"{"msats":1000000}"#).unwrap();
+        let topup = RoutstrTopupResult {
+            msats: number_field(&value, &["msats"]).map(|n| n as u64),
+            raw_json: pretty_json(&value),
+        };
+        assert_eq!(topup.msats, Some(1000000));
+    }
+
+    #[test]
+    fn redacted_response_body_hides_content() {
+        let body = r#"{"api_key":"sk-secret-key-123","detail":"some error"}"#;
+        let redacted = redacted_response_body(body);
+        assert!(redacted.contains("bytes"));
+        assert!(!redacted.contains("sk-secret-key-123"));
+    }
+}

--- a/src/stores/auth_store.rs
+++ b/src/stores/auth_store.rs
@@ -1106,6 +1106,14 @@ async fn warmup_profiles_from_db(pk: PublicKey) {
                     );
                     crate::stores::profiles::bump_cache_version();
                 }
+                // Pre-populate CONTACTS_CACHE so is_following is instant on
+                // the first profile view. Without this, the first
+                // fetch_contacts for the current user blocks up to 5s.
+                let contact_pubkeys: Vec<String> = db_contacts
+                    .iter()
+                    .map(|p| p.public_key().to_hex())
+                    .collect();
+                nostr_client::warm_contacts_cache(&pk.to_hex(), contact_pubkeys);
             }
         }
         Err(e) => {

--- a/src/stores/content/recipe_store.rs
+++ b/src/stores/content/recipe_store.rs
@@ -534,8 +534,8 @@ pub async fn publish_recipe(
         Tag::title(title),
         Tag::hashtag(RECIPE_TAG_PREFIX),
         Tag::hashtag(RECIPE_TAG_PREFIX_ALT),
-        Tag::hashtag(format!("{}-{}", RECIPE_TAG_PREFIX, &slug)),
-        Tag::hashtag(format!("{}-{}", RECIPE_TAG_PREFIX_ALT, &slug)),
+        Tag::hashtag(format!("{}-{}", RECIPE_TAG_PREFIX, slug)),
+        Tag::hashtag(format!("{}-{}", RECIPE_TAG_PREFIX_ALT, slug)),
         Tag::custom(
             TagKind::Custom("published_at".into()),
             vec![Timestamp::now().as_secs().to_string()],
@@ -594,8 +594,8 @@ pub async fn fork_recipe(
         Tag::title(new_title),
         Tag::hashtag(RECIPE_TAG_PREFIX),
         Tag::hashtag(RECIPE_TAG_PREFIX_ALT),
-        Tag::hashtag(format!("{}-{}", RECIPE_TAG_PREFIX, &slug)),
-        Tag::hashtag(format!("{}-{}", RECIPE_TAG_PREFIX_ALT, &slug)),
+        Tag::hashtag(format!("{}-{}", RECIPE_TAG_PREFIX, slug)),
+        Tag::hashtag(format!("{}-{}", RECIPE_TAG_PREFIX_ALT, slug)),
         Tag::custom(
             TagKind::Custom("published_at".into()),
             vec![Timestamp::now().as_secs().to_string()],

--- a/src/stores/media/blossom_store.rs
+++ b/src/stores/media/blossom_store.rs
@@ -284,16 +284,31 @@ pub fn set_as_preferred(url: &str) {
         log::warn!("Available servers: {:?}", *servers);
     }
 }
-/// Upload media (image or video) to Blossom with optional compression
+/// Upload an image to Blossom with optional compression.
+///
+/// Compression is only applied for formats the `image` crate can decode and
+/// re-encode (PNG/JPEG) when `quality < 100`. Any other image format (webp,
+/// avif, gif, heic) is uploaded untouched so the bytes match the declared MIME
+/// type. For non-image files (video, audio, documents) prefer `upload_file()`.
 ///
 /// # Arguments
-/// * `data` - Raw media bytes
-/// * `content_type` - MIME type (e.g., "image/png", "image/jpeg", "video/mp4")
-/// * `quality` - Compression quality (0-100). 100 = original, no compression. Only applies to images.
+/// * `data` - Raw image bytes
+/// * `content_type` - MIME type (e.g., "image/png", "image/jpeg")
+/// * `quality` - Compression quality (0-100). 100 = original, no compression.
+///   Ignored for formats that are not PNG/JPEG.
 /// * `server_url` - Optional server URL to upload to (uses primary server if None)
 ///
 /// # Returns
-/// URL of the uploaded media
+/// URL of the uploaded image
+/// True only for formats the `image` crate can decode AND re-encode given the
+/// current Cargo features (png + jpeg). webp/avif/gif/heic/video/other -> false.
+/// Used both internally (to gate compression) and by the UI (to show/hide the
+/// quality slider).
+pub fn is_image_compressible(content_type: &str) -> bool {
+    let ct = content_type.to_lowercase();
+    ct.contains("png") || ct.contains("jpeg") || ct.contains("jpg")
+}
+
 pub async fn upload_image(
     data: Vec<u8>,
     content_type: String,
@@ -302,40 +317,33 @@ pub async fn upload_image(
 ) -> Result<String, String> {
     let gen = next_upload_gen();
     let mut progress_guard = UploadProgressGuard::new(gen);
-    let is_video = content_type.starts_with("video/");
-    let media_type = if is_video { "video" } else { "image" };
-    let quality_str = if is_video {
-        String::new()
-    } else {
-        format!(", quality: {}%", quality)
-    };
-    log::info!(
-        "Uploading {}: {} bytes{}",
-        media_type,
-        data.len(),
-        quality_str
-    );
+    log::info!("Uploading image: {} bytes, type: {}", data.len(), content_type);
     set_progress_if_gen_matches(gen, Some(0.0));
     if nostr_client::get_signer().is_none() {
         return Err("Not authenticated. Please sign in to upload media.".to_string());
     }
-    let final_data = if !is_video && quality < 100 {
+    // Only compress formats we can actually decode/re-encode (png/jpeg). Any other
+    // image format (webp/avif/gif/heic) or any non-image is uploaded untouched so
+    // the bytes always match the declared MIME type.
+    let final_data = if quality < 100 && is_image_compressible(&content_type) {
         log::info!("Compressing image to {}% quality", quality);
         set_progress_if_gen_matches(gen, Some(25.0));
         compress_image(data, content_type.clone(), quality).await?
     } else {
-        if is_video {
-            log::info!("Skipping compression for video file");
-            set_progress_if_gen_matches(gen, Some(25.0));
-        }
+        log::info!(
+            "Skipping compression for {} at quality {}",
+            content_type,
+            quality
+        );
+        set_progress_if_gen_matches(gen, Some(25.0));
         data
     };
-    log::info!("Final {} size: {} bytes", media_type, final_data.len());
+    log::info!("Final image size: {} bytes", final_data.len());
     set_progress_if_gen_matches(gen, Some(50.0));
     let result = upload_blob_with_auth(
         final_data,
         content_type,
-        format!("Upload {} via nostr.blue", media_type),
+        "Upload image via nostr.blue".to_string(),
         50.0,
         server_url,
         gen,
@@ -489,6 +497,47 @@ pub async fn upload_audio(
         data,
         content_type,
         "Upload voice message via nostr.blue".to_string(),
+        25.0,
+        server_url,
+        gen,
+    )
+    .await;
+    if result.is_ok() {
+        progress_guard.disarm();
+    }
+    result
+}
+
+/// Upload any file to Blossom (no compression, no type-specific processing).
+///
+/// Use this for PDFs, documents, archives, videos, and any non-image file type.
+/// For images that may benefit from compression, use `upload_image()` instead.
+/// For audio, `upload_audio()` is equivalent but semantically clearer.
+///
+/// # Arguments
+/// * `data` - Raw file bytes
+/// * `content_type` - MIME type (e.g., "application/pdf", "video/mp4", "application/zip")
+/// * `server_url` - Optional server URL (uses primary server if None)
+///
+/// # Returns
+/// URL of the uploaded file
+pub async fn upload_file(
+    data: Vec<u8>,
+    content_type: String,
+    server_url: Option<String>,
+) -> Result<String, String> {
+    let gen = next_upload_gen();
+    let mut progress_guard = UploadProgressGuard::new(gen);
+    log::info!(
+        "Uploading file: {} bytes, type: {}",
+        data.len(),
+        content_type
+    );
+    set_progress_if_gen_matches(gen, Some(0.0));
+    let result = upload_blob_with_auth(
+        data,
+        content_type,
+        "Upload file via nostr.blue".to_string(),
         25.0,
         server_url,
         gen,

--- a/src/stores/media/blossom_store.rs
+++ b/src/stores/media/blossom_store.rs
@@ -284,6 +284,15 @@ pub fn set_as_preferred(url: &str) {
         log::warn!("Available servers: {:?}", *servers);
     }
 }
+/// True only for formats the `image` crate can decode AND re-encode given the
+/// current Cargo features (png + jpeg). webp/avif/gif/heic/video/other -> false.
+/// Used both internally (to gate compression) and by the UI (to show/hide the
+/// quality slider).
+pub fn is_image_compressible(content_type: &str) -> bool {
+    let ct = content_type.to_lowercase();
+    ct.contains("png") || ct.contains("jpeg") || ct.contains("jpg")
+}
+
 /// Upload an image to Blossom with optional compression.
 ///
 /// Compression is only applied for formats the `image` crate can decode and
@@ -300,15 +309,6 @@ pub fn set_as_preferred(url: &str) {
 ///
 /// # Returns
 /// URL of the uploaded image
-/// True only for formats the `image` crate can decode AND re-encode given the
-/// current Cargo features (png + jpeg). webp/avif/gif/heic/video/other -> false.
-/// Used both internally (to gate compression) and by the UI (to show/hide the
-/// quality slider).
-pub fn is_image_compressible(content_type: &str) -> bool {
-    let ct = content_type.to_lowercase();
-    ct.contains("png") || ct.contains("jpeg") || ct.contains("jpg")
-}
-
 pub async fn upload_image(
     data: Vec<u8>,
     content_type: String,

--- a/src/stores/mostro/cleanup.rs
+++ b/src/stores/mostro/cleanup.rs
@@ -33,6 +33,7 @@
 
 use crate::platform::timestamp;
 use crate::stores::mostro::trade_store::{self, CancelInitiator, TradeRole, TradeStatus};
+use crate::stores::mostro::creation_ledger;
 
 /// Default terminal-trade age limit (30 days). Phase 7.5: overridden at
 /// runtime by `MostroSettings::trade_history_expiration_days` (see
@@ -56,9 +57,9 @@ fn effective_max_age_secs() -> u64 {
 }
 
 /// A Pending trade with no daemon reply older than this is an orphan.
-const ORPHAN_THRESHOLD_SECS: i64 = 120;
+const ORPHAN_THRESHOLD_SECS: i64 = 600;
 /// Extended threshold when the daemon started the bond flow.
-const ORPHAN_BOND_GRACE_SECS: i64 = 180;
+const ORPHAN_BOND_GRACE_SECS: i64 = 900;
 /// Orphan-cleanup loop tick interval.
 const ORPHAN_INTERVAL_SECS: u64 = 30;
 
@@ -195,7 +196,7 @@ fn cleanup_expired() -> usize {
 }
 
 /// Predicate: is this trade an orphan that should be cleaned up?
-fn is_orphan(trade: &trade_store::Trade, now: i64) -> bool {
+fn is_orphan(trade: &trade_store::Trade, now: i64, in_ledger: bool) -> bool {
     // Only Pending trades can be orphans.
     if trade.status != TradeStatus::Pending {
         return false;
@@ -206,6 +207,12 @@ fn is_orphan(trade: &trade_store::Trade, now: i64) -> bool {
     if trade.updated_at > trade.created_at {
         return false;
     }
+    // Durable ledger exemption: trades recorded in the creation ledger were
+    // intentionally created by the user. They survive the orphan sweep so
+    // they can be recovered via `recover_order_by_id` or `request_restore`.
+    if in_ledger {
+        return false;
+    }
     // Maker listings with a real UUID order_id are legitimate open listings.
     // Maker trades with a placeholder `maker-{N}` id were never ACKed by
     // the daemon and ARE eligible for cleanup.
@@ -213,10 +220,9 @@ fn is_orphan(trade: &trade_store::Trade, now: i64) -> bool {
         return false;
     }
     // Defense-in-depth: if the order is demonstrably still live on the
-    // public P2P board (Pending), don't orphan it — the daemon clearly has
-    // it and a missed reply (now caught by the global session listener) is
-    // the only reason `updated_at` hasn't advanced. Protects both maker
-    // listings and pending taker records for range-order slices.
+    // public P2P board (any non-terminal status), don't orphan it — the
+    // daemon clearly has it and a missed reply (now caught by the global
+    // session listener) is the only reason `updated_at` hasn't advanced.
     if is_live_on_board(&trade.order_id) {
         return false;
     }
@@ -228,17 +234,25 @@ fn is_orphan(trade: &trade_store::Trade, now: i64) -> bool {
     (now - trade.created_at) >= threshold
 }
 
-/// True if `order_id` matches an active (still-takeable, `Pending`) order on
-/// the public P2P board. Only real UUIDs are published to the board
-/// (placeholders like `maker-{N}` aren't until ACK'd), so non-UUID ids
-/// short-circuit to false.
+/// True if `order_id` matches an order on the public P2P board that is in a
+/// non-terminal state (Pending, InProgress — NOT Canceled/Success/Expired).
+/// Only real UUIDs are published to the board (placeholders like `maker-{N}`
+/// aren't until ACK'd), so non-UUID ids short-circuit to false.
 fn is_live_on_board(order_id: &str) -> bool {
     if uuid::Uuid::parse_str(order_id).is_err() {
         return false;
     }
     crate::stores::social::p2p_store::get_all_cached_orders()
         .iter()
-        .any(|o| o.order_id == order_id && o.is_active())
+        .any(|o| {
+            o.order_id == order_id
+                && !matches!(
+                    o.status,
+                    crate::utils::nip69::OrderStatus::Canceled
+                        | crate::utils::nip69::OrderStatus::Success
+                        | crate::utils::nip69::OrderStatus::Expired
+                )
+        })
 }
 
 /// Returns true if `id` is a `maker-{N}` placeholder assigned locally
@@ -250,9 +264,13 @@ fn is_placeholder_maker_id(id: &str) -> bool {
 fn cleanup_orphans() -> usize {
     let now = timestamp::now_secs() as i64;
     let trades = trade_store::TRADES();
+    let ledger_ids: std::collections::HashSet<String> = creation_ledger::CREATION_LEDGER()
+        .iter()
+        .map(|e| e.order_id.clone())
+        .collect();
     let orphan_ids: Vec<String> = trades
         .iter()
-        .filter(|t| is_orphan(t, now))
+        .filter(|t| is_orphan(t, now, ledger_ids.contains(&t.order_id)))
         .map(|t| t.order_id.clone())
         .collect();
 
@@ -311,21 +329,21 @@ mod tests {
 
     #[test]
     fn test_orphan_taker_old_no_reply() {
-        let t = build_trade(TradeStatus::Pending, TradeRole::Taker, 150, false);
-        assert!(is_orphan(&t, NOW), "old Pending taker with no reply is orphan");
+        let t = build_trade(TradeStatus::Pending, TradeRole::Taker, 650, false);
+        assert!(is_orphan(&t, NOW, false), "old Pending taker with no reply is orphan");
     }
 
     #[test]
     fn test_not_orphan_taker_young() {
         let t = build_trade(TradeStatus::Pending, TradeRole::Taker, 30, false);
-        assert!(!is_orphan(&t, NOW), "young Pending trade is not orphan");
+        assert!(!is_orphan(&t, NOW, false), "young Pending trade is not orphan");
     }
 
     #[test]
     fn test_not_orphan_daemon_replied() {
         let t = build_trade(TradeStatus::Pending, TradeRole::Taker, 200, true);
         assert!(
-            !is_orphan(&t, NOW),
+            !is_orphan(&t, NOW, false),
             "trade whose updated_at advanced is not orphan"
         );
     }
@@ -335,15 +353,15 @@ mod tests {
         let mut t = build_trade(TradeStatus::Pending, TradeRole::Maker, 600, false);
         // Real UUID order id → legitimate open listing
         t.order_id = "550e8400-e29b-41d4-a716-446655440000".to_string();
-        assert!(!is_orphan(&t, NOW), "maker listing with real UUID is not orphan");
+        assert!(!is_orphan(&t, NOW, false), "maker listing with real UUID is not orphan");
     }
 
     #[test]
     fn test_orphan_maker_with_placeholder_id() {
-        let mut t = build_trade(TradeStatus::Pending, TradeRole::Maker, 200, false);
+        let mut t = build_trade(TradeStatus::Pending, TradeRole::Maker, 650, false);
         t.order_id = "maker-5".to_string();
         assert!(
-            is_orphan(&t, NOW),
+            is_orphan(&t, NOW, false),
             "maker with placeholder id and no reply is orphan"
         );
     }
@@ -352,7 +370,7 @@ mod tests {
     fn test_not_orphan_maker_placeholder_young() {
         let mut t = build_trade(TradeStatus::Pending, TradeRole::Maker, 30, false);
         t.order_id = "maker-5".to_string();
-        assert!(!is_orphan(&t, NOW), "young placeholder maker is not orphan");
+        assert!(!is_orphan(&t, NOW, false), "young placeholder maker is not orphan");
     }
 
     #[test]
@@ -360,17 +378,17 @@ mod tests {
         let mut t = build_trade(TradeStatus::Pending, TradeRole::Taker, 150, false);
         t.is_bond_invoice = Some(true);
         assert!(
-            !is_orphan(&t, NOW),
+            !is_orphan(&t, NOW, false),
             "bond-flow trade within grace window is not orphan"
         );
     }
 
     #[test]
     fn test_orphan_past_bond_grace_is_removed() {
-        let mut t = build_trade(TradeStatus::Pending, TradeRole::Taker, 250, false);
+        let mut t = build_trade(TradeStatus::Pending, TradeRole::Taker, 950, false);
         t.is_bond_invoice = Some(true);
         assert!(
-            is_orphan(&t, NOW),
+            is_orphan(&t, NOW, false),
             "bond-flow trade past grace window is orphan"
         );
     }
@@ -378,7 +396,7 @@ mod tests {
     #[test]
     fn test_not_orphan_when_status_advanced() {
         let t = build_trade(TradeStatus::Active, TradeRole::Taker, 9999, false);
-        assert!(!is_orphan(&t, NOW), "non-Pending trade is never orphan");
+        assert!(!is_orphan(&t, NOW, false), "non-Pending trade is never orphan");
     }
 
     #[test]

--- a/src/stores/mostro/cleanup.rs
+++ b/src/stores/mostro/cleanup.rs
@@ -21,7 +21,7 @@
 //! - Status is `Pending` (no transition has ever been observed).
 //! - `updated_at == created_at` (no daemon message has ever advanced it).
 //! - Enough time has elapsed that the daemon would definitely have
-//!   replied if it received the message (default 120s).
+//!   replied if it received the message (default 600s).
 //!
 //! Maker listings with a real UUID `order_id` are exempt — they're
 //! legitimate open listings that may sit Pending for hours or days.
@@ -29,7 +29,7 @@
 //! ACKed the NewOrder) ARE eligible for orphan cleanup.
 //!
 //! Trades with `is_bond_invoice == Some(true)` get an extended grace
-//! window (default 180s) to allow trailing `BondSlashed` notices.
+//! window (default 900s) to allow trailing `BondSlashed` notices.
 
 use crate::platform::timestamp;
 use crate::stores::mostro::trade_store::{self, CancelInitiator, TradeRole, TradeStatus};
@@ -375,7 +375,7 @@ mod tests {
 
     #[test]
     fn test_orphan_within_bond_grace_is_kept() {
-        let mut t = build_trade(TradeStatus::Pending, TradeRole::Taker, 150, false);
+        let mut t = build_trade(TradeStatus::Pending, TradeRole::Taker, 650, false);
         t.is_bond_invoice = Some(true);
         assert!(
             !is_orphan(&t, NOW, false),

--- a/src/stores/mostro/client.rs
+++ b/src/stores/mostro/client.rs
@@ -562,6 +562,12 @@ pub async fn resolve_effective_pow(
     if node.pow > 0 {
         return node.pow;
     }
+    // Slow path: PoW is unknown (cold start). Ensure daemon relays are in
+    // the pool and connected before fetching the kind-38385 info event.
+    // Without this, callers like `request_restore_inner` that don't
+    // explicitly call `ensure_node_relays_connected` will fail silently —
+    // `fetch_events_from` returns `RelayNotFound` for relays not in the pool.
+    ensure_node_relays_connected().await;
     match fetch_daemon_pow(node_pk, &node.relays).await {
         Some(fetched) if fetched > 0 => {
             if let Some(mut cfg) = super::node_config::try_get() {
@@ -717,10 +723,32 @@ pub fn apply_mostro_action(
             }
         }
         A::AddInvoice => {
-            if let P::PaymentRequest(_, bolt11, _) = kind {
-                trade.pending_hold_invoice = Some(bolt11.clone());
+            match kind {
+                P::Order(small_order) => {
+                    // Daemon sends Order payload (both initial take-sell flow
+                    // and post-payment-retry-exhaustion). Extract the sats
+                    // amount so the buyer knows how much to invoice.
+                    if small_order.amount > 0 {
+                        trade.sats_amount = Some(small_order.amount);
+                    }
+                    // When the trade is at PaymentFailed (retries exhausted),
+                    // keep it there for UI consistency — the TradeActionPanel
+                    // already shows an invoice input at PaymentFailed status.
+                    // Returning None skips the monotonicity guard entirely,
+                    // preserving the sats_amount mutation without rollback.
+                    if trade.status == S::PaymentFailed {
+                        None
+                    } else {
+                        Some(S::WaitingBuyerInvoice)
+                    }
+                }
+                P::PaymentRequest(_, bolt11, _) => {
+                    trade.pending_hold_invoice = Some(bolt11.clone());
+                    Some(S::WaitingBuyerInvoice)
+                }
+                _ if trade.status == S::PaymentFailed => None,
+                _ => Some(S::WaitingBuyerInvoice),
             }
-            Some(S::WaitingBuyerInvoice)
         }
         // `BuyerInvoiceAccepted` is a pure acknowledgment from the daemon
         // that the buyer's payout invoice was accepted. It is currently
@@ -746,7 +774,10 @@ pub fn apply_mostro_action(
                 trade.pending_hold_invoice = Some(bolt11.clone());
             }
             trade.is_bond_invoice = Some(true);
-            Some(S::WaitingTakerBond)
+            match trade.role {
+                super::trade_store::TradeRole::Maker => Some(S::WaitingMakerBond),
+                super::trade_store::TradeRole::Taker => Some(S::WaitingTakerBond),
+            }
         }
         A::WaitingSellerToPay => Some(S::WaitingSellerToPay),
         A::WaitingBuyerInvoice => Some(S::WaitingBuyerInvoice),

--- a/src/stores/mostro/node_config.rs
+++ b/src/stores/mostro/node_config.rs
@@ -270,8 +270,11 @@ impl MostroNodeInfo {
                 info.hold_invoice_cltv_delta = val.parse().ok();
             } else if kind == TagKind::Custom(std::borrow::Cow::Borrowed("invoice_expiration_window")) {
                 info.invoice_expiration_window = val.parse().ok();
-            } else if kind == TagKind::Custom(std::borrow::Cow::Borrowed("lnd_uris")) {
-                // Phase 6.1 (M13): spec-conformant field.
+            } else if kind == TagKind::Custom(std::borrow::Cow::Borrowed("lnd_uris"))
+                || kind == TagKind::Custom(std::borrow::Cow::Borrowed("lnd_node_uri"))
+            {
+                // Phase 6.1 (M13): spec-conformant field (`lnd_uris`).
+                // Backward-compat: also parse legacy `lnd_node_uri` tag name.
                 info.lnd_uris = Some(val);
             } else if kind == TagKind::Custom(std::borrow::Cow::Borrowed("lnd_node_alias")) {
                 info.lnd_node_alias = Some(val);

--- a/src/stores/mostro/node_config.rs
+++ b/src/stores/mostro/node_config.rs
@@ -139,7 +139,7 @@ fn default_protocol_version() -> u8 {
 /// Parsed daemon capabilities from a kind 38385 info event.
 ///
 /// Phase 6.1 (M13): added `bond_apply_to`, `bond_slash_on_waiting_timeout`,
-/// `bond_slash_node_share_pct`, `lnd_node_uri` (spec-conformant — replaces
+/// `bond_slash_node_share_pct`, `lnd_uris` (daemon-published tag name),
 /// the non-spec `lnd_node_alias`/`lnd_node_pubkey` which are kept for
 /// backward compat).
 #[allow(dead_code)]
@@ -180,7 +180,7 @@ pub struct MostroNodeInfo {
     pub pow_first_contact: Option<u8>,
     /// Phase 6.1 (M13): spec-conformant LND node URI (comma-joined pubkeys
     /// or URIs). Replaces the non-spec `lnd_node_alias`/`lnd_node_pubkey`.
-    pub lnd_node_uri: Option<String>,
+    pub lnd_uris: Option<String>,
     /// Legacy non-spec field kept for backward compat with older daemons.
     pub lnd_node_alias: Option<String>,
     /// Legacy non-spec field kept for backward compat with older daemons.
@@ -270,9 +270,9 @@ impl MostroNodeInfo {
                 info.hold_invoice_cltv_delta = val.parse().ok();
             } else if kind == TagKind::Custom(std::borrow::Cow::Borrowed("invoice_expiration_window")) {
                 info.invoice_expiration_window = val.parse().ok();
-            } else if kind == TagKind::Custom(std::borrow::Cow::Borrowed("lnd_node_uri")) {
+            } else if kind == TagKind::Custom(std::borrow::Cow::Borrowed("lnd_uris")) {
                 // Phase 6.1 (M13): spec-conformant field.
-                info.lnd_node_uri = Some(val);
+                info.lnd_uris = Some(val);
             } else if kind == TagKind::Custom(std::borrow::Cow::Borrowed("lnd_node_alias")) {
                 info.lnd_node_alias = Some(val);
             } else if kind == TagKind::Custom(std::borrow::Cow::Borrowed("lnd_node_pubkey")) {

--- a/src/stores/mostro/restore.rs
+++ b/src/stores/mostro/restore.rs
@@ -22,6 +22,7 @@ use nostr_relay_pool::relay::ReqExitPolicy;
 use nostr_relay_pool::SubscribeAutoCloseOptions;
 use serde::{Deserialize, Serialize};
 use std::result::Result;
+use tokio::sync::broadcast::error::RecvError;
 
 use super::client::{resolve_effective_pow, send_mostro_message, unwrap_mostro_response};
 use super::flow;
@@ -1159,7 +1160,13 @@ pub async fn recover_order_by_id(order_id: uuid::Uuid) -> Result<usize, String> 
                     return Some(unwrapped);
                 }
                 Ok(_) => continue,
-                Err(_) => return None,
+                Err(RecvError::Lagged(skipped)) => {
+                    log::warn!(
+                        "recover_order_by_id listener lagged, skipped {skipped} events, continuing"
+                    );
+                    continue;
+                }
+                Err(RecvError::Closed) => return None,
             }
         }
     };

--- a/src/stores/mostro/take.rs
+++ b/src/stores/mostro/take.rs
@@ -203,7 +203,7 @@ pub async fn take_order(req: TakeRequest) -> Result<TakeResult, String> {
                 &k,
                 order_uuid,
                 k.trade_index.saturating_sub(1),
-                sats_from_override,
+                range_fiat_amount,
             );
             (m, Action::TakeBuy)
         }

--- a/src/stores/nostr_client/contacts.rs
+++ b/src/stores/nostr_client/contacts.rs
@@ -132,6 +132,7 @@ async fn fetch_enriched_contacts_from_relay_with_gen(
 ) -> std::result::Result<Vec<EnrichedContact>, String> {
     fetch_enriched_contacts_from_relay_impl(pubkey_str, Some(start_gen)).await
 }
+
 /// Internal implementation with optional generation check
 async fn fetch_enriched_contacts_from_relay_impl(
     pubkey_str: String,
@@ -155,103 +156,101 @@ async fn fetch_enriched_contacts_from_relay_impl(
         .author(pubkey)
         .kind(Kind::ContactList)
         .limit(1);
-    match fetch_events_aggregated(filter, CONTACTS_FETCH_TIMEOUT).await {
-        Ok(events) => {
-            if let Some(event) = events.into_iter().max_by_key(|e| e.created_at) {
-                if let Err(e) = event.verify() {
-                    log::warn!("Contact list event failed verification: {}", e);
-                    return Err(format!("Invalid contact list event: {}", e));
+
+    let event: Option<nostr::Event> =
+        match fetch_events_aggregated(filter, CONTACTS_FETCH_TIMEOUT).await {
+            Ok(events) => events.into_iter().max_by_key(|e| e.created_at),
+            Err(e) => {
+                log::error!("Failed to fetch contacts: {}", e);
+                return Err(format!("Failed to fetch contacts: {}", e));
+            }
+        };
+
+    if let Some(event) = event {
+        if let Err(e) = event.verify() {
+            log::warn!("Contact list event failed verification: {}", e);
+            return Err(format!("Invalid contact list event: {}", e));
+        }
+        let contacts: Vec<EnrichedContact> = event
+            .tags
+            .iter()
+            .filter_map(|tag| {
+                let parts = tag.as_slice();
+                if parts.first().map(|s| s.as_str()) != Some("p") || parts.len() < 2 {
+                    return None;
                 }
-                let contacts: Vec<EnrichedContact> = event
-                    .tags
-                    .iter()
-                    .filter_map(|tag| {
-                        let parts = tag.as_slice();
-                        if parts.first().map(|s| s.as_str()) != Some("p") || parts.len() < 2 {
-                            return None;
-                        }
-                        let pubkey_str = parts[1].as_str();
-                        let normalized_pubkey = match nostr::PublicKey::from_hex(pubkey_str)
-                            .or_else(|_| nostr::PublicKey::parse(pubkey_str))
-                        {
-                            Ok(pk) => pk.to_hex(),
-                            Err(_) => {
-                                log::debug!(
-                                    "Skipping invalid pubkey in contact p-tag: {}",
-                                    pubkey_str
-                                );
-                                return None;
-                            }
-                        };
-                        Some(EnrichedContact {
-                            pubkey: normalized_pubkey,
-                            relay_url: parts
-                                .get(2)
-                                .filter(|s| !s.is_empty())
-                                .map(|s| s.to_string()),
-                            petname: parts
-                                .get(3)
-                                .filter(|s| !s.is_empty())
-                                .map(|s| s.to_string()),
-                        })
-                    })
-                    .collect();
-                log::info!("Found {} enriched contacts from relay", contacts.len());
-                let current_gen = get_cache_generation();
-                if let Some(gen) = start_gen {
-                    if gen != current_gen {
-                        log::debug!(
-                            "Discarding stale background refresh (gen {} vs current {})",
-                            gen,
-                            current_gen
-                        );
-                        return Ok(contacts);
-                    }
-                }
+                let pubkey_str = parts[1].as_str();
+                let normalized_pubkey = match nostr::PublicKey::from_hex(pubkey_str)
+                    .or_else(|_| nostr::PublicKey::parse(pubkey_str))
                 {
-                    let mut cache = get_contacts_cache()
-                        .lock()
-                        .unwrap_or_else(|poisoned| poisoned.into_inner());
-                    let existing_refresh = cache.as_ref().and_then(|c| c.last_refresh_spawned);
-                    *cache = Some(CachedContacts {
-                        pubkey: normalized_pubkey,
-                        contacts: contacts.clone(),
-                        cached_at: instant::Instant::now(),
-                        last_refresh_spawned: existing_refresh,
-                        generation: current_gen,
-                    });
-                }
-                Ok(contacts)
-            } else {
-                log::info!("No contact list found for {}", normalized_pubkey);
-                let current_gen = get_cache_generation();
-                if let Some(gen) = start_gen {
-                    if gen != current_gen {
+                    Ok(pk) => pk.to_hex(),
+                    Err(_) => {
                         log::debug!(
-                            "Discarding stale background refresh (gen {} vs current {})",
-                            gen,
-                            current_gen
+                            "Skipping invalid pubkey in contact p-tag: {}",
+                            pubkey_str
                         );
-                        return Ok(Vec::new());
+                        return None;
                     }
-                }
-                // Do NOT cache an empty result. Caching empty contacts for 5
-                // minutes would poison every subsequent caller — including the
-                // home feed, which would fall back to Global instead of showing
-                // the user's follows. This is especially common on cold starts
-                // where `fetch_events_aggregated` fires before
-                // `USER_RELAYS_APPLIED` flips true (the user's NIP-65 relays
-                // aren't in the pool yet, so the kind 3 isn't found on the
-                // default relays). By returning without caching, the next
-                // properly-gated caller can try again immediately.
-                let _ = current_gen; // generation tracked above for the stale check
-                Ok(Vec::new())
+                };
+                Some(EnrichedContact {
+                    pubkey: normalized_pubkey,
+                    relay_url: parts
+                        .get(2)
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string()),
+                    petname: parts
+                        .get(3)
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string()),
+                })
+            })
+            .collect();
+        log::info!("Found {} enriched contacts from relay", contacts.len());
+        let current_gen = get_cache_generation();
+        if let Some(gen) = start_gen {
+            if gen != current_gen {
+                log::debug!(
+                    "Discarding stale background refresh (gen {} vs current {})",
+                    gen,
+                    current_gen
+                );
+                return Ok(contacts);
             }
         }
-        Err(e) => {
-            log::error!("Failed to fetch contacts: {}", e);
-            Err(format!("Failed to fetch contacts: {}", e))
+        {
+            let mut cache = get_contacts_cache()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let existing_refresh = cache.as_ref().and_then(|c| c.last_refresh_spawned);
+            *cache = Some(CachedContacts {
+                pubkey: normalized_pubkey,
+                contacts: contacts.clone(),
+                cached_at: instant::Instant::now(),
+                last_refresh_spawned: existing_refresh,
+                generation: current_gen,
+            });
         }
+        Ok(contacts)
+    } else {
+        log::info!("No contact list found for {}", normalized_pubkey);
+        let current_gen = get_cache_generation();
+        if let Some(gen) = start_gen {
+            if gen != current_gen {
+                log::debug!(
+                    "Discarding stale background refresh (gen {} vs current {})",
+                    gen,
+                    current_gen
+                );
+                return Ok(Vec::new());
+            }
+        }
+        // Do NOT cache an empty result. Caching empty contacts for 5
+        // minutes would poison every subsequent caller — including the
+        // home feed, which would fall back to Global instead of showing
+        // the user's follows. By returning without caching, the next
+        // properly-gated caller can try again immediately.
+        let _ = current_gen;
+        Ok(Vec::new())
     }
 }
 /// Fetch contacts directly from relay, bypassing cache (backward compatible API)
@@ -445,4 +444,35 @@ pub async fn follow_users_batch(
         invalidate_contacts_cache();
     }
     Ok(new_count)
+}
+
+/// Pre-populate CONTACTS_CACHE from the SDK database (no network).
+///
+/// Called at login (`warmup_profiles_from_db`) so that `is_following` is
+/// instant on the first profile view of a session. Without this, the first
+/// `fetch_contacts` call for the current user blocks up to 5s on a relay
+/// round-trip, leaving the Follow button in the wrong state.
+///
+/// Only stores pubkeys (no relay_url/petname) — sufficient for `is_following`.
+/// The full enriched contacts are fetched later by `warmup_profiles_from_network`.
+pub fn warm_contacts_cache(pubkey: &str, contact_pubkeys: Vec<String>) {
+    if contact_pubkeys.is_empty() {
+        return;
+    }
+    let enriched: Vec<EnrichedContact> = contact_pubkeys
+        .into_iter()
+        .map(EnrichedContact::new)
+        .collect();
+    let count = enriched.len();
+    let mut cache = get_contacts_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *cache = Some(CachedContacts {
+        pubkey: pubkey.to_string(),
+        contacts: enriched,
+        cached_at: instant::Instant::now(),
+        last_refresh_spawned: None,
+        generation: get_cache_generation(),
+    });
+    log::info!("Pre-populated CONTACTS_CACHE with {} contacts from SDK DB", count);
 }

--- a/src/stores/nostr_client/contacts.rs
+++ b/src/stores/nostr_client/contacts.rs
@@ -459,6 +459,25 @@ pub fn warm_contacts_cache(pubkey: &str, contact_pubkeys: Vec<String>) {
     if contact_pubkeys.is_empty() {
         return;
     }
+    // Don't clobber richer existing data: if the cache already holds enriched
+    // contacts (with relay_url/petname) for this user — e.g. after a re-login
+    // without full logout where the network fetch already enriched the cache —
+    // skip the pubkey-only warmup.
+    {
+        let cache = get_contacts_cache()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(existing) = cache.as_ref() {
+            if existing.pubkey == pubkey
+                && existing
+                    .contacts
+                    .iter()
+                    .any(|c| c.relay_url.is_some() || c.petname.is_some())
+            {
+                return;
+            }
+        }
+    }
     let enriched: Vec<EnrichedContact> = contact_pubkeys
         .into_iter()
         .map(EnrichedContact::new)

--- a/src/stores/nostr_client/fetching.rs
+++ b/src/stores/nostr_client/fetching.rs
@@ -469,6 +469,7 @@ pub async fn fetch_profile_events_from_relays(
 
 /// Fetch profile events from pre-resolved relay URLs, skipping relay discovery.
 /// Falls back to generic relay fetch if targeted fetch returns empty.
+#[allow(dead_code)]
 pub async fn fetch_profile_events_from_relays_direct(
     client: &std::sync::Arc<Client>,
     filter: Filter,
@@ -485,10 +486,13 @@ pub async fn fetch_profile_events_from_relays_direct(
             filter.clone(),
             ephemeral.connected.clone(),
             timeout,
-        )
-        .await;
-        relay::coverage::cleanup_ephemeral_relays(client, &ephemeral.newly_added).await;
-        if let Ok(events) = result {
+            )
+            .await;
+            // NOTE: ephemeral relays are NOT cleaned up here. They share the
+            // same dedup pool as the profile tab-events stream, so cleaning up
+            // here could remove relays the stream is still using. Relays have
+            // `idle_timeout(300s)` and are cleaned up on profile change.
+            if let Ok(events) = result {
             if !events.is_empty() {
                 return Ok(events);
             }
@@ -898,5 +902,54 @@ pub async fn fetch_metadata_targeted(
     match client.fetch_metadata(public_key, timeout).await {
         Ok(m) => Ok(m),
         Err(e) => Err(format!("Failed to fetch metadata: {}", e)),
+    }
+}
+
+/// Fetch a user's metadata (kind 0) from the dedicated indexer relays.
+///
+/// Indexers (purplepag.es, coracle, …) are DISCOVERY-only pool members
+/// connected at boot and purpose-built for kind 0 / 10002 / 10050 discovery.
+/// This is the **fast path** for cold-profile metadata: it avoids the
+/// `resolve_user_relays` + ephemeral-connect + outbox-fetch chain of
+/// [`fetch_metadata_targeted`], which can take 5–10 s on a never-seen pubkey.
+///
+/// Use as the winner of a race against [`fetch_metadata_targeted`] in the
+/// profile viewer. Falls back to the SDK gossip `fetch_metadata` only if the
+/// indexer fetch errors (e.g. indexers not yet connected).
+pub async fn fetch_metadata_from_indexers(
+    pubkey_hex: &str,
+    timeout: Duration,
+) -> std::result::Result<Option<nostr_sdk::Metadata>, String> {
+    let client = get_client().ok_or("Client not initialized")?;
+    let public_key = PublicKey::from_hex(pubkey_hex).map_err(|e| format!("Invalid pubkey: {}", e))?;
+    let filter = Filter::new()
+        .author(public_key)
+        .kind(Kind::Metadata)
+        .limit(1);
+    match relay::nip65::fetch_events_from_indexers(&client, filter, timeout).await {
+        Ok(events) => {
+            // Pick the newest kind 0 event (replaceable: highest created_at wins).
+            if let Some(event) = events.into_iter().max_by_key(|e| e.created_at) {
+                match nostr_sdk::Metadata::from_json(&event.content) {
+                    Ok(metadata) => {
+                        log::debug!("fetch_metadata_from_indexers: found via indexers");
+                        return Ok(Some(metadata));
+                    }
+                    Err(e) => {
+                        log::warn!("fetch_metadata_from_indexers: failed to parse metadata: {}", e);
+                    }
+                }
+            }
+            Ok(None)
+        }
+        Err(e) => {
+            log::debug!("fetch_metadata_from_indexers: indexer fetch failed ({}); falling back to gossip", e);
+            // Indexers not connected yet or other transient error — fall back to
+            // the SDK's gossip `fetch_metadata` which targets READ-flagged relays.
+            client
+                .fetch_metadata(public_key, timeout)
+                .await
+                .map_err(|e| format!("Failed to fetch metadata: {}", e))
+        }
     }
 }

--- a/src/stores/nostr_client/mod.rs
+++ b/src/stores/nostr_client/mod.rs
@@ -86,7 +86,7 @@ pub use articles::{
 };
 pub use contacts::{
     fetch_contacts, follow_user, follow_users_batch, is_following, publish_contacts,
-    publish_contacts_tracked, unfollow_user,
+    publish_contacts_tracked, unfollow_user, warm_contacts_cache,
 };
 pub use custom_nips::{
     fetch_custom_nip_by_naddr, fetch_custom_nips, generate_custom_nip_naddr, publish_custom_nip,
@@ -97,10 +97,10 @@ pub use error::Error;
 pub use fetching::{
     fetch_custom_nip_events, fetch_event_targeted, fetch_events_aggregated,
     fetch_events_aggregated_outbox, fetch_events_from_connected_relays,
-    fetch_events_from_relays, fetch_metadata_targeted, fetch_profile_events_db,
-    fetch_profile_events_from_relays, fetch_profile_events_from_relays_direct,
-    fetch_profile_events_targeted, fetch_radio_events, fetch_nest_events, fetch_topic_events,
-    parse_event_id, ParsedEventId,
+    fetch_events_from_relays, fetch_metadata_from_indexers, fetch_metadata_targeted,
+    fetch_profile_events_db, fetch_profile_events_from_relays,
+    fetch_profile_events_from_relays_direct, fetch_profile_events_targeted, fetch_radio_events,
+    fetch_nest_events, fetch_topic_events, parse_event_id, ParsedEventId,
 };
 pub(crate) use fetching::fetch_events_from_connected_relays_with_client;
 #[cfg(feature = "native")]
@@ -136,6 +136,7 @@ pub use signals::{
 pub use streaming::{
     stream_events_batched, stream_events_collected, stream_events_from_connected_relays_batched,
     stream_events_immediate, stream_events_with_callback,
+    stream_profile_events_from_relays,
     stream_video_events_from_connected_relays_batched,
 };
 pub use types::PublishResult;

--- a/src/stores/nostr_client/streaming.rs
+++ b/src/stores/nostr_client/streaming.rs
@@ -299,6 +299,173 @@ where
     log::info!("Immediate stream completed: {} events", count);
     Ok(count)
 }
+
+/// Stream profile events by merging multiple relay sources simultaneously.
+///
+/// Fires queries to ALL of these sources in parallel and merges results with
+/// EventId deduplication (mirrors the SDK's own merge pattern at
+/// `pool/mod.rs:1267-1313` and wisp's multi-source fan-out):
+///
+/// 1. **Connected pool relays** (`stream_events_from`): immediate events from
+///    damus.io, nos.lol, the user's read relays, etc. Starts streaming within
+///    milliseconds — finds the author's content if it happens to be on any
+///    general relay.
+/// 2. **SDK gossip** (`stream_events`): discovers the author's NIP-65 write
+///    relays automatically using our DISCOVERY-flagged indexers for relay-list
+///    lookup. Takes 3–10s on cold start (relay discovery); near-instant if the
+///    gossip store already has the relay list (from prior kind 10002 ingestion
+///    within the 60-min freshness window). Finds content that connected relays
+///    don't have.
+/// 3. **Targeted outbox relays** (when `write_relay_urls` is non-empty):
+///    connects ephemerally to the author's resolved write relays and streams
+///    directly. Fastest when relays are already known (from Effect 3's
+///    background resolution).
+///
+/// Events from whichever source delivers first paint immediately; other sources
+/// fill in additional events as they arrive. This is the same pattern amethyst
+/// and wisp use: fire to everything available, merge with dedup.
+///
+/// Returns the total number of unique events delivered to `on_event`.
+pub async fn stream_profile_events_from_relays<F>(
+    filter: Filter,
+    write_relay_urls: &[String],
+    timeout: std::time::Duration,
+    mut on_event: F,
+) -> std::result::Result<usize, NostrBlueError>
+where
+    F: FnMut(nostr::Event),
+{
+    use futures::StreamExt;
+    use nostr_relay_pool::RelayStatus as PoolRelayStatus;
+
+    let client = get_client().ok_or(NostrBlueError::Other("Client not initialized".into()))?;
+
+    // Gates: ensure relays are connected and user relay lists are applied.
+    crate::stores::relay::wait_for_user_relays(
+        std::time::Duration::from_millis(500),
+        "stream_profile_events",
+    )
+    .await;
+    ensure_relays_ready(&client).await;
+
+    // Extract author set for client-side filtering (defense-in-depth against
+    // misbehaving relays that ignore filter authors).
+    let filter_authors = filter.authors.clone();
+    let author_set: Option<std::collections::HashSet<nostr::PublicKey>> = filter_authors
+        .as_ref()
+        .map(|authors| authors.iter().copied().collect());
+
+    // Multi-source merge channel (matches SDK's pool/mod.rs:1269 capacity).
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<nostr::Event>(512);
+
+    // ── Source 1: Connected pool relays (immediate) ──
+    {
+        let relays = client.relays().await;
+        let connected_urls: Vec<nostr::RelayUrl> = relays
+            .iter()
+            .filter(|(_, r)| r.status() == PoolRelayStatus::Connected)
+            .filter_map(|(url, _)| nostr::RelayUrl::parse(url.as_str()).ok())
+            .collect();
+        if !connected_urls.is_empty() {
+            let tx = tx.clone();
+            let client = client.clone();
+            let filter = filter.clone();
+            crate::platform::spawn::spawn_catch_unwind(
+                "profile_connected_stream",
+                async move {
+                    log::info!(
+                        "Profile connected-relays stream: {} relays",
+                        connected_urls.len()
+                    );
+                    match client
+                        .stream_events_from(connected_urls, filter, timeout)
+                        .await
+                    {
+                        Ok(mut stream) => {
+                            while let Some(event) = stream.next().await {
+                                if tx.send(event).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                        Err(e) => log::warn!("Connected-relays stream failed: {}", e),
+                    }
+                },
+            );
+        }
+    }
+
+    // ── Source 2: SDK gossip (discovers author's write relays via NIP-65) ──
+    {
+        let tx = tx.clone();
+        let client = client.clone();
+        let filter = filter.clone();
+        crate::platform::spawn::spawn_catch_unwind("profile_gossip_stream", async move {
+            log::info!("Profile gossip stream starting");
+            match client.stream_events(filter, timeout).await {
+                Ok(mut stream) => {
+                    while let Some(event) = stream.next().await {
+                        if tx.send(event).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                Err(e) => log::warn!("Gossip stream failed: {}", e),
+            }
+        });
+    }
+
+    // ── Source 3 (optional): Targeted outbox relays if known ──
+    if !write_relay_urls.is_empty() {
+        let tx = tx.clone();
+        let client = client.clone();
+        let filter = filter.clone();
+        let urls = write_relay_urls.to_vec();
+        crate::platform::spawn::spawn_catch_unwind("profile_outbox_stream", async move {
+            let ephemeral =
+                crate::stores::relay::coverage::connect_ephemeral_relays(&client, &urls).await;
+            if ephemeral.connected.is_empty() {
+                return;
+            }
+            let connected: Vec<nostr::RelayUrl> = ephemeral
+                .connected
+                .iter()
+                .filter_map(|u| nostr::RelayUrl::parse(u.as_str()).ok())
+                .collect();
+            log::info!("Profile outbox stream: {} relays", connected.len());
+            match client.stream_events_from(connected, filter, timeout).await {
+                Ok(mut stream) => {
+                    while let Some(event) = stream.next().await {
+                        if tx.send(event).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                Err(e) => log::warn!("Outbox stream failed: {}", e),
+            }
+        });
+    }
+
+    drop(tx); // All senders spawned; drop original so rx ends when all finish.
+
+    // ── Consumer: merge with EventId dedup + author filter ──
+    let mut seen: std::collections::HashSet<nostr::EventId> = std::collections::HashSet::new();
+    let mut count = 0;
+    while let Some(event) = rx.recv().await {
+        if let Some(ref authors) = author_set {
+            if !authors.contains(&event.pubkey) {
+                continue;
+            }
+        }
+        if seen.insert(event.id) {
+            on_event(event);
+            count += 1;
+        }
+    }
+
+    log::info!("Profile multi-source stream completed: {} unique events", count);
+    Ok(count)
+}
 /// Stream video events from connected relays with divine relay awareness
 ///
 /// Ensures the video relay (relay.divine.video) is connected first,

--- a/src/stores/relay/coverage.rs
+++ b/src/stores/relay/coverage.rs
@@ -352,37 +352,38 @@ pub async fn connect_ephemeral_relays(client: &Client, urls: &[String]) -> Ephem
     let mut already_connected: Vec<String> = Vec::new();
     let mut to_add: Vec<nostr::Url> = Vec::new();
 
-    for raw_url in urls {
-        let url = crate::utils::relay::upgrade_to_secure_relay_url(raw_url);
-        let Ok(parsed) = nostr::Url::parse(&url) else {
-            continue;
-        };
-        // Check if the relay is already connected in the pool.
-        let is_connected = relays
-            .iter()
-            .any(|(u, r)| u.as_str() == url && r.is_connected());
-        // Check if another concurrent caller has claimed this relay.
-        let in_use = EPHEMERAL_IN_USE.lock().unwrap().contains(&url);
-        if is_connected || in_use {
-            already_connected.push(url.clone());
-        } else {
-            to_add.push(parsed);
+    // Atomic check-and-claim: check pool connected + EPHEMERAL_IN_USE and claim
+    // in one lock scope so concurrent callers on different threads (desktop)
+    // can't both see in_use=false and both claim the same URL (TOCTOU).
+    {
+        let mut in_use = EPHEMERAL_IN_USE.lock().unwrap();
+        for raw_url in urls {
+            let url = crate::utils::relay::upgrade_to_secure_relay_url(raw_url);
+            let Ok(parsed) = nostr::Url::parse(&url) else {
+                continue;
+            };
+            let is_connected = relays
+                .iter()
+                .any(|(u, r)| u.as_str() == url && r.is_connected());
+            // insert() returns false if already present = atomic check-and-claim.
+            // Normalize so insert/remove/lookup all use the same string form —
+            // Url::parse adds a trailing "/" to bare host URLs (e.g. "wss://nos.lol"
+            // → "wss://nos.lol/"), matching the normalized strings produced by
+            // url.to_string() in newly_connected and pool RelayUrl::as_str().
+            let normalized = crate::utils::relay::normalize_known_relay_url(&url);
+            if is_connected || !in_use.insert(normalized) {
+                already_connected.push(url);
+            } else {
+                to_add.push(parsed);
+            }
         }
-    }
+    } // lock released — before any .await
 
     if to_add.is_empty() {
         return EphemeralResult {
             connected: already_connected,
             newly_added: Vec::new(),
         };
-    }
-
-    // Claim the URLs we're about to add so concurrent callers skip them.
-    {
-        let mut in_use = EPHEMERAL_IN_USE.lock().unwrap();
-        for url in &to_add {
-            in_use.insert(url.to_string());
-        }
     }
 
     let opts = RelayOptions::new()
@@ -394,7 +395,7 @@ pub async fn connect_ephemeral_relays(client: &Client, urls: &[String]) -> Ephem
     }
 
     const MAX_CONCURRENT: usize = 5;
-    let newly_connected: Vec<String> = stream::iter(to_add)
+    let newly_connected: Vec<String> = stream::iter(to_add.clone())
         .map(|url| {
             let client = client.clone();
             async move {
@@ -415,6 +416,20 @@ pub async fn connect_ephemeral_relays(client: &Client, urls: &[String]) -> Ephem
         .collect()
         .await;
 
+    // Reclaim failed connections: URLs we claimed in EPHEMERAL_IN_USE and
+    // added to the pool but whose try_connect_relay failed. Without this,
+    // the URL stays claimed forever (never reaches cleanup_ephemeral_relays)
+    // and lingers in the pool as a dormant entry, silently breaking all
+    // future connect attempts to that URL.
+    let newly_set: std::collections::HashSet<&String> = newly_connected.iter().collect();
+    for url in &to_add {
+        let url_str = url.to_string();
+        if !newly_set.contains(&url_str) {
+            EPHEMERAL_IN_USE.lock().unwrap().remove(&url_str);
+            let _ = client.force_remove_relay(&url_str).await;
+        }
+    }
+
     let mut connected = already_connected;
     connected.extend(newly_connected.clone());
     EphemeralResult {
@@ -428,7 +443,8 @@ pub async fn connect_ephemeral_relays(client: &Client, urls: &[String]) -> Ephem
 pub async fn cleanup_ephemeral_relays(client: &Client, urls: &[String]) {
     for url in urls {
         let _ = client.force_remove_relay(url.as_str()).await;
-        EPHEMERAL_IN_USE.lock().unwrap().remove(url);
+        let normalized = crate::utils::relay::normalize_known_relay_url(url);
+        EPHEMERAL_IN_USE.lock().unwrap().remove(&normalized);
     }
 }
 
@@ -436,7 +452,8 @@ pub async fn cleanup_ephemeral_relays(client: &Client, urls: &[String]) {
 /// still tracked (not yet cleaned up). Used by the profile-viewer reset effect
 /// to identify which relays to remove on profile change.
 pub fn is_ephemeral_relay(url: &str) -> bool {
-    EPHEMERAL_IN_USE.lock().unwrap().contains(url)
+    let normalized = crate::utils::relay::normalize_known_relay_url(url);
+    EPHEMERAL_IN_USE.lock().unwrap().contains(&normalized)
 }
 
 /// Remove gossip-only relays from the pool.

--- a/src/stores/relay/coverage.rs
+++ b/src/stores/relay/coverage.rs
@@ -17,9 +17,17 @@ use crate::stores::nostr_client;
 use crate::stores::relay::nip65::{parse_relay_list_event, USER_RELAY_METADATA, DEFAULT_NIP65_RELAYS};
 use dioxus::prelude::*;
 use nostr_sdk::prelude::*;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock, Mutex as StdMutex};
 use std::time::Duration;
 use tokio::sync::broadcast::error::RecvError;
+
+/// Tracks relay URLs that are being connected or have been connected by
+/// `connect_ephemeral_relays`. Prevents concurrent callers (e.g. the profile
+/// metadata fetch and the profile tab-events stream both connecting to the
+/// same author's write relays) from each tracking the URL as "newly added"
+/// and then racing to clean it up while the other is still using it.
+static EPHEMERAL_IN_USE: LazyLock<StdMutex<std::collections::HashSet<String>>> =
+    LazyLock::new(|| StdMutex::new(std::collections::HashSet::new()));
 
 #[derive(Clone, Debug, Default)]
 pub struct RelayCoverageMap {
@@ -123,11 +131,16 @@ pub async fn resolve_user_relays(pubkey: &str, purpose: RelayPurpose) -> Vec<Str
 
 /// Fetch kind 10002 from network for a single pubkey.
 /// Returns parsed relay URLs (all, unfiltered by purpose).
+///
+/// Uses `fetch_events_from_indexers` (the only sanctioned way to read from
+/// DISCOVERY-only indexers). `client.fetch_events` targets only strict-READ
+/// relays and would silently miss indexers where kind 10002 lists are
+/// aggregated — see AGENTS.md "Relay Routing & Discovery".
 async fn fetch_10002_from_network(pubkey: &str) -> Option<Vec<String>> {
     let client = nostr_client::get_client()?;
     let pk = PublicKey::from_hex(pubkey).ok()?;
     let filter = Filter::new().author(pk).kind(Kind::RelayList).limit(1);
-    let result = client.fetch_events(filter, Duration::from_secs(5)).await;
+    let result = super::nip65::fetch_events_from_indexers(&client, filter, Duration::from_secs(5)).await;
     match result {
         Ok(events) => {
             if let Some(event) = events.into_iter().next() {
@@ -148,11 +161,13 @@ async fn fetch_10002_from_network(pubkey: &str) -> Option<Vec<String>> {
 }
 
 /// Background refresh: fetch kind 10002 from network to update cache.
+///
+/// Same indexer-routed query as [`fetch_10002_from_network`].
 async fn refresh_10002_from_network(pubkey: &str) -> Option<Vec<String>> {
     let client = nostr_client::get_client()?;
     let pk = PublicKey::from_hex(pubkey).ok()?;
     let filter = Filter::new().author(pk).kind(Kind::RelayList).limit(1);
-    match client.fetch_events(filter, Duration::from_secs(5)).await {
+    match super::nip65::fetch_events_from_indexers(&client, filter, Duration::from_secs(5)).await {
         Ok(events) => {
             if let Some(event) = events.into_iter().next() {
                 let relays = parse_relay_list_event(&event);
@@ -323,6 +338,13 @@ pub struct EphemeralResult {
 ///
 /// Uses `reconnect(false)` so failed connections are not auto-retried.
 /// Returns an `EphemeralResult` distinguishing pre-existing relays from newly-added ones.
+///
+/// **Concurrent dedup**: if another caller has already added/connecting a URL
+/// (tracked in `EPHEMERAL_IN_USE`), it is treated as "already connected" and
+/// excluded from `newly_added`. This prevents two concurrent callers (e.g. the
+/// profile metadata fetch and the profile tab-events stream) from each tracking
+/// the same relay for cleanup and then racing to remove it while the other is
+/// still using it.
 pub async fn connect_ephemeral_relays(client: &Client, urls: &[String]) -> EphemeralResult {
     use futures::stream::{self, StreamExt};
 
@@ -335,10 +357,13 @@ pub async fn connect_ephemeral_relays(client: &Client, urls: &[String]) -> Ephem
         let Ok(parsed) = nostr::Url::parse(&url) else {
             continue;
         };
+        // Check if the relay is already connected in the pool.
         let is_connected = relays
             .iter()
             .any(|(u, r)| u.as_str() == url && r.is_connected());
-        if is_connected {
+        // Check if another concurrent caller has claimed this relay.
+        let in_use = EPHEMERAL_IN_USE.lock().unwrap().contains(&url);
+        if is_connected || in_use {
             already_connected.push(url.clone());
         } else {
             to_add.push(parsed);
@@ -350,6 +375,14 @@ pub async fn connect_ephemeral_relays(client: &Client, urls: &[String]) -> Ephem
             connected: already_connected,
             newly_added: Vec::new(),
         };
+    }
+
+    // Claim the URLs we're about to add so concurrent callers skip them.
+    {
+        let mut in_use = EPHEMERAL_IN_USE.lock().unwrap();
+        for url in &to_add {
+            in_use.insert(url.to_string());
+        }
     }
 
     let opts = RelayOptions::new()
@@ -391,10 +424,19 @@ pub async fn connect_ephemeral_relays(client: &Client, urls: &[String]) -> Ephem
 }
 
 /// Remove ephemeral relays from the pool after a targeted fetch.
+/// Also clears the `EPHEMERAL_IN_USE` claim so future calls can re-add.
 pub async fn cleanup_ephemeral_relays(client: &Client, urls: &[String]) {
     for url in urls {
         let _ = client.force_remove_relay(url.as_str()).await;
+        EPHEMERAL_IN_USE.lock().unwrap().remove(url);
     }
+}
+
+/// Check whether a relay URL was added by `connect_ephemeral_relays` and is
+/// still tracked (not yet cleaned up). Used by the profile-viewer reset effect
+/// to identify which relays to remove on profile change.
+pub fn is_ephemeral_relay(url: &str) -> bool {
+    EPHEMERAL_IN_USE.lock().unwrap().contains(url)
 }
 
 /// Remove gossip-only relays from the pool.

--- a/src/stores/social/community_store/fetch.rs
+++ b/src/stores/social/community_store/fetch.rs
@@ -236,7 +236,7 @@ pub async fn fetch_user_communities(
                 log::debug!(
                     "Caching {} approved members for community {}",
                     members.len(),
-                    &a_tag_str
+                    a_tag_str
                 );
                 APPROVED_MEMBERS_CACHE.write().insert(a_tag_str, members);
             } else {
@@ -268,7 +268,7 @@ pub async fn fetch_user_communities(
             log::debug!(
                 "Caching {} approved members from d_tag for {}",
                 members.len(),
-                &potential_a_tag
+                potential_a_tag
             );
             APPROVED_MEMBERS_CACHE
                 .write()

--- a/src/stores/ui/ai_provider_store.rs
+++ b/src/stores/ui/ai_provider_store.rs
@@ -9,6 +9,7 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::platform::storage;
 use crate::services::ppq::PPQ_CHAT_BASE_URL;
+use crate::services::routstr::ROUTSTR_BASE_URL;
 use crate::stores::nostr_client;
 use crate::stores::relay::{wait_for_user_relays, USER_RELAYS_APPLIED};
 use crate::stores::ui::sidebar_store::Nip78LoadState;
@@ -16,6 +17,7 @@ use crate::stores::ui::sidebar_store::Nip78LoadState;
 const STORAGE_KEY: &str = "nostr_blue_ai_provider_state";
 const SHAKESPEARE_PROVIDER_ID: &str = "shakespeare";
 const PPQ_PROVIDER_ID: &str = "ppq";
+pub const ROUTSTR_PROVIDER_ID: &str = "routstr";
 const APP_DATA_KIND: u16 = 30078;
 const CREDENTIALS_D_TAG: &str = "nostr.blue/ai_credentials";
 static PROVIDER_STATE_SAVE_EVENT_ID: AtomicU64 = AtomicU64::new(0);
@@ -68,6 +70,8 @@ pub struct AiProviderState {
     pub custom_providers: Vec<CustomAiProvider>,
     #[serde(default)]
     pub ppq_account: Option<PpqAccountState>,
+    #[serde(default)]
+    pub routstr_api_key: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -84,6 +88,7 @@ impl Default for AiProviderState {
             selected_model_by_provider: HashMap::new(),
             custom_providers: Vec::new(),
             ppq_account: None,
+            routstr_api_key: None,
         }
     }
 }
@@ -91,6 +96,7 @@ impl Default for AiProviderState {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProviderAuth {
     PpqManaged { api_key: Option<String> },
+    Routstr { api_key: Option<String> },
     BearerToken(String),
     XApiKey(String),
 }
@@ -108,7 +114,12 @@ pub struct AiProviderConfig {
 
 impl AiProviderConfig {
     pub fn requires_setup(&self) -> bool {
-        matches!(&self.auth, ProviderAuth::PpqManaged { api_key } if api_key.as_deref().unwrap_or("").trim().is_empty())
+        match &self.auth {
+            ProviderAuth::PpqManaged { api_key } | ProviderAuth::Routstr { api_key } => {
+                api_key.as_deref().unwrap_or("").trim().is_empty()
+            }
+            _ => false,
+        }
     }
 
     #[allow(dead_code)]
@@ -119,6 +130,7 @@ impl AiProviderConfig {
     pub fn authentication_label(&self) -> &'static str {
         match self.auth {
             ProviderAuth::PpqManaged { .. } => "Managed API Key",
+            ProviderAuth::Routstr { .. } => "API Key or Cashu Token",
             ProviderAuth::BearerToken(_) => "API Key",
             ProviderAuth::XApiKey(_) => "API Key",
         }
@@ -147,8 +159,27 @@ pub fn ppq_provider(account: Option<&PpqAccountState>) -> AiProviderConfig {
     }
 }
 
+pub fn routstr_provider(api_key: Option<&str>) -> AiProviderConfig {
+    AiProviderConfig {
+        id: ROUTSTR_PROVIDER_ID.to_string(),
+        name: "Routstr".to_string(),
+        base_url: ROUTSTR_BASE_URL.to_string(),
+        provider_kind: AiProviderKind::OpenAiCompatible,
+        auth: ProviderAuth::Routstr {
+            api_key: api_key
+                .map(|k| k.trim().to_string())
+                .filter(|k| !k.is_empty()),
+        },
+        is_builtin: true,
+        default_model: None,
+    }
+}
+
 pub fn resolve_providers(state: &AiProviderState) -> Vec<AiProviderConfig> {
-    let mut providers = vec![ppq_provider(state.ppq_account.as_ref())];
+    let mut providers = vec![
+        ppq_provider(state.ppq_account.as_ref()),
+        routstr_provider(state.routstr_api_key.as_deref()),
+    ];
     providers.extend(
         state
             .custom_providers
@@ -563,17 +594,23 @@ mod tests {
                 managed_api_key: None,
                 active_api_key_id: Some("key-1".to_string()),
             }),
+            routstr_api_key: None,
         };
 
         let providers = resolve_providers(&state);
-        assert_eq!(providers.len(), 2);
+        assert_eq!(providers.len(), 3);
         assert_eq!(providers[0].id, PPQ_PROVIDER_ID);
-        assert_eq!(providers[1].id, "custom");
+        assert_eq!(providers[1].id, ROUTSTR_PROVIDER_ID);
+        assert_eq!(providers[2].id, "custom");
         assert!(matches!(
             providers[0].auth,
             ProviderAuth::PpqManaged { api_key: Some(_) }
         ));
-        assert!(matches!(providers[1].auth, ProviderAuth::BearerToken(_)));
+        assert!(matches!(
+            providers[1].auth,
+            ProviderAuth::Routstr { api_key: None }
+        ));
+        assert!(matches!(providers[2].auth, ProviderAuth::BearerToken(_)));
     }
 
     #[test]
@@ -590,12 +627,14 @@ mod tests {
                 default_model: None,
             }],
             ppq_account: None,
+            routstr_api_key: None,
         };
 
         let providers = resolve_providers(&state);
-        assert_eq!(providers.len(), 2);
-        assert!(matches!(providers[1].auth, ProviderAuth::XApiKey(_)));
-        if let ProviderAuth::XApiKey(key) = &providers[1].auth {
+        assert_eq!(providers.len(), 3);
+        assert_eq!(providers[2].id, "anthropic");
+        assert!(matches!(providers[2].auth, ProviderAuth::XApiKey(_)));
+        if let ProviderAuth::XApiKey(key) = &providers[2].auth {
             assert_eq!(key, "sk-ant-123");
         }
     }
@@ -605,6 +644,20 @@ mod tests {
         let provider = ppq_provider(None);
         assert!(provider.requires_setup());
         assert!(provider.supports_tools());
+    }
+
+    #[test]
+    fn routstr_provider_requires_setup_without_key() {
+        let provider = routstr_provider(None);
+        assert!(provider.requires_setup());
+        assert!(provider.is_builtin);
+        assert_eq!(provider.id, ROUTSTR_PROVIDER_ID);
+    }
+
+    #[test]
+    fn routstr_provider_with_key_does_not_require_setup() {
+        let provider = routstr_provider(Some("sk-test123"));
+        assert!(!provider.requires_setup());
     }
 
     #[test]
@@ -628,6 +681,7 @@ mod tests {
             selected_model_by_provider: HashMap::new(),
             custom_providers: vec![],
             ppq_account: None,
+            routstr_api_key: None,
         });
         assert_eq!(migrated.selected_provider_id, PPQ_PROVIDER_ID);
     }
@@ -688,6 +742,7 @@ mod tests {
                 default_model: None,
             }],
             ppq_account: None,
+            routstr_api_key: None,
         };
         let second = AiProviderState {
             selected_provider_id: "custom-b".to_string(),
@@ -701,6 +756,7 @@ mod tests {
                 default_model: None,
             }],
             ppq_account: None,
+            routstr_api_key: None,
         };
 
         assert_eq!(queue_provider_state_save(first.clone()), Some(first));

--- a/src/utils/audio/ics.rs
+++ b/src/utils/audio/ics.rs
@@ -121,7 +121,7 @@ fn format_vevent(event: &CalendarEvent) -> String {
         "X-NOSTR-COORDINATE:{}\r\n",
         escape_ics_text(&event.coordinate)
     ));
-    vevent.push_str(&format!("X-NOSTR-PUBKEY:{}\r\n", &event.pubkey));
+    vevent.push_str(&format!("X-NOSTR-PUBKEY:{}\r\n", event.pubkey));
     vevent.push_str("END:VEVENT\r\n");
     vevent
 }

--- a/src/utils/date_helpers.rs
+++ b/src/utils/date_helpers.rs
@@ -60,7 +60,7 @@ pub fn get_month_from_date(date: &str) -> u32 {
         .and_then(|m| {
             m.parse::<u32>()
                 .ok()
-                .and_then(|v| if (1..=12).contains(&v) { Some(v) } else { None })
+                .filter(|&v| (1..=12).contains(&v))
         })
         .unwrap_or(0)
 }

--- a/src/utils/pin_metadata.rs
+++ b/src/utils/pin_metadata.rs
@@ -82,7 +82,7 @@ fn extract_event_metadata(event: &Event) -> PinPreviewMetadata {
         .map(|s| {
             let cleaned = s.trim();
             if cleaned.len() > 100 {
-                format!("{}...", &cleaned.chars().take(100).collect::<String>())
+                format!("{}...", cleaned.chars().take(100).collect::<String>())
             } else {
                 cleaned.to_string()
             }
@@ -91,7 +91,7 @@ fn extract_event_metadata(event: &Event) -> PinPreviewMetadata {
     let description = if event.content.len() > 500 {
         Some(format!(
             "{}...",
-            &event.content.chars().take(500).collect::<String>()
+            event.content.chars().take(500).collect::<String>()
         ))
     } else {
         Some(event.content.clone())
@@ -123,7 +123,7 @@ fn extract_addressable_metadata(event: &Event, kind: u16) -> PinPreviewMetadata 
         if event.content.len() > 500 {
             Some(format!(
                 "{}...",
-                &event.content.chars().take(500).collect::<String>(),
+                event.content.chars().take(500).collect::<String>(),
             ))
         } else if !event.content.is_empty() {
             Some(event.content.clone())


### PR DESCRIPTION
Release branch merge for **v0.8.20** (54 files, +2,879 / −702 across 8 commits).
Full notes in `public/docs/changelogs/0.8.20.md`.

## Highlights

### Routstr — built-in AI provider
- Adds [Routstr](https://routstr.com), a decentralized Bitcoin-powered
  OpenAI-compatible AI marketplace, as a second built-in provider alongside PPQ.
- New `ProviderAuth::Routstr` variant + `routstr_api_key` field on
  `AiProviderState` (serde-default for backward compat); `routstr_provider()`
  constructor as the second built-in in `resolve_providers`.
- **`src/services/routstr.rs`** (new): balance, Lightning invoice + status
  polling, Cashu topup, key creation from cashu token, refund. Defensive JSON
  parsing with redacted error bodies (mirrors `ppq.rs`). Endpoint shapes verified
  against routstr-core server source.
- **`src/components/routstr_settings_panel.rs`** (new): API key entry with
  auto-conversion of `cashuA...` tokens to `sk-...` keys, balance display
  (msats→sats), Lightning topup with QR + auto-poll, Cashu token topup,
  refund/withdraw to copyable Cashu token.
- AI chat route: renamed `ppq_blocked` → `needs_setup` (generalized copy);
  type-dispatched setup gates per provider — `PpqSetupGate`, `RoutstrSetupGate`,
  `ProviderSetupGate` (generic).

### Mostro — durable trade recovery & orphan resilience
- **create_order**: upserts a placeholder trade *before* sending the daemon
  message so `use_mostro_session` covers it during the ACK wait (survives a
  `Lagged` broadcast); `RecvError::Lagged` treated as recoverable; placeholder
  removed on send failure or daemon rejection.
- **trade_detail**: "Recover from daemon" button when no local record exists;
  real-UUID Pending trades past 30s transition to slow reconcile instead of
  being orphaned.
- **my_trades**: self-heals an empty trade list from the NIP-78 blob, the
  creation ledger, and `RestoreSession` on mount.
- **cleanup**: creation-ledger trades exempt from the orphan sweep; orphan
  thresholds widened (120→600s, bond grace 180→900s); `is_live_on_board`
  broadened to any non-terminal status.
- **take_mostro_button / order_card**: self-take disabled using both TRADES +
  creation ledger; "Yours" badge and "Open Trade" shortcut.
- **client**: `AddInvoice` handles the `Order` payload and preserves
  `PaymentFailed`; role-aware bond step; `ensure_node_relays_connected` in
  `resolve_effective_pow` so cold-start PoW fetch doesn't silently fail.
- **node_config**: `lnd_node_uri` → `lnd_uris` to match the daemon's tag name.

### Profile page — multi-source streaming & indexer routing
- **Metadata (kind 0)**: race dedicated indexer relays vs outbox path; first
  result wins (indexers <500ms vs 5–10s outbox). Relay resolution runs
  non-blocking in background.
- **Posts (tab events)**: replace blocking `join!` with multi-source streaming
  merge (connected pool + SDK gossip + optional outbox) via an mpsc channel with
  EventId dedup; events paint progressively through `DebouncedCollector`. New
  **`src/stores/nostr_client/streaming.rs`** primitive.
- **Relay routing bug fix**: `fetch_10002_from_network` now uses
  `fetch_events_from_indexers` instead of `client.fetch_events` (which cannot
  reach DISCOVERY-only indexers — latent bug per the relay taxonomy).
- Concurrent ephemeral relay dedup guard prevents cleanup races between metadata
  and tab-events fetches sharing the same write relays.
- **Follow stats**: pre-populate `CONTACTS_CACHE` from SDK database at login;
  fix `AddressViewer` remounting `ProfileViewer` when `CLIENT_INITIALIZED` flips
  (was resetting follower counts to 0).
- **Readiness**: `HAS_SIGNER` gate added to profile effects; live-tail
  subscription for realtime new posts on the active tab.

### Voice message playback — desktop & Android
- Playback was entirely `#[cfg(feature = "web")]` because the play/pause effect
  used `web_sys` direct DOM access, compiling out on Android and desktop — users
  saw a dead "Playback not supported" placeholder.
- Replaced with a uniform `document::eval` JS snippet that bridges to the real
  WebView on web, desktop (wry), and Android.
- Non-web platforms get a 200ms polling `use_future` reading
  `[currentTime, duration, ended]` via `document::eval`, gated to the active
  player only.
- Card navigation de-gated (mirrors `NoteCard`): plain `use_navigator()`,
  `role="button"`/`tabindex="0"`, unconditional nav on click + Enter/Space.

### Media upload refactor
- Splits the overloaded `upload_image()` into purpose-specific paths:
  `upload_image()` handles **images only**, gating compression behind
  `is_image_compressible()` (PNG/JPEG); webp/avif/gif/heic bytes now match the
  declared MIME type.
- New **`upload_file()`** for non-image types (video, audio, PDFs, docs) with no
  compression, replacing the `quality=100` bypass hack.
- `MediaUploader` now accepts configurable `accept` / `max_bytes` per context
  (default `*/*` 10 MB; music raises to 100 MB). All 17 call sites updated.

### Relay coverage fixes
- Fix TOCTOU race in `connect_ephemeral_relays`: atomic check-and-claim in a
  single `EPHEMERAL_IN_USE` lock scope.
- Fix normalization mismatch: normalize URLs at insert point so insert/remove/
  lookup all use the same canonical form (raw URLs never matched normalized
  removals, permanently leaking entries and blackholing relays for the session).
- Reclaim failed ephemeral connections; defensive normalization in cleanup and
  `is_ephemeral_relay`.

### Mention autocomplete fix
- `update_dropdown_position` was double-counting scroll offset (adding
  `scroll_y()`/`scroll_x()` to coords already viewport-relative from
  `get_bounding_client_rect()`), shoving the `@`-mention dropdown below the
  viewport in scrolled reply/comment modals.